### PR TITLE
fix(cd): combine double release commits into single commit

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -98,21 +98,25 @@ jobs:
           fi
           .ci/scripts/version/bump.sh --version ${{ steps.version.outputs.version }} $DRY_RUN_FLAG
 
-      - name: Version commit
-        if: ${{ !inputs.dry_run && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        run: .ci/scripts/version/commit.sh --version ${{ steps.version.outputs.version }} --push
-        env:
-          GITHUB_HEAD_REF: main
-
       - name: Bump submodule versions
         run: |
           DRY_RUN_FLAG=""
+          STAGE_ONLY_FLAG=""
           if [[ "${{ inputs.dry_run }}" == "true" ]]; then
             DRY_RUN_FLAG="--dry-run"
+          else
+            # Stage submodule pointers without committing; commit.sh will include them
+            STAGE_ONLY_FLAG="--stage-only"
           fi
-          .ci/scripts/version/bump-submodules.sh --version ${{ steps.version.outputs.version }} $DRY_RUN_FLAG
+          .ci/scripts/version/bump-submodules.sh --version ${{ steps.version.outputs.version }} $STAGE_ONLY_FLAG $DRY_RUN_FLAG
         env:
           GITHUB_PAT: ${{ secrets.GH_PAT }}
+
+      - name: Version commit
+        if: ${{ !inputs.dry_run && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: .ci/scripts/version/commit.sh --version ${{ steps.version.outputs.version }} --push --include-submodules
+        env:
+          GITHUB_HEAD_REF: main
 
       - name: Capture release SHA
         id: release


### PR DESCRIPTION
## Summary
- Add `--stage-only` flag to `bump-submodules.sh` that stages submodule pointers but skips commit/push
- Add `--include-submodules` flag to `commit.sh` that includes staged submodule pointers in the version commit
- Reorder CD workflow: `bump.sh` → `bump-submodules.sh --stage-only` → `commit.sh --push --include-submodules`

This combines two separate release commits into one:
```
Before: chore(release): bump version to X.Y.Z [skip ci]
        chore(release): bump submodule versions to X.Y.Z [skip ci]

After:  chore(release): bump version to X.Y.Z [skip ci]
        (includes submodule pointer updates)
```

## Test plan
- [ ] Run dry-run mode locally: `.ci/scripts/version/bump-submodules.sh --version 0.0.1 --stage-only --dry-run`
- [ ] Verify backwards compatibility: scripts work without new flags
- [ ] Test full workflow by triggering a dry-run CD pipeline
- [ ] Confirm only one commit appears in git history after release

Closes #5