### PR TITLE
feat: add centralized feature flags system for beta features

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import MainLayout from '@/components/layouts/MainLayout'
 import LoginPage from '@/pages/LoginPage'
 import { useComponentStyles } from '@/hooks/useComponentStyles'
 import { getBasePath } from '@/utils/basePath'
+import { featureFlags } from '@/config/featureFlags'
 
 // Lazy load heavy pages
 const DashboardPage = lazy(() => import('@/pages/DashboardPage'))
@@ -77,10 +78,14 @@ const AppContent: React.FC = () => {
     const initialize = async () => {
       // Initialize API client with correct URL
       await initializeApiClient()
-      
+
+      // Initialize feature flags after API connection is established
+      // This determines if we're in local development mode or production
+      featureFlags.updateDevelopmentState()
+
       // Migrate any existing localStorage data to secure memory storage
       await migrateFromLocalStorage()
-      
+
       // Check for existing auth data on mount
       const authData = await getAuthData()
       if (authData.token && authData.email) {
@@ -91,7 +96,7 @@ const AppContent: React.FC = () => {
         }))
       }
     }
-    
+
     initialize()
   }, [dispatch])
 
@@ -114,7 +119,7 @@ const AppContent: React.FC = () => {
                   (isAuthenticated || showSessionExpiredDialog || stayLoggedOutMode) ? <MainLayout /> : <Navigate to="/login" replace />
                 }
               >
-                <Route path="/" element={<Navigate to="/dashboard" replace />} />
+                <Route path="/" element={<Navigate to="/resources" replace />} />
 
                 {/* Dashboard */}
                 <Route path="/dashboard" element={

--- a/src/components/resources/MachineRepositoryList.tsx
+++ b/src/components/resources/MachineRepositoryList.tsx
@@ -16,6 +16,7 @@ import FunctionSelectionModal from '@/components/common/FunctionSelectionModal'
 import { LocalActionsMenu } from './LocalActionsMenu'
 import { showMessage } from '@/utils/messages'
 import { useAppSelector } from '@/store/store'
+import { featureFlags } from '@/config/featureFlags'
 
 const { Text } = Typography
 
@@ -1495,7 +1496,7 @@ export const MachineRepositoryList: React.FC<MachineRepositoryListProps> = ({ ma
         </div>
 
         {/* Plugin Containers Table */}
-        {pluginContainers.length > 0 && (
+        {featureFlags.isEnabled('plugins') && pluginContainers.length > 0 && (
           <div style={{ marginTop: 16 }} data-testid="machine-repo-list-plugins-section">
             <Table
               columns={containerColumnsWithRepo}
@@ -1699,7 +1700,7 @@ export const MachineRepositoryList: React.FC<MachineRepositoryListProps> = ({ ma
       ellipsis: true,
       render: (name: string, record: Repository) => {
         const isExpanded = expandedRows.includes(record.name)
-        const hasExpandableContent = record.mounted && (record.has_services || record.container_count > 0 || record.plugin_count > 0)
+        const hasExpandableContent = record.mounted && (record.has_services || record.container_count > 0 || (featureFlags.isEnabled('plugins') && record.plugin_count > 0))
 
         // Look up repository data to determine if it's a clone or original
         const repositoryData = teamRepositories.find(r => r.repositoryName === record.name)
@@ -2030,7 +2031,7 @@ export const MachineRepositoryList: React.FC<MachineRepositoryListProps> = ({ ma
           expandedRowRender: renderExpandedRow,
           expandedRowKeys: expandedRows,
           onExpandedRowsChange: (keys) => setExpandedRows(keys as string[]),
-          rowExpandable: (record) => record.mounted && (record.has_services || record.container_count > 0 || record.plugin_count > 0),
+          rowExpandable: (record) => record.mounted && (record.has_services || record.container_count > 0 || (featureFlags.isEnabled('plugins') && record.plugin_count > 0)),
           expandIcon: () => null, // Hide default expand icon
           expandRowByClick: false, // We'll handle this manually
         }}
@@ -2038,7 +2039,7 @@ export const MachineRepositoryList: React.FC<MachineRepositoryListProps> = ({ ma
           emptyText: t('resources:repositories.noRepositories')
         }}
         onRow={(record) => {
-          const hasExpandableContent = record.mounted && (record.has_services || record.container_count > 0 || record.plugin_count > 0)
+          const hasExpandableContent = record.mounted && (record.has_services || record.container_count > 0 || (featureFlags.isEnabled('plugins') && record.plugin_count > 0))
           return {
             onClick: (e) => {
               const target = e.target as HTMLElement

--- a/src/components/resources/MachineTable.tsx
+++ b/src/components/resources/MachineTable.tsx
@@ -49,6 +49,7 @@ import { ViewAssignmentStatusModal } from './ViewAssignmentStatusModal';
 import MachineAssignmentStatusCell from './MachineAssignmentStatusCell';
 import { useComponentStyles } from '@/hooks/useComponentStyles';
 import { DESIGN_TOKENS } from '@/utils/styleConstants';
+import { featureFlags } from '@/config/featureFlags';
 
 
 interface MachineTableProps {
@@ -337,8 +338,8 @@ export const MachineTable: React.FC<MachineTableProps> = ({
       }
     }
 
-    // Distributed Storage Assignment Status column - show in expert mode
-    if (!onRowClick && isExpertMode) {
+    // Distributed Storage Assignment Status column - show in expert mode with feature flag
+    if (!onRowClick && isExpertMode && featureFlags.isEnabled('assignToCluster')) {
       baseColumns.push({
         title: t('machines:assignmentStatus.title'),
         key: 'assignmentStatus',
@@ -475,9 +476,9 @@ export const MachineTable: React.FC<MachineTableProps> = ({
                     },
                     'data-testid': `machine-test-${record.machineName}`
                   },
-                  ...(isExpertMode ? [{
+                  ...(isExpertMode && featureFlags.isEnabled('assignToCluster') ? [{
                     key: 'assignCluster',
-                    label: record.distributedStorageClusterName 
+                    label: record.distributedStorageClusterName
                       ? t('machines:changeClusterAssignment')
                       : t('machines:assignToCluster'),
                     icon: <CloudServerOutlined />,
@@ -543,8 +544,8 @@ export const MachineTable: React.FC<MachineTableProps> = ({
     return baseColumns;
   }, [isExpertMode, uiMode, showActions, t, handleDelete, onEditMachine, onFunctionsMachine, onCreateRepository, executePingForMachineAndWait, machineFunctions, expandedRowKeys, externalRefreshKeys, setInternalRefreshKeys, setAssignClusterModal, setAuditTraceModal, setRemoteFileBrowserModal, onRowClick]);
 
-  // Row selection configuration
-  const rowSelection = isExpertMode ? {
+  // Row selection configuration - only show checkboxes if assignToCluster feature is enabled
+  const rowSelection = (isExpertMode && featureFlags.isEnabled('assignToCluster')) ? {
     selectedRowKeys,
     onChange: (newSelectedRowKeys: React.Key[]) => {
       setSelectedRowKeys(newSelectedRowKeys as string[]);
@@ -555,9 +556,9 @@ export const MachineTable: React.FC<MachineTableProps> = ({
     }),
   } : undefined;
 
-  // Render bulk actions toolbar
+  // Render bulk actions toolbar - only if feature is enabled
   const renderBulkActionsToolbar = () => {
-    if (!isExpertMode || selectedRowKeys.length === 0) return null;
+    if (!isExpertMode || !featureFlags.isEnabled('assignToCluster') || selectedRowKeys.length === 0) return null;
 
     return (
       <div style={{ 

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -1,0 +1,176 @@
+/**
+ * Centralized Feature Flags Configuration
+ *
+ * This file manages all beta and development features in one place.
+ * To hide a feature in production builds, set requiresLocalhost: true
+ *
+ * Usage:
+ *   import { featureFlags } from '@/config/featureFlags'
+ *   if (featureFlags.isEnabled('distributedStorage')) { ... }
+ */
+
+import { apiConnectionService } from '@/services/apiConnectionService'
+
+export interface FeatureFlag {
+  enabled: boolean
+  requiresLocalhost?: boolean  // Only show when connected to localhost
+  requiresBuildType?: 'DEBUG' | 'RELEASE'  // Only show in specific build type
+  requiresExpertMode?: boolean  // Requires expert UI mode (checked separately in components)
+  description?: string  // Description of the feature
+}
+
+class FeatureFlags {
+  private isDevelopment = false
+
+  constructor() {
+    // Will be initialized after API connection is established
+  }
+
+  /**
+   * Define all feature flags here
+   * This is the single source of truth for all beta features
+   */
+  private flags: Record<string, FeatureFlag> = {
+    // Distributed Storage - Beta feature
+    distributedStorage: {
+      enabled: false,
+      requiresLocalhost: true,  // Hide in production builds
+      requiresExpertMode: true,
+      description: 'Distributed storage cluster management - allows creating and managing storage clusters'
+    },
+
+    // Marketplace - Beta feature
+    marketplace: {
+      enabled: false,
+      requiresLocalhost: true,  // Hide in production builds
+      description: 'Template marketplace for quick deployments'
+    },
+
+    // Assign to Cluster - Beta feature (menu item in MachineTable)
+    assignToCluster: {
+      enabled: false,
+      requiresLocalhost: true,  // Hide in production builds
+      requiresExpertMode: true,
+      description: 'Assign machines to distributed storage clusters'
+    },
+
+    // Architecture - Beta feature
+    architecture: {
+      enabled: false,
+      requiresLocalhost: true,  // Hide in production builds
+      requiresExpertMode: true,
+      description: 'System architecture visualization and dependency management'
+    },
+
+    // Login Advanced Options - Beta feature (encryption password on login page)
+    loginAdvancedOptions: {
+      enabled: false,
+      requiresLocalhost: true,  // Hide in production builds
+      description: 'Advanced login options including master password / encryption password field'
+    },
+
+    // Plugins - Beta feature (vault-based plugin containers)
+    plugins: {
+      enabled: false,
+      requiresLocalhost: true,  // Hide in production builds
+      description: 'Plugin containers system - vault-based feature for custom service containers'
+    },
+
+    // Example: Future feature that's disabled for everyone
+    // newFeatureX: {
+    //   enabled: false,
+    //   description: 'Upcoming feature X - not ready yet'
+    // },
+
+    // Example: Feature only for DEBUG builds
+    // debugTooling: {
+    //   enabled: true,
+    //   requiresBuildType: 'DEBUG',
+    //   description: 'Advanced debugging tools'
+    // },
+  }
+
+  /**
+   * Check if a feature is enabled
+   * @param featureName - The name of the feature to check
+   * @returns true if the feature should be visible/enabled
+   */
+  isEnabled(featureName: string): boolean {
+    const flag = this.flags[featureName]
+
+    // Feature doesn't exist or is explicitly disabled
+    if (!flag || !flag.enabled) {
+      return false
+    }
+
+    // Check localhost requirement
+    if (flag.requiresLocalhost && !this.isDevelopment) {
+      return false
+    }
+
+    // Check build type requirement
+    if (flag.requiresBuildType) {
+      const currentBuildType = import.meta.env.VITE_BUILD_TYPE || 'DEBUG'
+      if (currentBuildType !== flag.requiresBuildType) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  /**
+   * Get all enabled features
+   * @returns Array of enabled feature names
+   */
+  getEnabledFeatures(): string[] {
+    return Object.keys(this.flags).filter(name => this.isEnabled(name))
+  }
+
+  /**
+   * Get feature flag details
+   * @param featureName - The name of the feature
+   * @returns The feature flag configuration or undefined
+   */
+  getFeature(featureName: string): FeatureFlag | undefined {
+    return this.flags[featureName]
+  }
+
+  /**
+   * Update development state based on current API connection
+   * This should be called after API connection is established
+   */
+  updateDevelopmentState(): void {
+    const endpointInfo = apiConnectionService.getEndpointInfo()
+    this.isDevelopment = endpointInfo?.type === 'localhost'
+
+    if (import.meta.env.DEV) {
+      console.log('[FeatureFlags] Development state updated:', {
+        isDevelopment: this.isDevelopment,
+        endpointType: endpointInfo?.type,
+        buildType: import.meta.env.VITE_BUILD_TYPE,
+        enabledFeatures: this.getEnabledFeatures()
+      })
+    }
+  }
+
+  /**
+   * Get development state
+   * @returns true if connected to localhost
+   */
+  isDevelopmentMode(): boolean {
+    return this.isDevelopment
+  }
+
+  /**
+   * Get current build type
+   * @returns 'DEBUG' or 'RELEASE'
+   */
+  getBuildType(): 'DEBUG' | 'RELEASE' {
+    const buildType = import.meta.env.VITE_BUILD_TYPE || 'DEBUG'
+    return buildType === 'RELEASE' ? 'RELEASE' : 'DEBUG'
+  }
+}
+
+// Export singleton instance
+export const featureFlags = new FeatureFlags()

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -18,6 +18,7 @@ import logoWhite from '@/assets/logo_white.png'
 import { useComponentStyles } from '@/hooks/useComponentStyles'
 import { DESIGN_TOKENS, spacing, borderRadius } from '@/utils/styleConstants'
 import { ModalSize } from '@/types/modal'
+import { featureFlags } from '@/config/featureFlags'
 import { 
   isEncrypted, 
   validateMasterPassword, 
@@ -275,7 +276,7 @@ const LoginPage: React.FC = () => {
         vault_protocol_state: vaultProtocolState?.toString() || 'none'
       })
 
-      navigate('/dashboard')
+      navigate('/resources')
     } catch (error: any) {
       // Track login failure
       trackUserAction('login_failure', 'login_form', {
@@ -331,10 +332,10 @@ const LoginPage: React.FC = () => {
           vaultCompany: vaultCompany,
           companyEncryptionEnabled: companyHasEncryption,
         }))
-        
+
         // Close modal and navigate
         setShowTFAModal(false)
-        navigate('/dashboard')
+        navigate('/resources')
       }
     } catch (error: any) {
       // Error is handled by the mutation
@@ -469,9 +470,9 @@ const LoginPage: React.FC = () => {
           </Form.Item>
 
           {/* Progressive disclosure: Show master password field only when needed */}
-          {(vaultProtocolState === VaultProtocolState.PASSWORD_REQUIRED || 
-            vaultProtocolState === VaultProtocolState.INVALID_PASSWORD || 
-            showAdvancedOptions) && (
+          {(vaultProtocolState === VaultProtocolState.PASSWORD_REQUIRED ||
+            vaultProtocolState === VaultProtocolState.INVALID_PASSWORD ||
+            (showAdvancedOptions && featureFlags.isEnabled('loginAdvancedOptions'))) && (
             <Form.Item
               name="masterPassword"
               label={
@@ -513,8 +514,9 @@ const LoginPage: React.FC = () => {
           )}
           
           {/* Show advanced options toggle when master password is not yet shown */}
-          {!(vaultProtocolState === VaultProtocolState.PASSWORD_REQUIRED || 
-            vaultProtocolState === VaultProtocolState.INVALID_PASSWORD || 
+          {featureFlags.isEnabled('loginAdvancedOptions') &&
+           !(vaultProtocolState === VaultProtocolState.PASSWORD_REQUIRED ||
+            vaultProtocolState === VaultProtocolState.INVALID_PASSWORD ||
             showAdvancedOptions) && (
             <div style={{ textAlign: 'center', marginBottom: spacing('MD'), marginTop: spacing('SM') }}>
               <Button


### PR DESCRIPTION
## Summary

Add a maintainable, centralized feature flag system to control the visibility of beta and development features based on environment and build type.

## Features Controlled by Flags

- **Distributed Storage** - Menu item and cluster assignment functionality
- **Marketplace** - Template marketplace
- **Architecture** - System architecture visualization
- **Login Advanced Options** - Encryption password field on login page
- **Plugins** - Plugin containers section in repository list

## Feature Flag Capabilities

- Master on/off switch per feature (`enabled` property)
- Environment-based visibility (`requiresLocalhost` - localhost vs production)
- Build type restrictions (`requiresBuildType` - DEBUG vs RELEASE)
- Expert mode requirements (`requiresExpertMode`)
- Self-documenting with descriptions

## Implementation Details

- All feature flags defined in `/console/src/config/featureFlags.ts`
- Feature flags initialized after API connection in App.tsx
- Automatically detects environment type (localhost vs production)
- Beta features hidden in production builds by default
- Can be enabled selectively by setting `enabled: true` in flag config

## Benefits

- Single source of truth for all beta features
- Easy to enable/disable features without code changes
- Flexible control based on multiple conditions
- Clear visibility of what features are in beta
- Easy graduation path (remove flag checks when stable)

## Testing

- Development: Run `./go dev` (features visible on localhost)
- Production: Run `./go system up` or `./go deploy publish` (beta features hidden)