### PR TITLE
Add i18n support for LocalCommandModal network host checkbox

### DIFF
--- a/src/components/resources/LocalCommandModal.tsx
+++ b/src/components/resources/LocalCommandModal.tsx
@@ -269,9 +269,9 @@ export const LocalCommandModal: React.FC<LocalCommandModalProps> = ({
               checked={useNetworkHost}
               onChange={(e) => setUseNetworkHost(e.target.checked)}
             >
-              Use host networking (--network=host)
+              {t('resources:localCommandBuilder.useNetworkHost')}
               <Text type="secondary" style={{ marginLeft: 8 }}>
-                Required for localhost API access (e.g., http://localhost:7322)
+                {t('resources:localCommandBuilder.useNetworkHostHelp')}
               </Text>
             </Checkbox>
           </Form.Item>

--- a/src/i18n/locales/en/resources.json
+++ b/src/i18n/locales/en/resources.json
@@ -160,6 +160,8 @@
     "useDockerHelp": "Run the command using the rediacc/cli Docker image",
     "useLoginAuth": "Use login authentication instead of token",
     "useLoginAuthHelp": "Login with {{email}} (you'll be prompted for password)",
+    "useNetworkHost": "Use host networking (--network=host)",
+    "useNetworkHostHelp": "Required for localhost API access (e.g., http://localhost:7322)",
     "verify": "Verify",
     "verifyHelp": "Use checksums to verify all transfers",
     "windows": "Windows"

--- a/src/i18n/locales/es/resources.json
+++ b/src/i18n/locales/es/resources.json
@@ -157,6 +157,8 @@
     "useDockerHelp": "Ejecute el comando usando la imagen de Docker rediacc/cli",
     "useLoginAuth": "Utilice autenticación de inicio de sesión en lugar de token",
     "useLoginAuthHelp": "Inicie sesión con {{email}} (se le solicitará la contraseña)",
+    "useNetworkHost": "Usar red de host (--network=host)",
+    "useNetworkHostHelp": "Requerido para acceso a API localhost (ej., http://localhost:7322)",
     "verify": "Verificar",
     "verifyHelp": "Utilice sumas de verificación para verificar todas las transferencias",
     "vscodeDescription": "Inicie VS Code con conexión remota SSH al repositorio",


### PR DESCRIPTION
## Summary
- Add translation support for the network host checkbox in LocalCommandModal
- Add 'useNetworkHost' and 'useNetworkHostHelp' translation keys to English and Spanish resources.json
- Replace hardcoded strings with translation function calls

## Changes
- Updated `/src/i18n/locales/en/resources.json` to add `useNetworkHost` and `useNetworkHostHelp` keys
- Updated `/src/i18n/locales/es/resources.json` to add Spanish translations
- Updated `/src/components/resources/LocalCommandModal.tsx` to use translation keys

Fixes #9

