### PR TITLE
fix(ci): increase CLI SEA build timeout for Windows ARM64

### DIFF
--- a/.github/workflows/ci-build-cli.yml
+++ b/.github/workflows/ci-build-cli.yml
@@ -14,7 +14,7 @@ jobs:
   build-cli-executables:
     name: CLI (${{ matrix.platform }}-${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: ${{ matrix.timeout }}
     strategy:
       fail-fast: true
       matrix:
@@ -22,21 +22,27 @@ jobs:
           - os: ubuntu-latest
             platform: linux
             arch: x64
+            timeout: 15
           - os: ubuntu-24.04-arm
             platform: linux
             arch: arm64
+            timeout: 15
           - os: macos-latest
             platform: mac
             arch: arm64
+            timeout: 15
           - os: macos-15-intel
             platform: mac
             arch: x64
+            timeout: 15
           - os: windows-latest
             platform: win
             arch: x64
+            timeout: 20
           - os: windows-11-arm
             platform: win
             arch: arm64
+            timeout: 30
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
 


### PR DESCRIPTION
## Summary
Auto-created PR for branch `fix/cli-sea-windows-arm64-timeout`

## Changes
e2fab5ad fix(ci): increase CLI SEA build timeout for Windows ARM64

---
*PR auto-created by Claude Code*