### PR TITLE
fix: sync package-lock.json with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@ant-design/charts": "^2.6.5",
         "@ant-design/icons": "^5.5.1",
+        "@hcaptcha/react-hcaptcha": "^1.12.1",
         "@hookform/resolvers": "^5.2.2",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-web": "^0.52.0",
@@ -1734,6 +1735,26 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hcaptcha/loader": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@hcaptcha/loader/-/loader-2.2.0.tgz",
+      "integrity": "sha512-LAd0XRt1Mu0hLpUpWAx5OS9FS0d6V+V0aCSYUKFAz0a6tTDHeAuwm5iO81mp2HIEhXFOSSB8AwCCOU9zq695lg==",
+      "license": "MIT"
+    },
+    "node_modules/@hcaptcha/react-hcaptcha": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@hcaptcha/react-hcaptcha/-/react-hcaptcha-1.14.0.tgz",
+      "integrity": "sha512-XHFhmRjw4L6spgRfTEUj/uW4cN4iWTp7BxLHyheF5zEle6g65fIHUCmqKMrIA/6OKLzBSElUKyc1IuDU+V8RaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.9",
+        "@hcaptcha/loader": "^2.2.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
       }
     },
     "node_modules/@hookform/resolvers": {


### PR DESCRIPTION
## Summary
- Fix npm CI failures by syncing package-lock.json with package.json
- Adds missing hcaptcha dependencies to the lock file
- Resolves CI build failures on console package installation

## Test Plan
- [x] npm ci completes successfully
- [x] All dependencies are properly locked in package-lock.json
- [x] CI pipeline should pass on next run