### PR TITLE
feat(www): display package version in website footer

### DIFF
--- a/packages/www/astro.config.mjs
+++ b/packages/www/astro.config.mjs
@@ -2,6 +2,7 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import { execSync } from 'child_process';
+import { version } from './package.json' with { type: 'json' };
 
 import react from '@astrojs/react';
 import sitemap, { ChangeFreqEnum } from '@astrojs/sitemap';
@@ -126,6 +127,11 @@ export default defineConfig({
   output: 'static',
   build: {
     assets: 'assets'
+  },
+  vite: {
+    define: {
+      __APP_VERSION__: JSON.stringify(version)
+    }
   },
   markdown: {
     remarkPlugins: [

--- a/packages/www/public/styles/main.css
+++ b/packages/www/public/styles/main.css
@@ -1474,6 +1474,13 @@ main {
   color: var(--color-text-secondary);
 }
 
+.footer-version {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  opacity: 0.7;
+  margin-top: 0.25rem;
+}
+
 .footer-bottom-right {
   display: flex;
   gap: var(--space-4);

--- a/packages/www/src/components/Footer.tsx
+++ b/packages/www/src/components/Footer.tsx
@@ -1,3 +1,5 @@
+declare const __APP_VERSION__: string;
+
 import React from 'react';
 import LanguageMenu from './LanguageMenu';
 import { useLanguage } from '../hooks/useLanguage';
@@ -113,6 +115,7 @@ const Footer: React.FC = () => {
               </a>
             </div>
             <p className="footer-copyright">Rediacc &copy; 2023-{currentYear}</p>
+            <p className="footer-version">v{__APP_VERSION__}</p>
           </div>
           <div className="footer-bottom-right">
             <LanguageMenu


### PR DESCRIPTION
## Summary
- Expose `package.json` version as a Vite build-time constant (`__APP_VERSION__`) in `astro.config.mjs`
- Render the version below the copyright text in the footer component
- Style with `--font-size-xs`, `--color-text-secondary`, and reduced opacity for a subtle appearance

## Test plan
- [ ] Run `npm run dev` from `packages/www` and verify the footer shows `v0.4.43` below the copyright
- [ ] Run `npm run build` and confirm no build errors
- [ ] Visually confirm version text is smaller/more muted than the copyright text