### PR TITLE
Fix endpoint selector showing false unhealthy status on load

### DIFF
--- a/src/components/common/EndpointSelector.tsx
+++ b/src/components/common/EndpointSelector.tsx
@@ -278,9 +278,11 @@ const EndpointSelector: React.FC = () => {
         {/* Predefined and custom endpoints */}
         {endpoints.map((endpoint) => {
           const health = healthStatus[endpoint.id];
-          const isHealthy = health?.isHealthy || endpoint.type === 'localhost'; // Always show localhost as healthy
+          // Default to healthy until proven otherwise (optimistic approach)
+          const isHealthy = health?.isHealthy ?? true;
           const isChecking = health?.checking;
-          const isDisabled = !isHealthy && endpoint.type !== 'localhost'; // Never disable localhost
+          // Only disable if we've checked and it's unhealthy (not localhost)
+          const isDisabled = (health !== undefined && !health.isHealthy && !health.checking) && endpoint.type !== 'localhost';
 
           // Label for selected value (with health indicator but without version)
           const labelContent = (


### PR DESCRIPTION
## Summary
- Fix endpoints showing as unhealthy (red dot) before health check completes
- Use optimistic defaults: assume healthy until proven otherwise
- Only disable endpoints after actual health check confirms they are unhealthy

## Issue
When loading the login page in development mode, the endpoint selector showed sandbox and other endpoints with a red dot and disabled state before any health check was performed. This prevented users from selecting those endpoints.

## Root Cause
The `healthStatus` object was empty on initial load, causing `isHealthy` to evaluate to `false` for all non-localhost endpoints, making them appear unhealthy and disabled.

## Solution
Changed the health check logic to:
- Default `isHealthy` to `true` (optimistic approach)
- Only disable endpoints when `health !== undefined && !health.isHealthy`
- This ensures endpoints are selectable until actually checked

## Test Plan
- [x] Load login page - endpoints show green dots
- [x] Open endpoint dropdown - health checks run
- [x] Unhealthy endpoints show red dot and become disabled
- [x] Healthy endpoints remain green and selectable