### PR TITLE
feat(workflows): reuse build artifacts for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
         with:
           name: build-${{ matrix.build-type }}-${{ github.sha }}
           path: dist/
-          retention-days: 7
+          retention-days: 90
 
   test-api:
     name: API Integration Tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,22 +77,21 @@ jobs:
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
           echo "Final tag: $TAG_NAME"
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Get commit SHA from tag
+        id: get-sha
+        run: |
+          COMMIT_SHA=$(git rev-parse ${{ steps.detect-tag.outputs.tag_name }}^{commit})
+          echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+          echo "Commit SHA: $COMMIT_SHA"
+
+      - name: Download build artifact from CI
+        uses: dawidd6/action-download-artifact@v3
         with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build for production
-        env:
-          NODE_ENV: production
-          REDIACC_BUILD_TYPE: RELEASE
-          VITE_APP_VERSION: ${{ steps.detect-tag.outputs.tag_name }}
-          VITE_BASE_PATH: /
-        run: npm run build
+          workflow: ci.yml
+          commit: ${{ steps.get-sha.outputs.commit_sha }}
+          name: build-RELEASE-${{ steps.get-sha.outputs.commit_sha }}
+          path: dist/
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create CNAME file
         run: echo 'console.rediacc.com' > dist/CNAME


### PR DESCRIPTION
## Summary

Optimize the release workflow by reusing build artifacts from CI instead of rebuilding at release time.

## Changes

### CI Workflow (`ci.yml`)
- Extended artifact retention from 7 to 90 days
- Enables artifact reuse for releases weeks after merge

### Publish Workflow (`publish.yml`)
- Download pre-built artifacts from CI by commit SHA
- Eliminate redundant rebuild at release time
- Fail fast if artifact doesn't exist (no fallback)

## Benefits

- **Faster releases**: No rebuild time (~2 minutes saved)
- **Guaranteed consistency**: Release exactly what passed CI
- **Resource efficiency**: Build once, deploy many times
- **Fail-safe**: Cannot release untested code

## Testing

After merge to main:
1. CI builds and uploads `build-RELEASE-{sha}` artifact
2. Tag commit: `git tag v0.0.99 && git push origin v0.0.99`
3. Publish workflow downloads artifact by SHA
4. Deploy proceeds with pre-built artifact

## Migration Notes

- Requires GitHub Actions artifact storage (already in use)
- Uses `dawidd6/action-download-artifact@v3` for cross-workflow downloads
- No changes to local scripts or manual workflows