### PR TITLE
chore(ci): add merge_group trigger for merge queue support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - main
       - develop
+  merge_group:
+    branches:
+      - main
+      - develop
 
 jobs:
   # PR Validation Jobs (only run on pull_request)


### PR DESCRIPTION
## Summary
Enable merge queue functionality by adding \`merge_group\` event trigger to CI workflow.

## Changes
- Added \`merge_group\` trigger to \`.github/workflows/ci.yml\`
- This allows the merge queue to run CI checks on merged commits before actually merging to main

## Why
The merge queue was configured but the CI workflow wasn't set up to respond to \`merge_group\` events. This PR fixes that so the 11 pending Dependabot PRs can be automatically merged through the queue.

## Test Plan
- [x] CI workflow updated
- [ ] Verify merge queue processes PRs after this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)