### PR TITLE
fix: sync endpoint selector with API client on load

### DIFF
--- a/src/components/common/EndpointSelector.tsx
+++ b/src/components/common/EndpointSelector.tsx
@@ -45,6 +45,12 @@ const EndpointSelector: React.FC = () => {
         }
 
         setSelectedEndpoint(selected);
+
+        // If we have a selected endpoint, update the API client immediately
+        if (selected) {
+          apiClient.updateApiUrl(selected.url);
+          console.log(`[EndpointSelector] Applied saved endpoint: ${selected.name} (${selected.url})`);
+        }
       } catch (error) {
         console.warn('Failed to fetch endpoints', error);
       } finally {


### PR DESCRIPTION
## Summary
Fix synchronization issue between endpoint selector UI and actual API endpoint being used.

## Problem
- Endpoint selector displayed saved selection from localStorage (e.g., "Sandbox")
- But API client was using auto-detected endpoint (e.g., "localhost")
- Mismatch only resolved when user manually switched endpoints

## Solution
- Update API client URL immediately when EndpointSelector loads with saved selection
- Ensures UI always reflects actual API endpoint being used

## Additional Changes
- Remove duplicate URL display from dropdown options
- Show URL only below selector for cleaner UI

## Test Plan
- [x] Save endpoint selection in localStorage
- [x] Reload page
- [x] Verify selected endpoint URL matches API calls
- [x] Verify no duplicate URL display