### PR TITLE
Fix Spanish translations for repository action buttons

### DIFF
--- a/src/i18n/locales/es/functions.json
+++ b/src/i18n/locales/es/functions.json
@@ -160,7 +160,7 @@
     },
     "down": {
       "description": "Detener servicios de repositorio",
-      "name": "abajo",
+      "name": "detener",
       "params": {
         "option": {
           "help": "Opciones adicionales",
@@ -310,7 +310,7 @@
     },
     "push": {
       "description": "Enviar el repositorio al almacenamiento remoto",
-      "name": "empujar",
+      "name": "enviar",
       "params": {
         "dest": {
           "help": "Nombre del archivo de copia de seguridad",
@@ -412,7 +412,7 @@
     },
     "up": {
       "description": "Iniciar servicios de repositorio usando Rediaccfile",
-      "name": "arriba",
+      "name": "iniciar",
       "params": {
         "option": {
           "help": "Opciones (por ejemplo, solo preparación)",


### PR DESCRIPTION
## Summary
- Fixed incorrect Spanish translations for repository action button labels
- Changed literal translations to proper action verbs

## Changes

### Spanish (es/functions.json)

**Before:**
- up: "arriba" (literally "up")
- down: "abajo" (literally "down")
- push: "empujar" (literally "push/shove")

**After:**
- up: "iniciar" (start)
- down: "detener" (stop)
- push: "enviar" (send/push)

## Explanation

The previous translations were literal word-for-word translations that didn't make sense in the context of repository actions. The new translations use proper action verbs that accurately convey what each button does:

- **iniciar** - Means "to start/initiate", appropriate for starting repository services
- **detener** - Means "to stop", appropriate for stopping repository services
- **enviar** - Means "to send/push", appropriate for pushing repositories to remote storage

## Testing
Repository action buttons in the Spanish interface now display meaningful action verbs instead of confusing literal translations.

Resolves #8