### PR TITLE
fix(i18n): translate notification panel titles, tags, and timestamps

### DIFF
--- a/src/components/common/LanguageSelector.tsx
+++ b/src/components/common/LanguageSelector.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Select } from 'antd';
 import { GlobalOutlined } from '@/utils/optimizedIcons';
 import { useTranslation } from 'react-i18next';
+import dayjs from 'dayjs';
+import 'dayjs/locale/es';
 const { Option } = Select;
 
 interface Language {
@@ -29,6 +31,13 @@ const LanguageSelector: React.FC = () => {
     await i18n.changeLanguage(value);
     // Force a re-render of the entire app by updating the document direction for RTL languages
     document.documentElement.dir = value === 'ar' ? 'rtl' : 'ltr';
+
+    // Set dayjs locale globally
+    const dayjsLocaleMap: Record<string, string> = {
+      en: 'en',
+      es: 'es'
+    };
+    dayjs.locale(dayjsLocaleMap[value] || 'en');
   };
 
   const selectorStyle = {

--- a/src/components/common/NotificationBell.tsx
+++ b/src/components/common/NotificationBell.tsx
@@ -21,6 +21,7 @@ import {
 import { useTranslation } from 'react-i18next'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
+import 'dayjs/locale/es'
 import { useComponentStyles } from '@/hooks/useComponentStyles'
 import { DESIGN_TOKENS, spacing } from '@/utils/styleConstants'
 
@@ -30,11 +31,20 @@ const { Text } = Typography
 
 const NotificationBell: React.FC = () => {
   const dispatch = useDispatch()
-  const { t } = useTranslation('common')
+  const { t, i18n } = useTranslation('common')
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const styles = useComponentStyles()
-  
+
   const { notifications, unreadCount } = useSelector((state: RootState) => state.notifications)
+
+  // Update dayjs locale when language changes
+  React.useEffect(() => {
+    const dayjsLocaleMap: Record<string, string> = {
+      en: 'en',
+      es: 'es'
+    }
+    dayjs.locale(dayjsLocaleMap[i18n.language] || 'en')
+  }, [i18n.language])
 
   const getIcon = (type: NotificationType) => {
     switch (type) {
@@ -143,7 +153,7 @@ const NotificationBell: React.FC = () => {
                       <Space>
                         <Text strong={!notification.read}>{notification.title}</Text>
                         <Tag color={getTypeColor(notification.type)} style={{ marginLeft: spacing('XS') }}>
-                          {notification.type.toUpperCase()}
+                          {t(`notifications.types.${notification.type}`).toUpperCase()}
                         </Tag>
                       </Space>
                       <Button

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -138,7 +138,13 @@
     "clearAll": "Clear all",
     "empty": "No notifications",
     "markAllRead": "Mark all as read",
-    "title": "Notifications"
+    "title": "Notifications",
+    "types": {
+      "success": "Success",
+      "error": "Error",
+      "warning": "Warning",
+      "info": "Information"
+    }
   },
   "refresh": "Refresh",
   "status": {

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -138,7 +138,13 @@
     "clearAll": "Borrar todo",
     "empty": "Sin notificaciones",
     "markAllRead": "Marcar todo como leído",
-    "title": "Notificaciones"
+    "title": "Notificaciones",
+    "types": {
+      "success": "Éxito",
+      "error": "Error",
+      "warning": "Advertencia",
+      "info": "Información"
+    }
   },
   "refresh": "Refrescar",
   "status": {

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -11,15 +11,10 @@ const recentErrors = new Map<string, number>()
 const ERROR_DEDUP_WINDOW_MS = 1000 // 1 second window for deduplication
 const ERROR_CLEANUP_THRESHOLD_MS = ERROR_DEDUP_WINDOW_MS * 2
 
-const NOTIFICATION_TITLES: Record<MessageType, string> = {
-  success: 'Success',
-  error: 'Error',
-  warning: 'Warning',
-  info: 'Information'
+const getNotificationTitle = (type: MessageType): string => {
+  const titleKey = `notifications.types.${type}`
+  return i18n.t(`common:${titleKey}`) || 'Notification'
 }
-
-const getNotificationTitle = (type: MessageType): string => 
-  NOTIFICATION_TITLES[type] ?? 'Notification'
 
 export const showMessage = (type: MessageType, content: string) => {
   // For error messages, check if we've shown this recently


### PR DESCRIPTION
## Summary

Fixes #7 - Notification panel text elements now properly translate when switching languages (English ↔ Spanish).

This PR implements i18n support for three critical notification panel elements that were previously hardcoded in English:

- ✅ **Notification titles** (Success, Error, Warning, Information)
- ✅ **Notification type tags** (SUCCESS, ERROR, WARNING, INFO)
- ✅ **Relative timestamps** (2 hours ago, 3 days ago)

## Changes Made

### 1. Translation Files
- Added `notifications.types` object to EN and ES locale files with translations for all notification types

### 2. Code Updates
- **messages.ts**: Replaced hardcoded `NOTIFICATION_TITLES` object with `i18n.t()` function call
- **NotificationBell.tsx**: 
  - Updated type tags to use `t(\`notifications.types.\${notification.type}\`)`
  - Added dayjs Spanish locale import
  - Added useEffect to update dayjs locale when language changes
- **LanguageSelector.tsx**: 
  - Added dayjs import and Spanish locale
  - Updated `handleChange` to set dayjs locale globally when language switches

## Translation Examples

When switching from English to Spanish:

| Element | English | Spanish |
|---------|---------|---------|
| Success title | Success | Éxito |
| Error title | Error | Error |
| Warning title | Warning | Advertencia |
| Info title | Information | Información |
| Success tag | SUCCESS | ÉXITO |
| Warning tag | WARNING | ADVERTENCIA |
| Timestamp | 2 hours ago | hace 2 horas |
| Timestamp | 3 days ago | hace 3 días |

## Testing

Manual testing verified:
1. Switch language from English → Spanish
2. Trigger notifications (success, error, warning, info)
3. Verify all text elements translate correctly
4. Check timestamp localization displays in Spanish

## Notes

- Only EN and ES locales updated per requirements
- Dayjs locale switching implemented both locally (NotificationBell) and globally (LanguageSelector) for comprehensive coverage
- All notification panel UI elements were already translating correctly (panel title, buttons)

🤖 Generated with [Claude Code](https://claude.com/claude-code)