### PR TITLE
fix: add retries for flaky E2E tests in CI

### DIFF
--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -47,8 +47,8 @@ export default test.defineConfig({
   /* Fail the build if you accidentally left test.only in the source code. */
   forbidOnly: true,
 
-  /* No retries - tests should pass consistently */
-  retries: 0,
+  /* Retry failed tests in CI to handle flaky browser behavior */
+  retries: process.env.CI ? 2 : 0,
 
   /* Single worker for maximum stability and resource isolation */
   workers: 1,


### PR DESCRIPTION
## Summary

E2E browser tests occasionally fail (about 1 in 4-5 runs) due to timing issues, network latency, or browser quirks. This wastes CI resources by requiring full pipeline re-runs.

## Solution

Add 2 automatic retries for failed tests when running in CI (`process.env.CI` is set by GitHub Actions).

- **CI**: 2 retries - handles flaky browser behavior
- **Local**: 0 retries - fast feedback for developers

## Test plan

- [ ] CI passes
- [ ] Flaky tests get retried instead of failing immediately