### PR TITLE
fix: use absolute URLs for config files to support tunnel access

### DIFF
--- a/src/api/pricingService.ts
+++ b/src/api/pricingService.ts
@@ -1,5 +1,7 @@
 // Pricing service to fetch centralized pricing configuration
 
+import { CONFIG_URLS } from '@/utils/apiConstants'
+
 export interface PricingConfig {
   baseMonthlyPrices: {
     [key: string]: {
@@ -54,7 +56,7 @@ export const fetchPricingConfig = async (): Promise<PricingConfig | null> => {
 
   try {
     // Always fetch the base pricing.json (English content)
-    const response = await fetch('/configs/pricing.json');
+    const response = await fetch(CONFIG_URLS.PRICING);
     if (!response.ok) {
       throw new Error(`Failed to fetch pricing: ${response.status}`);
     }

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -1,5 +1,6 @@
 
 import { apiConnectionService } from './apiConnectionService'
+import { CONFIG_URLS } from '@/utils/apiConstants'
 
 interface AppConfig {
   apiUrl: string
@@ -173,7 +174,7 @@ class ConfigService {
 
   async getTemplatesUrl(): Promise<string> {
     const config = await this.getConfig()
-    return config.templatesUrl || '/configs/templates.json'
+    return config.templatesUrl || CONFIG_URLS.TEMPLATES
   }
 
   // Check if configuration is from runtime (nginx) or build-time (vite)

--- a/src/services/endpointService.ts
+++ b/src/services/endpointService.ts
@@ -3,6 +3,8 @@
  * Manages API endpoint selection with predefined and custom endpoints
  */
 
+import { CONFIG_URLS } from '@/utils/apiConstants'
+
 export interface Endpoint {
   id: string
   name: string
@@ -28,7 +30,7 @@ class EndpointService {
    */
   private async fetchPredefinedEndpoints(): Promise<Endpoint[]> {
     try {
-      const response = await fetch('/configs/endpoints.json')
+      const response = await fetch(CONFIG_URLS.ENDPOINTS)
 
       if (!response.ok) {
         throw new Error(`Failed to fetch endpoints.json: ${response.status}`)

--- a/src/services/templateService.ts
+++ b/src/services/templateService.ts
@@ -1,4 +1,5 @@
 import { configService } from './configService'
+import { CONFIG_URLS } from '@/utils/apiConstants'
 
 interface Template {
   id?: string
@@ -42,7 +43,7 @@ class TemplateService {
    * Get the base URL for templates directory
    */
   private getTemplatesBaseUrl(): string {
-    return `${window.location.origin}/configs/templates`
+    return CONFIG_URLS.TEMPLATES_DIR
   }
 
   /**
@@ -58,15 +59,20 @@ class TemplateService {
    * Handles both id and name fields for backward compatibility
    */
   getTemplateDataUrl(template: { id?: string; name: string; download_url?: string }): string {
-    // If download_url is provided, use it
+    // If download_url is provided, use it (relative to templates directory)
     if (template.download_url) {
-      return `${window.location.origin}/configs/${template.download_url}`
+      // If download_url already includes the full path, use templates dir directly
+      if (template.download_url.startsWith('templates/')) {
+        return `${CONFIG_URLS.TEMPLATES_DIR}/${template.download_url.replace('templates/', '')}`
+      }
+      // Otherwise assume it's relative to configs
+      return `${CONFIG_URLS.TEMPLATES_DIR}/${template.download_url}`
     }
 
     // Prefer id over name
     const identifier = template.id || template.name
 
-    // Standard pattern: /configs/templates/{identifier}.json
+    // Standard pattern: templates/{identifier}.json
     return `${this.getTemplatesBaseUrl()}/${identifier}.json`
   }
 

--- a/src/utils/apiConstants.ts
+++ b/src/utils/apiConstants.ts
@@ -1,0 +1,34 @@
+/**
+ * API Constants
+ * Centralized constants for external API endpoints and configuration URLs
+ */
+
+/**
+ * Base URL for JSON configuration files hosted on json.rediacc.com
+ * This ensures configs are fetched from the correct source regardless of
+ * how the console is accessed (direct URL, tunnel, proxy, etc.)
+ */
+export const JSON_API_BASE_URL = 'https://json.rediacc.com'
+
+/**
+ * Full URLs for configuration endpoints
+ */
+export const CONFIG_URLS = {
+  /** Templates list endpoint */
+  TEMPLATES: `${JSON_API_BASE_URL}/templates.json`,
+
+  /** Templates directory (for individual template JSON files) */
+  TEMPLATES_DIR: `${JSON_API_BASE_URL}/templates`,
+
+  /** API endpoints configuration */
+  ENDPOINTS: `${JSON_API_BASE_URL}/configs/endpoints.json`,
+
+  /** Pricing configuration */
+  PRICING: `${JSON_API_BASE_URL}/configs/pricing.json`,
+
+  /** Services configuration */
+  SERVICES: `${JSON_API_BASE_URL}/configs/services.json`,
+
+  /** Tiers configuration */
+  TIERS: `${JSON_API_BASE_URL}/configs/tiers.json`,
+} as const


### PR DESCRIPTION
## Summary
- Config files (templates, endpoints, pricing) now use absolute URLs pointing to json.rediacc.com
- This ensures proper functionality when accessing the console through cloudflare tunnels or alternative origins
- Previously, relative URLs like /configs/templates.json would resolve to the current origin (e.g., cloudflare tunnel URL), causing 404 errors

## Changes
- Add centralized API constants in `src/utils/apiConstants.ts`
- Update `configService` to use absolute template URL
- Update `templateService` to use absolute URLs for all template data
- Update `endpointService` to use absolute endpoints URL
- Update `pricingService` to use absolute pricing URL

## Testing
- Console will now correctly fetch templates regardless of access method
- Works with direct URLs, cloudflare tunnels, proxies, etc.