### PR TITLE
Fix hardcoded action button tooltips in System page

### DIFF
--- a/src/i18n/locales/en/system.json
+++ b/src/i18n/locales/en/system.json
@@ -2,16 +2,19 @@
   "actions": {
     "addMember": "Add Member",
     "addPermission": "Add Permission",
+    "assignUser": "Assign User",
     "changePassword": "Change Password",
     "configureVault": "Configure Vault",
     "createGroup": "Create Group",
     "createTeam": "Create Team",
     "createUser": "Create User",
     "deactivate": "Deactivate",
+    "edit": "Edit",
     "members": "Members",
     "permissions": "Permissions",
     "resetAuth": "Reset Auth",
     "token": "Token",
+    "trace": "Trace",
     "twoFactorAuth": "Two-Factor Authentication"
   },
   "architecture": {
@@ -179,6 +182,30 @@
   },
   "regionsInfrastructure": {
     "title": "Regions & Infrastructure"
+  },
+  "tables": {
+    "permissionGroups": {
+      "actions": "Actions",
+      "groupName": "Group Name",
+      "permissions": "Permissions",
+      "users": "Users"
+    },
+    "teams": {
+      "actions": "Actions",
+      "machines": "Machines",
+      "members": "Members",
+      "repositories": "Repositories",
+      "storage": "Storage",
+      "teamName": "Team Name",
+      "vaultVersion": "Vault Version"
+    },
+    "users": {
+      "actions": "Actions",
+      "email": "Email",
+      "lastActive": "Last Active",
+      "permissionGroup": "Permission Group",
+      "status": "Status"
+    }
   },
   "userSessions": {
     "active": "Active",

--- a/src/i18n/locales/es/system.json
+++ b/src/i18n/locales/es/system.json
@@ -2,16 +2,19 @@
   "actions": {
     "addMember": "Agregar miembro",
     "addPermission": "Agregar permiso",
+    "assignUser": "Asignar usuario",
     "changePassword": "Cambiar la contraseña",
     "configureVault": "Configurar bóveda",
     "createGroup": "Crear grupo",
     "createTeam": "Crear equipo",
     "createUser": "Crear usuario",
     "deactivate": "Desactivar",
+    "edit": "Editar",
     "members": "Miembros",
     "permissions": "Permisos",
     "resetAuth": "Restablecer autenticación",
-    "token": "Simbólica",
+    "token": "Token",
+    "trace": "Rastro",
     "twoFactorAuth": "Autenticación de dos factores"
   },
   "architecture": {
@@ -179,6 +182,30 @@
   },
   "regionsInfrastructure": {
     "title": "Regiones e infraestructura"
+  },
+  "tables": {
+    "permissionGroups": {
+      "actions": "Acciones",
+      "groupName": "Nombre del grupo",
+      "permissions": "Permisos",
+      "users": "Usuarios"
+    },
+    "teams": {
+      "actions": "Acciones",
+      "machines": "Máquinas",
+      "members": "Miembros",
+      "repositories": "Repositorios",
+      "storage": "Almacenamiento",
+      "teamName": "Nombre del equipo",
+      "vaultVersion": "Versión de bóveda"
+    },
+    "users": {
+      "actions": "Acciones",
+      "email": "Correo electrónico",
+      "lastActive": "Última actividad",
+      "permissionGroup": "Grupo de permisos",
+      "status": "Estado"
+    }
   },
   "userSessions": {
     "active": "Activa",

--- a/src/pages/system/SystemPage.tsx
+++ b/src/pages/system/SystemPage.tsx
@@ -896,7 +896,7 @@ const SystemPage: React.FC = () => {
   // Permission columns
   const permissionColumns = [
     {
-      title: 'Group Name',
+      title: tSystem('tables.permissionGroups.groupName'),
       dataIndex: 'permissionGroupName',
       key: 'permissionGroupName',
       render: (text: string) => (
@@ -907,7 +907,7 @@ const SystemPage: React.FC = () => {
       ),
     },
     {
-      title: 'Users',
+      title: tSystem('tables.permissionGroups.users'),
       dataIndex: 'userCount',
       key: 'userCount',
       width: 100,
@@ -918,7 +918,7 @@ const SystemPage: React.FC = () => {
       ),
     },
     {
-      title: 'Permissions',
+      title: tSystem('tables.permissionGroups.permissions'),
       dataIndex: 'permissionCount',
       key: 'permissionCount',
       width: 120,
@@ -929,12 +929,12 @@ const SystemPage: React.FC = () => {
       ),
     },
     {
-      title: 'Actions',
+      title: tSystem('tables.permissionGroups.actions'),
       key: 'actions',
       width: 350,
       render: (_: any, record: PermissionGroup) => (
         <Space>
-          <Tooltip title="Permissions">
+          <Tooltip title={tSystem('actions.permissions')}>
             <Button
               type="primary"
               size="small"
@@ -944,10 +944,10 @@ const SystemPage: React.FC = () => {
                 setIsManageModalOpen(true)
               }}
               data-testid={`system-permission-group-manage-button-${record.permissionGroupName}`}
-              aria-label="Permissions"
+              aria-label={tSystem('actions.permissions')}
             />
           </Tooltip>
-          <Tooltip title="Assign User">
+          <Tooltip title={tSystem('actions.assignUser')}>
             <Button
               type="primary"
               size="small"
@@ -957,10 +957,10 @@ const SystemPage: React.FC = () => {
                 setIsAssignModalOpen(true)
               }}
               data-testid={`system-permission-group-assign-user-button-${record.permissionGroupName}`}
-              aria-label="Assign User"
+              aria-label={tSystem('actions.assignUser')}
             />
           </Tooltip>
-          <Tooltip title="Trace">
+          <Tooltip title={tSystem('actions.trace')}>
             <Button
               type="primary"
               size="small"
@@ -974,7 +974,7 @@ const SystemPage: React.FC = () => {
                 })
               }}
               data-testid={`system-permission-group-trace-button-${record.permissionGroupName}`}
-              aria-label="Trace"
+              aria-label={tSystem('actions.trace')}
             />
           </Tooltip>
           <Popconfirm
@@ -985,15 +985,15 @@ const SystemPage: React.FC = () => {
             cancelText="No"
             okButtonProps={{ danger: true }}
           >
-            <Tooltip title="Delete">
-              <Button 
+            <Tooltip title={tCommon('actions.delete')}>
+              <Button
                 type="primary"
                 danger
                 size="small"
                 icon={<DeleteOutlined />}
                 loading={deleteGroupMutation.isPending}
                 data-testid={`system-permission-group-delete-button-${record.permissionGroupName}`}
-                aria-label="Delete"
+                aria-label={tCommon('actions.delete')}
               />
             </Tooltip>
           </Popconfirm>
@@ -1005,7 +1005,7 @@ const SystemPage: React.FC = () => {
   // User columns
   const userColumns = [
     {
-      title: 'Email',
+      title: tSystem('tables.users.email'),
       dataIndex: 'userEmail',
       key: 'userEmail',
       render: (email: string) => (
@@ -1016,7 +1016,7 @@ const SystemPage: React.FC = () => {
       ),
     },
     {
-      title: 'Status',
+      title: tSystem('tables.users.status'),
       dataIndex: 'activated',
       key: 'activated',
       width: 120,
@@ -1029,7 +1029,7 @@ const SystemPage: React.FC = () => {
       ),
     },
     {
-      title: 'Permission Group',
+      title: tSystem('tables.users.permissionGroup'),
       dataIndex: 'permissionGroupName',
       key: 'permissionGroupName',
       render: (group: string) => group ? (
@@ -1039,18 +1039,18 @@ const SystemPage: React.FC = () => {
       ),
     },
     {
-      title: 'Last Active',
+      title: tSystem('tables.users.lastActive'),
       dataIndex: 'lastActive',
       key: 'lastActive',
       render: (date: string) => date ? new Date(date).toLocaleDateString() : 'Never',
     },
     {
-      title: 'Actions',
+      title: tSystem('tables.users.actions'),
       key: 'actions',
       width: 300,
       render: (_: any, record: User) => (
         <Space>
-          <Tooltip title="Permissions">
+          <Tooltip title={tSystem('actions.permissions')}>
             <Button
               type="primary"
               size="small"
@@ -1060,10 +1060,10 @@ const SystemPage: React.FC = () => {
                 setSelectedUserGroup(record.permissionGroupName || '')
               }}
               data-testid={`system-user-permissions-button-${record.userEmail}`}
-              aria-label="Permissions"
+              aria-label={tSystem('actions.permissions')}
             />
           </Tooltip>
-          <Tooltip title="Trace">
+          <Tooltip title={tSystem('actions.trace')}>
             <Button
               type="primary"
               size="small"
@@ -1077,7 +1077,7 @@ const SystemPage: React.FC = () => {
                 })
               }}
               data-testid={`system-user-trace-button-${record.userEmail}`}
-              aria-label="Trace"
+              aria-label={tSystem('actions.trace')}
             />
           </Tooltip>
           {record.activated && (
@@ -1089,15 +1089,15 @@ const SystemPage: React.FC = () => {
               cancelText="No"
               okButtonProps={{ danger: true }}
             >
-              <Tooltip title="Deactivate">
-                <Button 
+              <Tooltip title={tSystem('actions.deactivate')}>
+                <Button
                   type="primary"
                   danger
                   size="small"
                   icon={<StopOutlined />}
                   loading={deactivateUserMutation.isPending}
                   data-testid={`system-user-deactivate-button-${record.userEmail}`}
-                  aria-label="Deactivate"
+                  aria-label={tSystem('actions.deactivate')}
                 />
               </Tooltip>
             </Popconfirm>
@@ -1113,7 +1113,7 @@ const SystemPage: React.FC = () => {
   // Team columns
   const teamColumns = [
     {
-      title: 'Team Name',
+      title: tSystem('tables.teams.teamName'),
       dataIndex: 'teamName',
       key: 'teamName',
       render: (text: string) => (
@@ -1124,7 +1124,7 @@ const SystemPage: React.FC = () => {
       ),
     },
     {
-      title: 'Members',
+      title: tSystem('tables.teams.members'),
       dataIndex: 'memberCount',
       key: 'memberCount',
       width: 100,
@@ -1135,7 +1135,7 @@ const SystemPage: React.FC = () => {
       ),
     },
     {
-      title: 'Machines',
+      title: tSystem('tables.teams.machines'),
       dataIndex: 'machineCount',
       key: 'machineCount',
       width: 100,
@@ -1147,7 +1147,7 @@ const SystemPage: React.FC = () => {
       ),
     },
     {
-      title: 'Repositories',
+      title: tSystem('tables.teams.repositories'),
       dataIndex: 'repoCount',
       key: 'repoCount',
       width: 120,
@@ -1159,7 +1159,7 @@ const SystemPage: React.FC = () => {
       ),
     },
     {
-      title: 'Storage',
+      title: tSystem('tables.teams.storage'),
       dataIndex: 'storageCount',
       key: 'storageCount',
       width: 100,
@@ -1171,29 +1171,29 @@ const SystemPage: React.FC = () => {
       ),
     },
     ...(featureFlags.isEnabled('vaultVersionColumns') ? [{
-      title: 'Vault Version',
+      title: tSystem('tables.teams.vaultVersion'),
       dataIndex: 'vaultVersion',
       key: 'vaultVersion',
       width: 120,
       render: (version: number) => <Tag>{t('common:general.versionFormat', { version })}</Tag>,
     }] : []),
     {
-      title: 'Actions',
+      title: tSystem('tables.teams.actions'),
       key: 'actions',
       width: 350,
       render: (_: any, record: Team) => (
         <Space>
-          <Tooltip title="Edit">
-            <Button 
-              type="primary" 
+          <Tooltip title={tSystem('actions.edit')}>
+            <Button
+              type="primary"
               size="small"
               icon={<EditOutlined />}
               onClick={() => openUnifiedModal('team', 'edit', record)}
               data-testid={`system-team-edit-button-${record.teamName}`}
-              aria-label="Edit"
+              aria-label={tSystem('actions.edit')}
             />
           </Tooltip>
-          <Tooltip title="Members">
+          <Tooltip title={tSystem('actions.members')}>
             <Button
               type="primary"
               size="small"
@@ -1203,10 +1203,10 @@ const SystemPage: React.FC = () => {
                 setIsManageTeamModalOpen(true)
               }}
               data-testid={`system-team-members-button-${record.teamName}`}
-              aria-label="Members"
+              aria-label={tSystem('actions.members')}
             />
           </Tooltip>
-          <Tooltip title="Trace">
+          <Tooltip title={tSystem('actions.trace')}>
             <Button
               type="primary"
               size="small"
@@ -1220,7 +1220,7 @@ const SystemPage: React.FC = () => {
                 })
               }}
               data-testid={`system-team-trace-button-${record.teamName}`}
-              aria-label="Trace"
+              aria-label={tSystem('actions.trace')}
             />
           </Tooltip>
           <Popconfirm
@@ -1231,15 +1231,15 @@ const SystemPage: React.FC = () => {
             cancelText="No"
             okButtonProps={{ danger: true }}
           >
-            <Tooltip title="Delete">
-              <Button 
-                type="primary" 
+            <Tooltip title={tCommon('actions.delete')}>
+              <Button
+                type="primary"
                 danger
                 size="small"
                 icon={<DeleteOutlined />}
                 loading={deleteTeamMutation.isPending}
                 data-testid={`system-team-delete-button-${record.teamName}`}
-                aria-label="Delete"
+                aria-label={tCommon('actions.delete')}
               />
             </Tooltip>
           </Popconfirm>
@@ -1296,7 +1296,7 @@ const SystemPage: React.FC = () => {
               aria-label={tOrg('general.edit')}
             />
           </Tooltip>
-          <Tooltip title="Trace">
+          <Tooltip title={tSystem('actions.trace')}>
             <Button
               type="primary"
               size="small"
@@ -1310,7 +1310,7 @@ const SystemPage: React.FC = () => {
                 })
               }}
               data-testid={`system-region-trace-button-${record.regionName}`}
-              aria-label="Trace"
+              aria-label={tSystem('actions.trace')}
             />
           </Tooltip>
           <Popconfirm
@@ -1416,31 +1416,31 @@ const SystemPage: React.FC = () => {
               aria-label={tOrg('general.edit')}
             />
           </Tooltip>
-          <Tooltip title="Token">
+          <Tooltip title={tSystem('actions.token')}>
             <Button
               type="primary"
               size="small"
               icon={<KeyOutlined />}
               onClick={() => setBridgeCredentialsModal({ open: true, bridge: record })}
               data-testid={`system-bridge-token-button-${record.bridgeName}`}
-              aria-label="Token"
+              aria-label={tSystem('actions.token')}
             />
           </Tooltip>
-          <Tooltip title="Reset Auth">
-            <Button 
-              type="primary" 
+          <Tooltip title={tSystem('actions.resetAuth')}>
+            <Button
+              type="primary"
               size="small"
               icon={<SyncOutlined />}
-              onClick={() => setResetAuthModal({ 
-                open: true, 
-                bridgeName: record.bridgeName, 
-                isCloudManaged: false 
+              onClick={() => setResetAuthModal({
+                open: true,
+                bridgeName: record.bridgeName,
+                isCloudManaged: false
               })}
               data-testid={`system-bridge-reset-auth-button-${record.bridgeName}`}
-              aria-label="Reset Auth"
+              aria-label={tSystem('actions.resetAuth')}
             />
           </Tooltip>
-          <Tooltip title="Trace">
+          <Tooltip title={tSystem('actions.trace')}>
             <Button
               type="primary"
               size="small"
@@ -1454,7 +1454,7 @@ const SystemPage: React.FC = () => {
                 })
               }}
               data-testid={`system-bridge-trace-button-${record.bridgeName}`}
-              aria-label="Trace"
+              aria-label={tSystem('actions.trace')}
             />
           </Tooltip>
           <Popconfirm


### PR DESCRIPTION
## Summary
- Fixed hardcoded English tooltips in System page action buttons
- Replaced hardcoded strings with translation keys for proper internationalization
- Added missing translation keys to English and Spanish system.json files

## Changes

### Action Button Tooltips
Updated all hardcoded action button tooltips to use translation keys:

**Actions (system namespace):**
- `edit`: "Edit" / "Editar"
- `trace`: "Trace" / "Rastro"  
- `deactivate`: "Deactivate" / "Desactivar"
- `permissions`: "Permissions" / "Permisos"
- `assignUser`: "Assign User" / "Asignar usuario"
- `token`: "Token" / "Token"
- `resetAuth`: "Reset Auth" / "Restablecer autenticación"

### Table Columns
Added translations for table column headers:

**Permission Groups:**
- Group Name, Users, Permissions, Actions

**Users:**
- Email, Status, Permission Group, Last Active, Actions

**Teams:**
- Team Name, Members, Machines, Repositories, Storage, Vault Version, Actions

### Files Modified
- `src/i18n/locales/en/system.json` - Added action and table translation keys
- `src/i18n/locales/es/system.json` - Added Spanish translations
- `src/pages/system/SystemPage.tsx` - Replaced hardcoded strings with translation function calls

## Testing
- All action button tooltips now properly display in user's selected language
- Switching between English and Spanish correctly translates all tooltips and table headers

Resolves #11