### PR TITLE
refactor: rename repoLoopbackIp to repoNetworkId

### DIFF
--- a/cli/src/services/queue.ts
+++ b/cli/src/services/queue.ts
@@ -52,7 +52,7 @@ export class CliQueueService {
       storageVault: vaults.storageVault,
       bridgeVault: vaults.bridgeVault,
       repositoryGuid: context.params.repo as string | undefined,
-      repositoryLoopbackIp: (vaults.repositoryVault as { repoLoopbackIp?: string })?.repoLoopbackIp,
+      repositoryNetworkId: (vaults.repositoryVault as { repoNetworkId?: number })?.repoNetworkId,
       repositoryNetworkMode: (vaults.repositoryVault as { networkMode?: string })?.networkMode,
       storageName: (context.params.to || context.params.from) as string | undefined,
     }
@@ -135,15 +135,15 @@ export class CliQueueService {
         const reposResponse = await apiClient.get('/GetTeamRepositories', {
           teamName: context.teamName,
         })
-        const repos = reposResponse.resultSets?.[0]?.data as Array<{ repoGuid: string; vaultContent?: string; repoLoopbackIP?: string; repoNetworkMode?: string }> | undefined
+        const repos = reposResponse.resultSets?.[0]?.data as Array<{ repoGuid: string; vaultContent?: string; repoNetworkId?: number; repoNetworkMode?: string }> | undefined
         const repo = repos?.find(r => r.repoGuid === repoGuid)
         if (repo?.vaultContent) {
           const repoVault = typeof repo.vaultContent === 'string'
             ? JSON.parse(repo.vaultContent)
             : repo.vaultContent
-          // Add loopback IP and network mode to vault data
-          if (repo.repoLoopbackIP) {
-            repoVault.repoLoopbackIp = repo.repoLoopbackIP
+          // Add network ID and network mode to vault data
+          if (repo.repoNetworkId !== undefined) {
+            repoVault.repoNetworkId = repo.repoNetworkId
           }
           if (repo.repoNetworkMode) {
             repoVault.networkMode = repo.repoNetworkMode

--- a/packages/queue-vault/src/builders/QueueVaultBuilder.ts
+++ b/packages/queue-vault/src/builders/QueueVaultBuilder.ts
@@ -155,9 +155,9 @@ export class QueueVaultBuilder {
         }
       }
 
-      // Add REPO_LOOPBACK_IP if repository loopback IP is provided
-      if (requirements.repository && context.repositoryLoopbackIp) {
-        queueVaultData.contextData.REPO_LOOPBACK_IP = context.repositoryLoopbackIp
+      // Add REPO_NETWORK_ID if repository network ID is provided
+      if (requirements.repository && context.repositoryNetworkId !== undefined) {
+        queueVaultData.contextData.REPO_NETWORK_ID = context.repositoryNetworkId
       }
 
       // Add REPO_NETWORK_MODE if repository network mode is provided

--- a/packages/queue-vault/src/types/requirements.ts
+++ b/packages/queue-vault/src/types/requirements.ts
@@ -5,7 +5,7 @@ export interface QueueRequestContext {
   machineName?: string | null
   bridgeName?: string
   repositoryGuid?: string
-  repositoryLoopbackIp?: string
+  repositoryNetworkId?: number
   repositoryNetworkMode?: string
   repositoryTag?: string
   storageName?: string

--- a/packages/queue-vault/src/types/vault.ts
+++ b/packages/queue-vault/src/types/vault.ts
@@ -28,7 +28,7 @@ export interface VaultContextData extends VaultData {
   MACHINES?: Record<string, MachineContextData>
   STORAGE_SYSTEMS?: Record<string, StorageSystemContextData>
   REPO_CREDENTIALS?: Record<string, string>
-  REPO_LOOPBACK_IP?: string
+  REPO_NETWORK_ID?: number
   REPO_NETWORK_MODE?: string
   REPO_TAG?: string
   PLUGINS?: VaultData

--- a/src/api/queries/repositories.ts
+++ b/src/api/queries/repositories.ts
@@ -11,7 +11,7 @@ export interface Repository {
   vaultContent?: string
   grandGuid?: string         // Top-most parent repository GUID
   parentGuid?: string        // Immediate parent repository GUID
-  repoLoopbackIp?: string    // Repository loopback IP address (127.11.0.0 to 127.255.255.255)
+  repoNetworkId?: number     // Repository network ID (integer, 2816-16777215)
   repoNetworkMode?: string   // Docker network mode: bridge, host, none, overlay, ipvlan, macvlan
   repoTag?: string           // Docker image tag (e.g., latest, v1.0, dev)
 }
@@ -31,7 +31,7 @@ export const useRepositories = createResourceQuery<Repository>({
       vaultContent: 'vaultContent',
       grandGuid: 'grandGuid',
       parentGuid: 'parentGuid',
-      repoLoopbackIp: 'repoLoopbackIP',
+      repoNetworkId: 'repoNetworkId',
       repoNetworkMode: 'repoNetworkMode',
       repoTag: 'repoTag'
     })(item)

--- a/src/components/resources/MachineRepositoryTable/index.tsx
+++ b/src/components/resources/MachineRepositoryTable/index.tsx
@@ -506,7 +506,7 @@ export const MachineRepositoryTable: React.FC<MachineRepositoryTableProps> = ({ 
       machineVault: machine.vaultContent || '{}',
       repositoryGuid: repositoryData.repositoryGuid,
       repositoryVault: grandRepositoryVault,
-      repositoryLoopbackIp: repositoryData.repoLoopbackIp,
+      repositoryNetworkId: repositoryData.repoNetworkId,
       repositoryNetworkMode: repositoryData.repoNetworkMode,
       repositoryTag: repositoryData.repoTag
     })
@@ -596,7 +596,7 @@ export const MachineRepositoryTable: React.FC<MachineRepositoryTableProps> = ({ 
           machineVault: machine.vaultContent || '{}',
           repositoryGuid: repositoryData.repositoryGuid,
           repositoryVault: grandRepositoryVault,
-          repositoryLoopbackIp: newRepo.repoLoopbackIp,
+          repositoryNetworkId: newRepo.repoNetworkId,
           repositoryNetworkMode: newRepo.repoNetworkMode,
           repositoryTag: newRepo.repoTag
         })
@@ -687,7 +687,7 @@ export const MachineRepositoryTable: React.FC<MachineRepositoryTableProps> = ({ 
             machineVault: machine.vaultContent || '{}',
             repositoryGuid: context.repositoryGuid,
             repositoryVault: grandRepositoryVault,
-            repositoryLoopbackIp: context.repoLoopbackIp
+            repositoryNetworkId: context.repoNetworkId
           })
 
           if (result.success) {
@@ -963,7 +963,7 @@ export const MachineRepositoryTable: React.FC<MachineRepositoryTableProps> = ({ 
             machineVault: machine.vaultContent || '{}',
             repositoryGuid: context.repositoryGuid,
             repositoryVault: grandRepositoryVault,
-            repositoryLoopbackIp: context.repoLoopbackIp
+            repositoryNetworkId: context.repoNetworkId
           })
 
           if (result.success) {
@@ -1116,7 +1116,7 @@ export const MachineRepositoryTable: React.FC<MachineRepositoryTableProps> = ({ 
               destinationMachineVault: destinationMachine.vaultContent || '{}',
               repositoryGuid,
               repositoryVault,
-              repositoryLoopbackIp: newRepo.repoLoopbackIp,
+              repositoryNetworkId: newRepo.repoNetworkId,
               repositoryNetworkMode: newRepo.repoNetworkMode,
               repositoryTag: newRepo.repoTag
             })
@@ -1204,7 +1204,7 @@ export const MachineRepositoryTable: React.FC<MachineRepositoryTableProps> = ({ 
               destinationStorageVault: destinationStorage.vaultContent || '{}',
               repositoryGuid,
               repositoryVault,
-              repositoryLoopbackIp: repositoryData.repoLoopbackIp,
+              repositoryNetworkId: repositoryData.repoNetworkId,
               repositoryNetworkMode: repositoryData.repoNetworkMode,
               repositoryTag: repositoryData.repoTag
             })
@@ -1261,7 +1261,7 @@ export const MachineRepositoryTable: React.FC<MachineRepositoryTableProps> = ({ 
         machineVault: machine.vaultContent || '{}',
         repositoryGuid,
         repositoryVault,
-        repositoryLoopbackIp: repositoryData.repoLoopbackIp,
+        repositoryNetworkId: repositoryData.repoNetworkId,
         repositoryNetworkMode: repositoryData.repoNetworkMode,
         repositoryTag: repositoryData.repoTag
       })

--- a/src/components/resources/internal/PipInstallationModal/index.tsx
+++ b/src/components/resources/internal/PipInstallationModal/index.tsx
@@ -321,7 +321,7 @@ export const PipInstallationModal: React.FC<PipInstallationModalProps> = ({
             <Text>
               {t('resources:pipInstall.reportIssue')}: {' '}
               <a 
-                href="https://github.com/rediacc/cli/issues" 
+                href="https://github.com/rediacc/desktop/issues" 
                 target="_blank" 
                 rel="noopener noreferrer"
                 data-testid="pip-install-github-link"

--- a/src/core/services/repository/orchestration.ts
+++ b/src/core/services/repository/orchestration.ts
@@ -28,7 +28,7 @@ export interface ForkDeletionContext extends OperationContext {
   repositoryGuid?: string
   grandGuid?: string
   parentName?: string
-  repoLoopbackIp?: string
+  repoNetworkId?: number
   repoTag?: string | null
 }
 
@@ -38,7 +38,7 @@ export interface ForkDeletionContext extends OperationContext {
 export interface GrandDeletionContext extends OperationContext {
   repositoryGuid?: string
   childClones: ChildClone[]
-  repoLoopbackIp?: string
+  repoNetworkId?: number
   repoTag?: string | null
 }
 
@@ -60,7 +60,7 @@ export interface BackupContext extends OperationContext {
   canBackupToStorage: boolean
   canBackupToMachine: boolean
   storageBlockReason?: string
-  repoLoopbackIp?: string
+  repoNetworkId?: number
   repoNetworkMode?: string
   repoTag?: string | null
 }
@@ -71,7 +71,7 @@ export interface BackupContext extends OperationContext {
 export interface ForkCreationContext extends OperationContext {
   repositoryGuid?: string
   grandGuid?: string
-  repoLoopbackIp?: string
+  repoNetworkId?: number
   repoNetworkMode?: string
   repoTag?: string | null
   mounted?: boolean
@@ -122,7 +122,7 @@ export function prepareForkDeletion(
     repositoryGuid: repoData.repositoryGuid,
     grandGuid: repoData.grandGuid || undefined,
     parentName: parent?.repositoryName,
-    repoLoopbackIp: (repoData as any).repoLoopbackIp,
+    repoNetworkId: (repoData as any).repoNetworkId,
     repoTag: repoData.repoTag
   }
 }
@@ -172,7 +172,7 @@ export function prepareGrandDeletion(
       errorCode: 'HAS_CHILD_CLONES',
       repositoryGuid: repoData.repositoryGuid,
       childClones: validation.childClones,
-      repoLoopbackIp: (repoData as any).repoLoopbackIp,
+      repoNetworkId: (repoData as any).repoNetworkId,
       repoTag: repoData.repoTag
     }
   }
@@ -181,7 +181,7 @@ export function prepareGrandDeletion(
     status: 'ready',
     repositoryGuid: repoData.repositoryGuid,
     childClones: [],
-    repoLoopbackIp: (repoData as any).repoLoopbackIp,
+    repoNetworkId: (repoData as any).repoNetworkId,
     repoTag: repoData.repoTag
   }
 }
@@ -274,7 +274,7 @@ export function prepareBackup(
     canBackupToStorage: storageValidation.canBackup,
     canBackupToMachine: true, // Always allowed
     storageBlockReason: storageValidation.reason,
-    repoLoopbackIp: (repoData as any).repoLoopbackIp,
+    repoNetworkId: (repoData as any).repoNetworkId,
     repoNetworkMode: (repoData as any).repoNetworkMode,
     repoTag: repoData.repoTag
   }
@@ -315,7 +315,7 @@ export function prepareForkCreation(
     status: 'ready',
     repositoryGuid: repoData.repositoryGuid,
     grandGuid,
-    repoLoopbackIp: (repoData as any).repoLoopbackIp,
+    repoNetworkId: (repoData as any).repoNetworkId,
     repoNetworkMode: (repoData as any).repoNetworkMode,
     repoTag: repoData.repoTag,
     mounted: (repoData as any).mounted

--- a/src/hooks/useRepositoryCreation.ts
+++ b/src/hooks/useRepositoryCreation.ts
@@ -135,7 +135,7 @@ export function useRepositoryCreation(
             machineVault: fullMachine?.vaultContent || '{}',
             repositoryVault: repositoryVault,
             repositoryGuid: repositoryGuid,
-            repositoryLoopbackIp: createdRepo?.repoLoopbackIP,
+            repositoryNetworkId: createdRepo?.repoNetworkId,
             repositoryNetworkMode: createdRepo?.repoNetworkMode,
             repositoryTag: createdRepo?.repoTag
           })

--- a/src/pages/credentials/CredentialsPage.tsx
+++ b/src/pages/credentials/CredentialsPage.tsx
@@ -377,7 +377,7 @@ const CredentialsPage: React.FC = () => {
           teamVault: teams.find((team) => team.teamName === currentResource.teamName)?.vaultContent || '{}',
           repositoryGuid: currentResource.repositoryGuid,
           repositoryVault: currentResource.vaultContent || '{}',
-          repositoryLoopbackIp: currentResource.repoLoopbackIp,
+          repositoryNetworkId: currentResource.repoNetworkId,
           repositoryNetworkMode: currentResource.repoNetworkMode,
           repositoryTag: currentResource.repoTag,
           machineVault: selectedMachine?.vaultContent || '{}'

--- a/src/pages/resources/components/RepositoryContainerTable/index.tsx
+++ b/src/pages/resources/components/RepositoryContainerTable/index.tsx
@@ -211,7 +211,7 @@ export const RepositoryContainerTable: React.FC<RepositoryContainerTableProps> =
       machineVault: machine.vaultContent || '{}',
       repositoryGuid: repositoryData?.repositoryGuid,
       repositoryVault: grandRepositoryVault,
-      repositoryLoopbackIp: repositoryData?.repoLoopbackIp,
+      repositoryNetworkId: repositoryData?.repoNetworkId,
       repositoryNetworkMode: repositoryData?.repoNetworkMode,
       repositoryTag: repositoryData?.repoTag
     })

--- a/src/services/queueActionService.ts
+++ b/src/services/queueActionService.ts
@@ -11,7 +11,7 @@ export interface QueueActionParams {
   machineVault: string
   repositoryGuid?: string
   repositoryVault?: string
-  repositoryLoopbackIp?: string
+  repositoryNetworkId?: number
   repositoryNetworkMode?: string
   repositoryTag?: string
   storageName?: string
@@ -59,7 +59,7 @@ export class QueueActionService {
       machineVault: params.machineVault,
       repositoryGuid: params.repositoryGuid,
       repositoryVault: params.repositoryVault,
-      repositoryLoopbackIp: params.repositoryLoopbackIp,
+      repositoryNetworkId: params.repositoryNetworkId,
       repositoryNetworkMode: params.repositoryNetworkMode,
       repositoryTag: params.repositoryTag,
       storageName: params.storageName,


### PR DESCRIPTION
## Summary
- Replace IP-based repository network identification with numeric network IDs
- Change `repoLoopbackIp` (string, 127.11.0.0 - 127.255.255.255) to `repoNetworkId` (number, 2816-16777215)
- Update all references across console, CLI, and queue-vault packages

## Test plan
- [ ] Verify repository creation still works with network ID
- [ ] Confirm queue vault builder correctly passes REPO_NETWORK_ID context
- [ ] Test repository operations (fork, clone, delete) function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)