### PR TITLE
test(e2e): add missing placeholder test files for doc coverage

### DIFF
--- a/packages/e2e/tests/03-machines/02-04-03-machine-refresh.test.ts
+++ b/packages/e2e/tests/03-machines/02-04-03-machine-refresh.test.ts
@@ -1,0 +1,7 @@
+import { test } from '@/base/BaseTest';
+
+test.describe('2.4.3 Refreshing Machine List', () => {
+  test.skip('should refresh the machine list', async () => {
+    // TODO: Implement - corresponds to doc section 2.4.3
+  });
+});

--- a/packages/e2e/tests/04-repositories/02-05-02-repository-fork.test.ts
+++ b/packages/e2e/tests/04-repositories/02-05-02-repository-fork.test.ts
@@ -1,0 +1,7 @@
+import { test } from '@/base/BaseTest';
+
+test.describe('2.5.2 Repository Fork', () => {
+  test.skip('should fork an existing repository with a new tag', async () => {
+    // TODO: Implement - corresponds to doc section 2.5.2
+  });
+});

--- a/packages/e2e/tests/04-repositories/02-05-03-repository-up.test.ts
+++ b/packages/e2e/tests/04-repositories/02-05-03-repository-up.test.ts
@@ -1,0 +1,7 @@
+import { test } from '@/base/BaseTest';
+
+test.describe('2.5.3 Repository Up', () => {
+  test.skip('should activate the repository', async () => {
+    // TODO: Implement - corresponds to doc section 2.5.3
+  });
+});

--- a/packages/e2e/tests/04-repositories/02-05-04-repository-down.test.ts
+++ b/packages/e2e/tests/04-repositories/02-05-04-repository-down.test.ts
@@ -1,0 +1,7 @@
+import { test } from '@/base/BaseTest';
+
+test.describe('2.5.4 Repository Down', () => {
+  test.skip('should stop an active repository', async () => {
+    // TODO: Implement - corresponds to doc section 2.5.4
+  });
+});

--- a/packages/e2e/tests/04-repositories/02-05-05-repository-deploy.test.ts
+++ b/packages/e2e/tests/04-repositories/02-05-05-repository-deploy.test.ts
@@ -1,0 +1,7 @@
+import { test } from '@/base/BaseTest';
+
+test.describe('2.5.5 Deploy', () => {
+  test.skip('should deploy the repository to target machines', async () => {
+    // TODO: Implement - corresponds to doc section 2.5.5
+  });
+});

--- a/packages/e2e/tests/04-repositories/02-05-06-repository-backup.test.ts
+++ b/packages/e2e/tests/04-repositories/02-05-06-repository-backup.test.ts
@@ -1,0 +1,7 @@
+import { test } from '@/base/BaseTest';
+
+test.describe('2.5.6 Backup', () => {
+  test.skip('should backup the repository', async () => {
+    // TODO: Implement - corresponds to doc section 2.5.6
+  });
+});

--- a/packages/e2e/tests/04-repositories/02-05-07-repository-templates.test.ts
+++ b/packages/e2e/tests/04-repositories/02-05-07-repository-templates.test.ts
@@ -1,0 +1,7 @@
+import { test } from '@/base/BaseTest';
+
+test.describe('2.5.7 Template Application', () => {
+  test.skip('should apply a template to the repository', async () => {
+    // TODO: Implement - corresponds to doc section 2.5.7
+  });
+});

--- a/packages/e2e/tests/04-repositories/02-05-08-repository-unmount.test.ts
+++ b/packages/e2e/tests/04-repositories/02-05-08-repository-unmount.test.ts
@@ -1,0 +1,7 @@
+import { test } from '@/base/BaseTest';
+
+test.describe('2.5.8 Unmount', () => {
+  test.skip('should unmount the repository', async () => {
+    // TODO: Implement - corresponds to doc section 2.5.8
+  });
+});

--- a/packages/e2e/tests/04-repositories/02-05-09-repository-expand.test.ts
+++ b/packages/e2e/tests/04-repositories/02-05-09-repository-expand.test.ts
@@ -1,0 +1,7 @@
+import { test } from '@/base/BaseTest';
+
+test.describe('2.5.9 Expand', () => {
+  test.skip('should expand the repository size', async () => {
+    // TODO: Implement - corresponds to doc section 2.5.9
+  });
+});

--- a/packages/e2e/tests/04-repositories/02-05-10-repository-rename.test.ts
+++ b/packages/e2e/tests/04-repositories/02-05-10-repository-rename.test.ts
@@ -1,0 +1,7 @@
+import { test } from '@/base/BaseTest';
+
+test.describe('2.5.10 Rename', () => {
+  test.skip('should rename the repository', async () => {
+    // TODO: Implement - corresponds to doc section 2.5.10
+  });
+});

--- a/packages/e2e/tests/04-repositories/02-05-11-repository-delete.test.ts
+++ b/packages/e2e/tests/04-repositories/02-05-11-repository-delete.test.ts
@@ -1,0 +1,7 @@
+import { test } from '@/base/BaseTest';
+
+test.describe('2.5.11 Repository Deletion', () => {
+  test.skip('should delete the repository', async () => {
+    // TODO: Implement - corresponds to doc section 2.5.11
+  });
+});

--- a/packages/e2e/tests/04-repositories/02-05-12-repository-details.test.ts
+++ b/packages/e2e/tests/04-repositories/02-05-12-repository-details.test.ts
@@ -1,0 +1,7 @@
+import { test } from '@/base/BaseTest';
+
+test.describe('2.5.12 Repository Details', () => {
+  test.skip('should view repository details', async () => {
+    // TODO: Implement - corresponds to doc section 2.5.12
+  });
+});

--- a/packages/e2e/tests/08-credentials/02-09-02-credential-trace.test.ts
+++ b/packages/e2e/tests/08-credentials/02-09-02-credential-trace.test.ts
@@ -1,0 +1,7 @@
+import { test } from '@/base/BaseTest';
+
+test.describe('2.9.2 Credential Trace', () => {
+  test.skip('should trace credential audit history', async () => {
+    // TODO: Implement - corresponds to doc section 2.9.2
+  });
+});

--- a/packages/e2e/tests/08-credentials/02-09-03-credential-delete.test.ts
+++ b/packages/e2e/tests/08-credentials/02-09-03-credential-delete.test.ts
@@ -1,0 +1,7 @@
+import { test } from '@/base/BaseTest';
+
+test.describe('2.9.3 Credential Deletion', () => {
+  test.skip('should delete a credential', async () => {
+    // TODO: Implement - corresponds to doc section 2.9.3
+  });
+});


### PR DESCRIPTION
## Summary

- Add 14 missing placeholder test files to achieve complete coverage of documented features
- Machines: 1 new test file (02-04-03-machine-refresh.test.ts)
- Repositories: 11 new test files (02-05-02 through 02-05-12)
- Credentials: 2 new test files (02-09-02, 02-09-03)

## Changes

All test files follow the existing pattern with `test.skip()` and reference their corresponding documentation section:

| Directory | Files Added | Doc Sections |
|-----------|-------------|--------------|
| `03-machines/` | 1 | 2.4.3 |
| `04-repositories/` | 11 | 2.5.2 - 2.5.12 |
| `08-credentials/` | 2 | 2.9.2 - 2.9.3 |

## Test plan

- [x] All quality checks pass locally (lint, format, typecheck, i18n, security)
- [ ] CI pipeline passes
- [ ] Tests are discoverable via glob patterns in test-suites.json