### PR TITLE
revert(ci): remove merge_group trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,6 @@ on:
     branches:
       - main
       - develop
-  merge_group:
-    branches:
-      - main
-      - develop
 
 jobs:
   # PR Validation Jobs (only run on pull_request)


### PR DESCRIPTION
## Summary
Remove merge queue functionality as it's not needed.

## Changes
- Removed \`merge_group\` trigger from \`.github/workflows/ci.yml\`

## Why
User decided not to use the merge queue approach for merging Dependabot PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)