### PR TITLE
fix(cli): skip master password prompt when company has no encryption

### DIFF
--- a/packages/cli/src/utils/spinner.ts
+++ b/packages/cli/src/utils/spinner.ts
@@ -44,7 +44,7 @@ export async function withSpinner<T>(
       const result = await fn();
       // Always print success message for CI/piped output
       if (successText) {
-        console.log(`✓ ${successText}`);
+        process.stdout.write(`✓ ${successText}\n`);
       }
       return result;
     } catch (error) {

--- a/packages/shared/src/encryption/index.ts
+++ b/packages/shared/src/encryption/index.ts
@@ -38,3 +38,4 @@ export function createVaultEncryptor(provider: ICryptoProvider): VaultEncryptor 
 
 export { hasVaultFields, isVaultField, transformVaultFields };
 export type { ICryptoProvider };
+export { isEncrypted, VaultProtocolState, analyzeVaultProtocolState } from './vaultProtocol';

--- a/packages/shared/src/encryption/vaultProtocol.ts
+++ b/packages/shared/src/encryption/vaultProtocol.ts
@@ -1,0 +1,77 @@
+/**
+ * Vault Protocol utilities for encryption detection
+ *
+ * The protocol works as follows:
+ * 1. VaultCompany is the Company's vault content returned during login
+ * 2. If VaultCompany is encrypted (base64 pattern), all users must provide the master password
+ * 3. The master password is stored in secure memory and used to encrypt/decrypt vault fields
+ * 4. The encrypted VaultCompany serves as an indicator that encryption is enabled
+ * 5. All users in a company must use the same master password
+ */
+
+// Base64 pattern for encrypted values - matches output from encryptText
+const ENCRYPTED_PATTERN = /^[A-Za-z0-9+/]+=*$/;
+
+/**
+ * Check if a value appears to be encrypted
+ * Encrypted values are base64 encoded and typically longer than the original
+ */
+export function isEncrypted(value: string | null | undefined): boolean {
+  if (!value || value.length < 20) return false;
+
+  // Check if the value is valid JSON (not encrypted)
+  try {
+    JSON.parse(value);
+    // If it parses as JSON, it's not encrypted
+    return false;
+  } catch {
+    // Not valid JSON, continue checking if it's encrypted
+  }
+
+  // Check if it matches base64 pattern and has reasonable length
+  // Encrypted values are typically much longer than originals due to IV + encrypted data
+  return ENCRYPTED_PATTERN.test(value) && value.length >= 40;
+}
+
+/**
+ * Protocol states for UI feedback
+ */
+export enum VaultProtocolState {
+  // Company has not enabled encryption
+  NOT_ENABLED = 'NOT_ENABLED',
+  // Company has encryption, user needs to provide password
+  PASSWORD_REQUIRED = 'PASSWORD_REQUIRED',
+  // Company has encryption, user provided wrong password
+  INVALID_PASSWORD = 'INVALID_PASSWORD',
+  // Company has encryption, password is valid
+  VALID = 'VALID',
+  // User provided password but company hasn't enabled encryption
+  PASSWORD_NOT_NEEDED = 'PASSWORD_NOT_NEEDED',
+}
+
+/**
+ * Analyze vault protocol state based on VaultCompany and user input
+ */
+export function analyzeVaultProtocolState(
+  vaultCompany: string | null | undefined,
+  userProvidedPassword: boolean,
+  passwordValid?: boolean
+): VaultProtocolState {
+  const companyHasEncryption = isEncrypted(vaultCompany);
+
+  if (!companyHasEncryption) {
+    return userProvidedPassword
+      ? VaultProtocolState.PASSWORD_NOT_NEEDED
+      : VaultProtocolState.NOT_ENABLED;
+  }
+
+  if (!userProvidedPassword) {
+    return VaultProtocolState.PASSWORD_REQUIRED;
+  }
+
+  if (!passwordValid) {
+    return VaultProtocolState.INVALID_PASSWORD;
+  }
+
+  return VaultProtocolState.VALID;
+}

--- a/packages/web/src/utils/vaultProtocol.ts
+++ b/packages/web/src/utils/vaultProtocol.ts
@@ -1,39 +1,12 @@
+import {
+  isEncrypted,
+  VaultProtocolState,
+  analyzeVaultProtocolState,
+} from '@rediacc/shared/encryption';
 import { decryptString, encryptString } from './encryption';
 
-/**
- * Vault Protocol using VaultCompany as an encryption indicator
- *
- * The protocol works as follows:
- * 1. VaultCompany is the Company's vault content returned during login
- * 2. If VaultCompany is encrypted (base64 pattern), all users must provide the master password
- * 3. The master password is stored in Redux and used to encrypt/decrypt vault fields
- * 4. The encrypted VaultCompany serves as an indicator that encryption is enabled
- * 5. All users in a company must use the same master password
- */
-
-// Base64 pattern for encrypted values - matches output from encryptText
-const ENCRYPTED_PATTERN = /^[A-Za-z0-9+/]+=*$/;
-
-/**
- * Check if a value appears to be encrypted
- * Encrypted values are base64 encoded and typically longer than the original
- */
-export function isEncrypted(value: string | null | undefined): boolean {
-  if (!value || value.length < 20) return false;
-
-  // Check if the value is valid JSON (not encrypted)
-  try {
-    JSON.parse(value);
-    // If it parses as JSON, it's not encrypted
-    return false;
-  } catch {
-    // Not valid JSON, continue checking if it's encrypted
-  }
-
-  // Check if it matches base64 pattern and has reasonable length
-  // Encrypted values are typically much longer than originals due to IV + encrypted data
-  return ENCRYPTED_PATTERN.test(value) && value.length >= 40;
-}
+// Re-export shared utilities for backward compatibility
+export { isEncrypted, VaultProtocolState, analyzeVaultProtocolState };
 
 /**
  * Validate master password by attempting to decrypt VaultCompany
@@ -62,49 +35,6 @@ export async function validateMasterPassword(
     // Decryption failed - wrong password
     return false;
   }
-}
-
-/**
- * Protocol states for UI feedback
- */
-export enum VaultProtocolState {
-  // Company has not enabled encryption
-  NOT_ENABLED = 'NOT_ENABLED',
-  // Company has encryption, user needs to provide password
-  PASSWORD_REQUIRED = 'PASSWORD_REQUIRED',
-  // Company has encryption, user provided wrong password
-  INVALID_PASSWORD = 'INVALID_PASSWORD',
-  // Company has encryption, password is valid
-  VALID = 'VALID',
-  // User provided password but company hasn't enabled encryption
-  PASSWORD_NOT_NEEDED = 'PASSWORD_NOT_NEEDED',
-}
-
-/**
- * Analyze vault protocol state based on VaultCompany and user input
- */
-export function analyzeVaultProtocolState(
-  vaultCompany: string | null | undefined,
-  userProvidedPassword: boolean,
-  passwordValid?: boolean
-): VaultProtocolState {
-  const companyHasEncryption = isEncrypted(vaultCompany);
-
-  if (!companyHasEncryption) {
-    return userProvidedPassword
-      ? VaultProtocolState.PASSWORD_NOT_NEEDED
-      : VaultProtocolState.NOT_ENABLED;
-  }
-
-  if (!userProvidedPassword) {
-    return VaultProtocolState.PASSWORD_REQUIRED;
-  }
-
-  if (passwordValid === false || passwordValid === undefined) {
-    return VaultProtocolState.INVALID_PASSWORD;
-  }
-
-  return VaultProtocolState.VALID;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Move `isEncrypted` and `VaultProtocolState` to shared package for reuse between CLI and web
- Update CLI login to only store master password if company has encryption enabled
- Clear stored password on login if company doesn't have encryption (handles legacy data)
- Remove interactive prompt for new password in `requireMasterPassword` (throw error instead)
- Refactor web `vaultProtocol.ts` to re-export from shared

## Problem
CLI would hang waiting for master password input during non-interactive scripts like `./go system up`, even when the company hasn't enabled vault encryption.

## Root Cause
CLI always stored login password as master password, regardless of company encryption status. Then during vault operations, it would prompt for the password.

## Solution
Match the console's behavior: only store/use master password when `isEncrypted(vaultCompany)` returns true.

## Test plan
- [x] Run `./go _post_up _post_up` - should complete without prompts
- [ ] Verify web login still works with encryption enabled companies
- [ ] Verify CLI login works with encryption enabled companies