### PR TITLE
fix(desktop): resolve external modules for all platforms and verify packaged app

### DIFF
--- a/.ci/scripts/build/build-desktop.sh
+++ b/.ci/scripts/build/build-desktop.sh
@@ -71,14 +71,13 @@ if [[ ! -f "$DESKTOP_DIR/out/main/index.js" ]] || [[ ! -f "$DESKTOP_DIR/out/prel
     (cd "$DESKTOP_DIR" && npm run build)
 fi
 
-# Windows-specific: Ensure externalized modules are available locally.
-# On Windows, --ignore-scripts skips the postinstall hook (install-app-deps),
-# so hoisted modules aren't linked into the desktop package's node_modules/.
-# electron-builder needs them there to include in the packaged app.
-if [[ "$PLATFORM" == "win" ]]; then
-    # Resolve externalized modules and their transitive dependencies
-    "$SCRIPT_DIR/resolve-desktop-externals.sh"
+# Resolve externalized modules for all platforms.
+# npm workspaces hoist dependencies to the monorepo root, but electron-builder
+# needs them in the desktop package's node_modules/ to include in the app.
+"$SCRIPT_DIR/resolve-desktop-externals.sh"
 
+# Windows-specific: bundle MSYS2 for rsync/SSH functionality
+if [[ "$PLATFORM" == "win" ]]; then
     log_step "Bundling MSYS2 for Windows..."
     (cd "$DESKTOP_DIR" && npm run bundle:msys2) || log_warn "MSYS2 bundling skipped"
 fi

--- a/.ci/scripts/build/verify-desktop.sh
+++ b/.ci/scripts/build/verify-desktop.sh
@@ -20,11 +20,18 @@ DESKTOP_DIR="$REPO_ROOT/packages/desktop"
 # (Unix paths like /d/a/... are misinterpreted by Node.js as drive-relative)
 require_file "$DESKTOP_DIR/externals.json"
 REQUIRED_EXTERNALS=()
+OPTIONAL_EXTERNALS=()
 while IFS= read -r mod; do
     [[ -n "$mod" ]] && REQUIRED_EXTERNALS+=("$mod")
 done <<< "$(cd "$DESKTOP_DIR" && node -e "
   const cfg = JSON.parse(require('fs').readFileSync('./externals.json', 'utf8'));
   cfg.externals.forEach(m => console.log(m));
+")"
+while IFS= read -r mod; do
+    [[ -n "$mod" ]] && OPTIONAL_EXTERNALS+=("$mod")
+done <<< "$(cd "$DESKTOP_DIR" && node -e "
+  const cfg = JSON.parse(require('fs').readFileSync('./externals.json', 'utf8'));
+  (cfg.optional || []).forEach(m => console.log(m));
 ")"
 
 log_step "Verifying desktop build (warmup)..."
@@ -67,4 +74,101 @@ if [[ $EXIT_CODE -eq 0 ]]; then
 else
     log_error "Desktop warmup verification failed - modules missing from package"
     exit 1
+fi
+
+# ==============================================================================
+# Verify packaged app.asar contains all required modules
+# ==============================================================================
+
+log_step "Verifying packaged app.asar..."
+
+# Find the unpacked directory (electron-builder creates platform-specific names)
+# Examples: win-unpacked, linux-unpacked, mac-arm64, mac-x64, mac (universal)
+UNPACKED_DIR=""
+
+# First try platform-specific unpacked directories
+for pattern in win-unpacked linux-unpacked mac-arm64 mac-x64 mac; do
+    if [[ -d "$REPO_ROOT/dist/desktop/$pattern" ]]; then
+        UNPACKED_DIR="$REPO_ROOT/dist/desktop/$pattern"
+        break
+    fi
+done
+
+# Check for macOS .app bundle if no unpacked dir found
+if [[ -z "$UNPACKED_DIR" ]]; then
+    APP_BUNDLE=$(find "$REPO_ROOT/dist/desktop" -maxdepth 1 -type d -name '*.app' 2>/dev/null | head -1)
+    if [[ -n "$APP_BUNDLE" ]]; then
+        UNPACKED_DIR="$APP_BUNDLE/Contents"
+    fi
+fi
+
+if [[ -z "$UNPACKED_DIR" ]]; then
+    log_warn "Unpacked directory not found - skipping packaged verification"
+    log_info "This is expected if only installers were built (no unpacked output)"
+else
+    ASAR_PATH="$UNPACKED_DIR/resources/app.asar"
+    ASAR_UNPACKED="$UNPACKED_DIR/resources/app.asar.unpacked"
+
+    if [[ -f "$ASAR_PATH" ]]; then
+        # Extract and verify app.asar contains required modules
+        TEMP_DIR=$(mktemp -d)
+        if [[ ! -d "$TEMP_DIR" ]]; then
+            log_error "Failed to create temporary directory"
+            exit 1
+        fi
+        # Clean up temp dir on exit
+        trap 'rm -rf "$TEMP_DIR"' EXIT
+
+        log_info "Extracting app.asar for verification..."
+        npx asar extract "$ASAR_PATH" "$TEMP_DIR"
+
+        # Check for required externals in extracted app
+        MISSING_MODS=()
+        for mod in "${REQUIRED_EXTERNALS[@]}"; do
+            if [[ ! -d "$TEMP_DIR/node_modules/$mod" ]]; then
+                MISSING_MODS+=("$mod")
+            else
+                log_info "  Found in app.asar: $mod"
+            fi
+        done
+
+        if [[ ${#MISSING_MODS[@]} -gt 0 ]]; then
+            log_error "Modules missing from app.asar: ${MISSING_MODS[*]}"
+            exit 1
+        fi
+
+        # Verify native modules are unpacked (required for native bindings)
+        # Only native modules need unpacking - pure JS modules (like electron-updater) don't
+        # These match the asarUnpack config in electron-builder.yml
+        NATIVE_MODULES=(ssh2 node-pty)
+        OPTIONAL_NATIVE=(cpu-features)
+
+        if [[ -d "$ASAR_UNPACKED" ]]; then
+            log_info "Checking unpacked native modules..."
+            MISSING_UNPACKED=()
+            for native_mod in "${NATIVE_MODULES[@]}"; do
+                if [[ -d "$ASAR_UNPACKED/node_modules/$native_mod" ]]; then
+                    log_info "  Unpacked: $native_mod"
+                else
+                    MISSING_UNPACKED+=("$native_mod")
+                fi
+            done
+            # Check optional native modules (don't fail if missing)
+            for native_mod in "${OPTIONAL_NATIVE[@]}"; do
+                if [[ -d "$ASAR_UNPACKED/node_modules/$native_mod" ]]; then
+                    log_info "  Unpacked (optional): $native_mod"
+                else
+                    log_info "  Not found (optional): $native_mod"
+                fi
+            done
+            if [[ ${#MISSING_UNPACKED[@]} -gt 0 ]]; then
+                log_error "Native modules missing from asar.unpacked: ${MISSING_UNPACKED[*]}"
+                exit 1
+            fi
+        fi
+
+        log_info "Packaged app.asar verification passed"
+    else
+        log_warn "app.asar not found at $ASAR_PATH"
+    fi
 fi

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -11,15 +11,24 @@ directories:
   output: ../../dist/desktop
 
 files:
-  - '!**/.vscode/*'
-  - '!src/*'
-  - '!electron.vite.config.*'
-  - '!{.eslintignore,.eslintrc.cjs,.prettierignore,.prettierrc.yaml}'
-  - '!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}'
-  - '!{dev-app-update.yml}'
+  # Include built output and config files
+  - out/**
+  - package.json
+  - externals.json
+  # Include external modules copied by resolve-desktop-externals.sh
+  # (not in package.json dependencies - they're externalized for build)
+  # Use from/to mapping to preserve directory structure
+  - from: node_modules
+    to: node_modules
+    filter:
+      - "**/*"
 
 asarUnpack:
   - resources/**
+  # Native modules must be unpacked for their bindings to work
+  - node_modules/ssh2/**
+  - node_modules/cpu-features/**
+  - node_modules/node-pty/**
 
 # Windows Configuration
 # Note: arch is controlled by CI via --arch flag, not hardcoded here


### PR DESCRIPTION
## Summary

- **Fixed module resolution for all platforms**: Moved `resolve-desktop-externals.sh` call outside the Windows-only block so Linux/macOS builds also get hoisted npm workspace modules copied to local `node_modules/`
- **Added packaged app.asar verification**: New verification step extracts the packaged `app.asar` and verifies all required external modules are present before release
- **Reverted unnecessary changes**: Removed redundant module copying in `before-build.js` and explicit module listings in `electron-builder.yml`

## Test plan

- [ ] CI builds pass for all platforms (linux, mac, win) × (x64, arm64)
- [ ] CI logs show "Packaged app.asar verification passed"
- [ ] No "Cannot find module 'ssh2'" errors when launching built app
- [ ] Verify `resolve-desktop-externals.sh` runs for Linux/macOS builds in CI logs