### PR TITLE
Add internationalization support to theme toggle button

### DIFF
--- a/src/components/common/ThemeToggle.tsx
+++ b/src/components/common/ThemeToggle.tsx
@@ -4,21 +4,25 @@ import { SunOutlined, MoonOutlined } from '@/utils/optimizedIcons';
 import { useTheme } from '../../context/ThemeContext';
 import { useComponentStyles } from '@/hooks/useComponentStyles';
 import { DESIGN_TOKENS } from '@/utils/styleConstants';
+import { useTranslation } from 'react-i18next';
 
 export const ThemeToggle: React.FC = () => {
   const { theme, toggleTheme } = useTheme();
   const styles = useComponentStyles();
+  const { t } = useTranslation('common');
+
+  const switchText = theme === 'light' ? t('theme.switchToDark') : t('theme.switchToLight');
 
   return (
     <Button
       type="text"
-      icon={theme === 'light' ? 
-        <SunOutlined style={{ fontSize: DESIGN_TOKENS.DIMENSIONS.ICON_MD }} /> : 
+      icon={theme === 'light' ?
+        <SunOutlined style={{ fontSize: DESIGN_TOKENS.DIMENSIONS.ICON_MD }} /> :
         <MoonOutlined style={{ fontSize: DESIGN_TOKENS.DIMENSIONS.ICON_MD }} />
       }
       onClick={toggleTheme}
-      aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
-      title={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+      aria-label={switchText}
+      title={switchText}
       data-testid="theme-toggle-button"
       style={{
         ...styles.touchTarget,

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -161,7 +161,9 @@
   },
   "theme": {
     "dark": "Dark",
-    "light": "Light"
+    "light": "Light",
+    "switchToDark": "Switch to dark mode",
+    "switchToLight": "Switch to light mode"
   },
   "thisMonth": "This Month",
   "today": "Today",

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -161,7 +161,9 @@
   },
   "theme": {
     "dark": "Oscura",
-    "light": "Ligera"
+    "light": "Ligera",
+    "switchToDark": "Cambiar a modo oscuro",
+    "switchToLight": "Cambiar a modo claro"
   },
   "thisMonth": "este mes",
   "today": "Hoy",


### PR DESCRIPTION
## Summary
- Added internationalization support to theme toggle button
- Replaced hardcoded English tooltip and aria-label with translation keys
- Button text now translates based on user's selected language

## Changes

### ThemeToggle.tsx
- Imported `useTranslation` hook from react-i18next
- Added translation hook with 'common' namespace
- Replaced hardcoded strings with dynamic translation calls:
  - `aria-label`: Now uses `t('theme.switchToDark')` or `t('theme.switchToLight')`
  - `title`: Now uses the same translation keys
- Introduced `switchText` variable to compute the appropriate translation

### Translation Files

**English (en/common.json):**
```json
"theme": {
  "dark": "Dark",
  "light": "Light",
  "switchToDark": "Switch to dark mode",
  "switchToLight": "Switch to light mode"
}
```

**Spanish (es/common.json):**
```json
"theme": {
  "dark": "Oscura",
  "light": "Ligera",
  "switchToDark": "Cambiar a modo oscuro",
  "switchToLight": "Cambiar a modo claro"
}
```

## Testing
- Theme toggle tooltip displays "Switch to dark mode" in English / "Cambiar a modo oscuro" in Spanish when in light mode
- Theme toggle tooltip displays "Switch to light mode" in English / "Cambiar a modo claro" in Spanish when in dark mode
- Accessibility attributes (aria-label) properly translate
- Theme toggle functionality remains intact

Resolves #6