### PR TITLE
feat(ci): consolidate renet builds and add CLI renet embedding

### DIFF
--- a/.ci/scripts/build/build-cli-executables.sh
+++ b/.ci/scripts/build/build-cli-executables.sh
@@ -116,6 +116,10 @@ node bundle.mjs
 require_file "$CLI_DIR/dist/cli-bundle.cjs"
 log_info "Bundle created: $(wc -c < dist/cli-bundle.cjs) bytes"
 
+# Step 1.5: Prepare embedded assets (renet binaries)
+log_step "Preparing embedded renet assets..."
+"$SCRIPT_DIR/prepare-cli-assets.sh"
+
 # Step 2: Generate SEA blob
 log_step "Generating SEA blob..."
 node --experimental-sea-config sea-config.json

--- a/.ci/scripts/build/build-renet.sh
+++ b/.ci/scripts/build/build-renet.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Build full renet binaries with embedded CRIU/rsync assets
+#
+# Usage:
+#   build-renet.sh --version 1.2.3 --output ./bin
+#   build-renet.sh --version 1.2.3 --assets-dir ./assets --output ./bin
+#
+# Options:
+#   --version VERSION    Version to embed in binary (required)
+#   --assets-dir DIR     Directory containing CRIU/rsync binaries (default: auto-detect)
+#   --output DIR         Output directory for renet binaries (default: private/bin)
+#   --skip-embed         Build without embedded assets (lightweight, for testing)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# Defaults
+VERSION=""
+ASSETS_DIR=""
+OUTPUT_DIR=""
+SKIP_EMBED=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --version) VERSION="$2"; shift 2 ;;
+        --assets-dir) ASSETS_DIR="$2"; shift 2 ;;
+        --output) OUTPUT_DIR="$2"; shift 2 ;;
+        --skip-embed) SKIP_EMBED=true; shift ;;
+        -h|--help)
+            echo "Usage: $0 --version VERSION [--assets-dir DIR] [--output DIR] [--skip-embed]"
+            echo ""
+            echo "Build full renet binaries with embedded CRIU/rsync assets"
+            echo ""
+            echo "Options:"
+            echo "  --version VERSION    Version to embed in binary (required)"
+            echo "  --assets-dir DIR     Directory containing CRIU/rsync binaries"
+            echo "  --output DIR         Output directory for renet binaries"
+            echo "  --skip-embed         Build without embedded assets"
+            exit 0
+            ;;
+        *) log_error "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+[[ -z "$VERSION" ]] && { log_error "--version is required"; exit 1; }
+
+REPO_ROOT="$(get_repo_root)"
+OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/private/bin}"
+RENET_DIR="$REPO_ROOT/private/renet"
+
+# Convert to absolute path (handles relative paths, symlinks, and ..)
+OUTPUT_DIR="$(readlink -f "$OUTPUT_DIR")"
+
+mkdir -p "$OUTPUT_DIR"
+
+log_step "Building renet binaries (release)"
+log_info "  Version: $VERSION"
+log_info "  Output: $OUTPUT_DIR"
+
+# Embed assets if not skipped
+if [[ "$SKIP_EMBED" != "true" ]]; then
+    log_step "Preparing embedded assets..."
+
+    ASSETS_DIR="${ASSETS_DIR:-$REPO_ROOT/binaries}"
+
+    # Convert to absolute path (handles relative paths, symlinks, and ..)
+    ASSETS_DIR="$(readlink -f "$ASSETS_DIR")"
+
+    EMBED_DIR="$RENET_DIR/pkg/embed/assets"
+    mkdir -p "$EMBED_DIR"
+
+    for asset in criu-linux-amd64 criu-linux-arm64 rsync-linux-amd64 rsync-linux-arm64; do
+        if [[ -f "$ASSETS_DIR/$asset" ]]; then
+            log_info "Embedding $asset..."
+            gzip -c "$ASSETS_DIR/$asset" > "$EMBED_DIR/$asset.gz"
+        else
+            log_error "Missing asset: $ASSETS_DIR/$asset"
+            exit 1
+        fi
+    done
+
+    log_info "Embedded assets:"
+    ls -la "$EMBED_DIR"
+else
+    log_info "Skipping asset embedding (--skip-embed)"
+fi
+
+# Build renet binaries (release mode: stripped)
+log_step "Building renet binaries (release)..."
+
+require_cmd go
+
+cd "$RENET_DIR"
+
+for arch in amd64 arm64; do
+    log_info "Building renet-linux-$arch..."
+    CGO_ENABLED=0 GOOS=linux GOARCH=$arch go build \
+        -ldflags="-s -w -X main.Version=$VERSION" \
+        -o "$OUTPUT_DIR/renet-linux-$arch" ./cmd/renet
+done
+
+# Generate checksums
+log_step "Generating checksums..."
+cd "$OUTPUT_DIR"
+sha256sum renet-linux-* > checksums.sha256
+
+log_info "Renet binaries built successfully:"
+ls -la "$OUTPUT_DIR"/renet-linux-*
+cat "$OUTPUT_DIR/checksums.sha256"
+
+# Verify release build (no debug info)
+log_step "Verifying release builds..."
+for arch in amd64 arm64; do
+    binary="$OUTPUT_DIR/renet-linux-$arch"
+    if file "$binary" | grep -q "stripped"; then
+        log_info "renet-linux-$arch: stripped (release build)"
+    else
+        log_warn "renet-linux-$arch: may contain debug symbols"
+    fi
+done

--- a/.ci/scripts/build/extract-renet-from-image.sh
+++ b/.ci/scripts/build/extract-renet-from-image.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Extract renet binaries from existing Docker bridge image
+# Used when skipping full renet build (bridge_exists=true)
+#
+# Usage: extract-renet-from-image.sh --tag TAG --output DIR
+#   --tag TAG       Bridge image tag to extract from (required)
+#   --output DIR    Output directory for binaries (default: private/bin)
+#   --registry REG  Docker registry (default: ghcr.io/rediacc/elite)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# Defaults
+TAG=""
+OUTPUT_DIR=""
+REGISTRY="ghcr.io/rediacc/elite"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tag) TAG="$2"; shift 2 ;;
+        --output) OUTPUT_DIR="$2"; shift 2 ;;
+        --registry) REGISTRY="$2"; shift 2 ;;
+        *) log_error "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# Validation
+if [[ -z "$TAG" ]]; then
+    log_error "--tag is required"
+    exit 1
+fi
+
+REPO_ROOT="$(get_repo_root)"
+OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/private/bin}"
+BRIDGE_IMAGE="${REGISTRY}/bridge:${TAG}"
+
+log_step "Extracting renet binaries from $BRIDGE_IMAGE"
+
+mkdir -p "$OUTPUT_DIR"
+
+# Create a temporary container to extract files
+log_info "Creating temporary container..."
+CONTAINER_ID=$(docker create "$BRIDGE_IMAGE")
+
+cleanup() {
+    if [[ -n "${CONTAINER_ID:-}" ]]; then
+        docker rm "$CONTAINER_ID" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
+
+# Extract renet binaries from /opt/renet/
+log_info "Extracting renet-linux-amd64..."
+docker cp "$CONTAINER_ID:/opt/renet/renet-linux-amd64" "$OUTPUT_DIR/"
+
+log_info "Extracting renet-linux-arm64..."
+docker cp "$CONTAINER_ID:/opt/renet/renet-linux-arm64" "$OUTPUT_DIR/"
+
+# Generate checksums (use absolute path)
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
+log_step "Generating checksums..."
+cd "$OUTPUT_DIR"
+sha256sum renet-linux-* > checksums.sha256
+
+log_info "Renet binaries extracted successfully:"
+ls -la renet-linux-*
+cat checksums.sha256

--- a/.ci/scripts/build/prepare-cli-assets.sh
+++ b/.ci/scripts/build/prepare-cli-assets.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Prepare renet binaries and metadata for CLI SEA embedding
+#
+# This script copies renet Linux binaries to the CLI assets directory
+# and generates a metadata file with SHA256 hashes for verification.
+#
+# Usage:
+#   prepare-cli-assets.sh
+#
+# Environment:
+#   RENET_VERSION - Override version (default: from package.json)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+REPO_ROOT="$(get_repo_root)"
+CLI_ASSETS_DIR="$REPO_ROOT/packages/cli/dist/assets"
+RENET_BIN_DIR="$REPO_ROOT/private/bin"
+
+log_step "Preparing CLI embedded assets..."
+
+# Create assets directory
+mkdir -p "$CLI_ASSETS_DIR"
+
+# Copy renet binaries
+for arch in amd64 arm64; do
+    BINARY="$RENET_BIN_DIR/renet-linux-$arch"
+    if [[ -f "$BINARY" ]]; then
+        log_info "Copying renet-linux-$arch..."
+        cp "$BINARY" "$CLI_ASSETS_DIR/"
+    else
+        log_error "Missing renet binary: $BINARY"
+        exit 1
+    fi
+done
+
+# Get version (from env or package.json)
+# Use jq instead of node to avoid MSYS path translation issues on Windows
+VERSION="${RENET_VERSION:-$(jq -r '.version' "$REPO_ROOT/packages/cli/package.json")}"
+
+# Generate metadata with SHA256 hashes
+log_step "Generating renet metadata..."
+
+AMD64_SIZE=$(stat -c%s "$CLI_ASSETS_DIR/renet-linux-amd64" 2>/dev/null || stat -f%z "$CLI_ASSETS_DIR/renet-linux-amd64")
+ARM64_SIZE=$(stat -c%s "$CLI_ASSETS_DIR/renet-linux-arm64" 2>/dev/null || stat -f%z "$CLI_ASSETS_DIR/renet-linux-arm64")
+
+# Compute SHA256 (handle both Linux sha256sum and macOS shasum)
+if command -v sha256sum &>/dev/null; then
+    AMD64_SHA256=$(sha256sum "$CLI_ASSETS_DIR/renet-linux-amd64" | cut -d' ' -f1)
+    ARM64_SHA256=$(sha256sum "$CLI_ASSETS_DIR/renet-linux-arm64" | cut -d' ' -f1)
+elif command -v shasum &>/dev/null; then
+    AMD64_SHA256=$(shasum -a 256 "$CLI_ASSETS_DIR/renet-linux-amd64" | cut -d' ' -f1)
+    ARM64_SHA256=$(shasum -a 256 "$CLI_ASSETS_DIR/renet-linux-arm64" | cut -d' ' -f1)
+else
+    log_error "No sha256sum or shasum available"
+    exit 1
+fi
+
+jq -n \
+  --arg version "$VERSION" \
+  --arg generatedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --argjson amd64Size "$AMD64_SIZE" \
+  --arg amd64Sha256 "$AMD64_SHA256" \
+  --argjson arm64Size "$ARM64_SIZE" \
+  --arg arm64Sha256 "$ARM64_SHA256" \
+  '{
+    version: $version,
+    generatedAt: $generatedAt,
+    binaries: {
+      amd64: { size: $amd64Size, sha256: $amd64Sha256 },
+      arm64: { size: $arm64Size, sha256: $arm64Sha256 }
+    }
+  }' > "$CLI_ASSETS_DIR/renet-metadata.json"
+
+log_info "Metadata written to $CLI_ASSETS_DIR/renet-metadata.json"
+log_info "  Version: $VERSION"
+log_info "  amd64: $AMD64_SIZE bytes, sha256=$AMD64_SHA256"
+log_info "  arm64: $ARM64_SIZE bytes, sha256=$ARM64_SHA256"
+
+log_info "CLI assets prepared successfully"

--- a/.ci/scripts/ci/watchdog-monitor.cjs
+++ b/.ci/scripts/ci/watchdog-monitor.cjs
@@ -1,5 +1,5 @@
 // Cancel Watchdog - monitors all CI jobs and force-cancels on failure
-// Polls every 15 seconds, exits when all jobs complete or a failure is detected.
+// Polls every 15 seconds, exits only when the workflow run completes or a failure is detected.
 //
 // Labels:
 //   no-cancel-failure  - Skip cancellation on job failure (workflow continues)
@@ -13,8 +13,52 @@ module.exports = async ({ github, context, core }) => {
   const minRuntime = 30000;    // 30 seconds minimum before allowing exit
   const startTime = Date.now();
 
+  // Grace period: wait N consecutive polls with all jobs complete before exiting.
+  // Prevents premature exit during partial reruns where new jobs haven't appeared yet.
+  const GRACE_POLLS = 3;     // 3 polls × 15s = 45 seconds grace period
+  let allCompleteStreak = 0;
+
   // Jobs to exclude from monitoring
   const excludePatterns = ['Watchdog', 'CI Complete'];
+
+  // Helper: log failure details and force-cancel the workflow run
+  async function cancelOnFailure(job, reason) {
+    const failureMsg = `${reason}: "${job.name}"`;
+    console.log('');
+    console.log('='.repeat(70));
+    console.log(failureMsg);
+    if (job.id) {
+      console.log(`   Job URL: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/job/${job.id}`);
+    }
+    console.log('='.repeat(70));
+
+    if (skipCancellationOnFailure) {
+      console.log('');
+      console.log('NOTICE: Skipping workflow cancellation due to "no-cancel-failure" label');
+      console.log('Workflow will continue running despite this failure.');
+      core.setFailed(failureMsg + ' (cancellation skipped due to label)');
+      return;
+    }
+
+    console.log('Force-cancelling workflow run...');
+    try {
+      await github.request('POST /repos/{owner}/{repo}/actions/runs/{run_id}/force-cancel', {
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        run_id: context.runId
+      });
+    } catch (e) {
+      // Fallback to regular cancel if force-cancel not available
+      console.log(`Force-cancel failed (${e.message}), using regular cancel...`);
+      await github.rest.actions.cancelWorkflowRun({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        run_id: context.runId
+      });
+    }
+
+    core.setFailed('PIPELINE CANCELLED: ' + failureMsg);
+  }
 
   // Check for skip-cancellation label
   let skipCancellationOnFailure = false;
@@ -59,9 +103,9 @@ module.exports = async ({ github, context, core }) => {
     const failed = monitoredJobs.filter(j => j.conclusion === 'failure');
     const cancelled = monitoredJobs.filter(j => j.conclusion === 'cancelled');
 
-    console.log(`[${elapsedMin}m] Run: ${run.status} | Jobs: ${completed.length} done, ${inProgress.length} running, ${queued.length} queued, ${failed.length} failed`);
+    console.log(`[${elapsedMin}m] Run: ${run.status} | Jobs: ${completed.length} done, ${inProgress.length} running, ${queued.length} queued, ${failed.length} failed, ${cancelled.length} cancelled`);
 
-    // Check if workflow was externally cancelled
+    // Check if workflow was externally cancelled (mass cancellation)
     if (cancelled.length > 0 && cancelled.length >= completed.length / 2) {
       console.log(`Workflow externally cancelled (${cancelled.length}/${completed.length} jobs cancelled) - exiting`);
       return;
@@ -69,54 +113,35 @@ module.exports = async ({ github, context, core }) => {
 
     // Check for ANY failure - cancel immediately
     if (failed.length > 0) {
-      const failedJob = failed[0];
-      const failureMsg = `Job failed: "${failedJob.name}"`;
-      console.log('');
-      console.log('='.repeat(70));
-      console.log(failureMsg);
-      console.log(`   Job URL: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/job/${failedJob.id}`);
-      console.log('='.repeat(70));
+      await cancelOnFailure(failed[0], 'Job failed');
+      return;
+    }
 
-      if (skipCancellationOnFailure) {
-        console.log('');
-        console.log('NOTICE: Skipping workflow cancellation due to "no-cancel-failure" label');
-        console.log('Workflow will continue running despite this failure.');
-        core.setFailed(failureMsg + ' (cancellation skipped due to label)');
+    // Check for individually cancelled jobs (e.g., timeout-killed).
+    // Mass cancellation is already handled above.
+    if (cancelled.length > 0) {
+      await cancelOnFailure(cancelled[0], 'Job cancelled (likely timeout)');
+      return;
+    }
+
+    // Exit when workflow run is externally completed
+    if (run.status === 'completed' && elapsed >= minRuntime) {
+      console.log(`Workflow run completed (conclusion: ${run.conclusion}) - exiting watchdog (after ${elapsedMin}m)`);
+      return;
+    }
+
+    // Exit when all monitored jobs are complete, with grace period to handle partial reruns.
+    // Without this check, the watchdog deadlocks (it's the only running job keeping
+    // run.status === 'in_progress'). The grace period ensures rerun jobs have time to appear.
+    if (monitoredJobs.length > 0 && completed.length === monitoredJobs.length && elapsed >= minRuntime) {
+      allCompleteStreak++;
+      if (allCompleteStreak >= GRACE_POLLS) {
+        console.log(`All ${monitoredJobs.length} monitored jobs completed for ${allCompleteStreak} consecutive polls - exiting watchdog (after ${elapsedMin}m)`);
         return;
       }
-
-      console.log('Force-cancelling workflow run...');
-      try {
-        await github.request('POST /repos/{owner}/{repo}/actions/runs/{run_id}/force-cancel', {
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-          run_id: context.runId
-        });
-      } catch (e) {
-        // Fallback to regular cancel if force-cancel not available
-        console.log(`Force-cancel failed (${e.message}), using regular cancel...`);
-        await github.rest.actions.cancelWorkflowRun({
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-          run_id: context.runId
-        });
-      }
-
-      core.setFailed('PIPELINE CANCELLED: ' + failureMsg);
-      return;
-    }
-
-    // Exit if all monitored jobs are complete (avoids deadlock where
-    // watchdog is the only running job keeping the run "in_progress")
-    if (monitoredJobs.length > 0 && completed.length === monitoredJobs.length && elapsed >= minRuntime) {
-      console.log(`All ${monitoredJobs.length} monitored jobs completed - exiting watchdog (after ${elapsedMin}m)`);
-      return;
-    }
-
-    // Also check workflow run status (handles edge cases with reusable workflows)
-    if (run.status === 'completed' && elapsed >= minRuntime) {
-      console.log(`Workflow run completed with conclusion: ${run.conclusion} - exiting watchdog (after ${elapsedMin}m)`);
-      return;
+      console.log(`[${elapsedMin}m] All jobs complete (${allCompleteStreak}/${GRACE_POLLS} polls) - waiting for possible rerun...`);
+    } else {
+      allCompleteStreak = 0;
     }
 
     await new Promise(resolve => setTimeout(resolve, pollInterval));

--- a/.ci/scripts/quality/check-claude-attribution.sh
+++ b/.ci/scripts/quality/check-claude-attribution.sh
@@ -27,7 +27,8 @@ echo "Checking for Claude attribution in PR #${PR_NUMBER}..."
 
 # Pattern to match Claude attribution (case-insensitive)
 # Matches: Co-Authored-By: Claude, Generated with Claude, etc.
-CLAUDE_PATTERN="(Co-Authored-By.*Claude|Generated with.*Claude|Claude Code|Claude Opus|Claude Sonnet|noreply@anthropic\.com)"
+# Note: We specifically match attribution markers, not general mentions of Claude as a tool
+CLAUDE_PATTERN="(Co-Authored-By[[:space:]]*:[[:space:]]*Claude|Generated with[[:space:]]+\[?Claude|🤖[[:space:]]*Generated|noreply@anthropic\.com)"
 
 # Check PR description
 echo "  Checking PR description..."

--- a/.ci/scripts/release/update-homebrew-tap.sh
+++ b/.ci/scripts/release/update-homebrew-tap.sh
@@ -3,18 +3,14 @@
 #
 # Usage:
 #   update-homebrew-tap.sh --version X.Y.Z [--push] [--dry-run]
-#   update-homebrew-tap.sh --version X.Y.Z --local-checksums <dir> --stage-only
 #
 # Options:
-#   --version          Required version to apply to formula
-#   --push             Commit and push changes to homebrew-tap repo
-#   --stage-only       Update formula and stage submodule pointer (no commit)
-#   --local-checksums  Calculate checksums from local directory instead of GitHub release
-#   --dry-run          Show actions without making changes
+#   --version    Required version to apply to formula
+#   --push       Commit and push changes to homebrew-tap repo
+#   --dry-run    Show actions without making changes
 #
 # Notes:
-#   - By default, downloads SHA256 checksums from GitHub release
-#   - With --local-checksums, calculates from local CLI binaries
+#   - Downloads SHA256 checksums from GitHub release
 #   - Updates Formula/rediacc-cli.rb with new version and checksums
 #   - Commits include [skip ci] to avoid triggering CI on homebrew-tap
 
@@ -26,8 +22,6 @@ source "$SCRIPT_DIR/../../config/constants.sh"
 
 VERSION=""
 PUSH=false
-STAGE_ONLY=false
-LOCAL_CHECKSUMS_DIR=""
 DRY_RUN=false
 
 while [[ $# -gt 0 ]]; do
@@ -40,20 +34,12 @@ while [[ $# -gt 0 ]]; do
             PUSH=true
             shift
             ;;
-        --stage-only)
-            STAGE_ONLY=true
-            shift
-            ;;
-        --local-checksums)
-            LOCAL_CHECKSUMS_DIR="$2"
-            shift 2
-            ;;
         --dry-run)
             DRY_RUN=true
             shift
             ;;
         -h|--help)
-            echo "Usage: $0 --version X.Y.Z [--push] [--stage-only] [--local-checksums <dir>] [--dry-run]"
+            echo "Usage: $0 --version X.Y.Z [--push] [--dry-run]"
             exit 0
             ;;
         *)
@@ -123,42 +109,6 @@ download_checksums() {
     done
 
     log_info "Downloaded all checksum files"
-}
-
-calculate_local_checksums() {
-    local srcdir="$1"
-    local tmpdir="$2"
-    log_step "Calculating SHA256 checksums from local files in $srcdir..."
-
-    if [[ "$DRY_RUN" == "true" ]]; then
-        log_info "[DRY-RUN] Would calculate checksums from $srcdir"
-        return 0
-    fi
-
-    # Map of binary names to checksum file names
-    local -A binaries=(
-        ["rdc-mac-arm64"]="rdc-mac-arm64"
-        ["rdc-mac-x64"]="rdc-mac-x64"
-        ["rdc-linux-arm64"]="rdc-linux-arm64"
-        ["rdc-linux-x64"]="rdc-linux-x64"
-    )
-
-    for binary in "${!binaries[@]}"; do
-        local binary_path="$srcdir/$binary"
-        local checksum_file="$tmpdir/${binaries[$binary]}.sha256"
-
-        if [[ ! -f "$binary_path" ]]; then
-            log_error "Missing binary: $binary_path"
-            exit 1
-        fi
-
-        # Calculate SHA256 and write to file in same format as GitHub release
-        local checksum
-        checksum=$(sha256sum "$binary_path" | awk '{print $1}')
-        echo "$checksum  $binary" > "$checksum_file"
-    done
-
-    log_info "Calculated all checksums from local files"
 }
 
 extract_checksum() {
@@ -265,19 +215,6 @@ commit_and_push() {
     log_info "Pushed to homebrew-tap"
 }
 
-stage_submodule_pointer() {
-    if [[ "$DRY_RUN" == "true" ]]; then
-        log_info "[DRY-RUN] Would stage submodule pointer"
-        return 0
-    fi
-
-    (
-        cd "$REPO_ROOT"
-        git add private/homebrew-tap
-        log_info "Staged homebrew-tap submodule pointer"
-    )
-}
-
 update_submodule_pointer() {
     if [[ "$DRY_RUN" == "true" ]]; then
         log_info "[DRY-RUN] Would update submodule pointer"
@@ -291,10 +228,12 @@ update_submodule_pointer() {
         if git diff --cached --quiet; then
             log_info "No submodule pointer changes"
         else
+            # Amend the previous version commit to include homebrew-tap update
+            # This consolidates two commits into one
             git -c user.name="$PUBLISH_BOT_NAME" -c user.email="$PUBLISH_BOT_EMAIL" \
-                commit -m "chore(release): update homebrew-tap to $VERSION [skip ci]"
-            git push origin HEAD:main
-            log_info "Pushed submodule pointer update"
+                commit --amend --no-edit
+            git push --force-with-lease origin HEAD:main
+            log_info "Amended version commit with homebrew-tap update"
         fi
     )
 }
@@ -311,23 +250,14 @@ trap 'rm -rf "$CHECKSUM_DIR"' EXIT
 # Sync submodule to origin/main
 sync_to_origin_main "$TAP_DIR"
 
-# Get checksums (from local files or GitHub release)
-if [[ -n "$LOCAL_CHECKSUMS_DIR" ]]; then
-    calculate_local_checksums "$LOCAL_CHECKSUMS_DIR" "$CHECKSUM_DIR"
-else
-    download_checksums "$CHECKSUM_DIR"
-fi
+# Download checksums from release
+download_checksums "$CHECKSUM_DIR"
 
 # Update the formula
 update_formula "$CHECKSUM_DIR"
 
-# Handle commit/push based on mode
-if [[ "$STAGE_ONLY" == "true" ]]; then
-    # Stage-only mode: commit to homebrew-tap, stage pointer in main repo
-    commit_and_push
-    stage_submodule_pointer
-elif [[ "$PUSH" == "true" ]]; then
-    # Full push mode: commit to homebrew-tap and main repo
+# Commit and push if requested
+if [[ "$PUSH" == "true" ]]; then
     commit_and_push
     update_submodule_pointer
 fi

--- a/.ci/scripts/version/commit.sh
+++ b/.ci/scripts/version/commit.sh
@@ -141,9 +141,9 @@ stage_files() {
         ((staged++)) || true
     fi
 
-    # Count staged submodule pointers (staged by bump-submodules.sh --stage-only and update-homebrew-tap.sh --stage-only)
+    # Count staged submodule pointers (staged by bump-submodules.sh --stage-only)
     if [[ "$INCLUDE_SUBMODULES" == "true" ]]; then
-        for submodule in private/middleware private/renet private/homebrew-tap; do
+        for submodule in private/middleware private/renet; do
             if ! git diff --cached --quiet -- "$submodule" 2>/dev/null; then
                 log_info "Including staged submodule: $submodule" >&2
                 ((staged++)) || true
@@ -191,7 +191,7 @@ main() {
     if [[ "$INCLUDE_SUBMODULES" == "true" ]]; then
         # Only add note if submodules were actually staged
         local has_staged_submodules=false
-        for submodule in private/middleware private/renet private/homebrew-tap; do
+        for submodule in private/middleware private/renet; do
             if ! git diff --cached --quiet -- "$submodule" 2>/dev/null; then
                 has_staged_submodules=true
                 break

--- a/.github/workflows/cd-v2.yml
+++ b/.github/workflows/cd-v2.yml
@@ -84,9 +84,22 @@ jobs:
   # ============================================================================
   # BUILD (parallel reusable workflows)
   # ============================================================================
+
+  # Unified renet build - produces full binaries with embedded CRIU/rsync
+  # Used by BOTH CLI (SEA embedding) and Docker (bridge images)
+  build-renet:
+    name: Build (Renet)
+    needs: [init]
+    uses: ./.github/workflows/ci-build-renet.yml
+    with:
+      next_version: ${{ needs.init.outputs.next_version }}
+      skip_build: ${{ needs.init.outputs.bridge_exists == 'true' }}
+      bridge_tag: ${{ needs.init.outputs.bridge_tag }}
+    secrets: inherit
+
   build-docker:
     name: Build (Docker)
-    needs: [init]
+    needs: [init, build-renet]
     uses: ./.github/workflows/ci-build-docker.yml
     with:
       next_version: ${{ needs.init.outputs.next_version }}
@@ -112,7 +125,7 @@ jobs:
 
   build-cli:
     name: Build (CLI)
-    needs: [init]
+    needs: [init, build-renet]
     uses: ./.github/workflows/ci-build-cli.yml
     with:
       next_version: ${{ needs.init.outputs.next_version }}
@@ -205,29 +218,14 @@ jobs:
           .ci/scripts/docker/retag-image.sh --image cli --from "$STAGING_TAG" --to "$VERSION" --push-latest --skip-if-exists
 
       # -----------------------------------------------------------------------
-      # Step 2: Bump version & commit (includes all submodules)
+      # Step 2: Bump version & commit
       # -----------------------------------------------------------------------
-      - name: Download staging release artifact
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
-        with:
-          name: staging-release-${{ github.sha }}
-          path: dist/
-
       - name: Version bump
         run: .ci/scripts/version/bump.sh --version ${{ needs.init.outputs.next_version }}
 
       - name: Bump submodule versions
         run: |
           .ci/scripts/version/bump-submodules.sh --version ${{ needs.init.outputs.next_version }} --stage-only
-        env:
-          GITHUB_PAT: ${{ secrets.GH_PAT }}
-
-      - name: Update Homebrew formula
-        run: |
-          .ci/scripts/release/update-homebrew-tap.sh \
-            --version ${{ needs.init.outputs.next_version }} \
-            --local-checksums dist/cli \
-            --stage-only
         env:
           GITHUB_PAT: ${{ secrets.GH_PAT }}
 
@@ -242,6 +240,12 @@ jobs:
       # -----------------------------------------------------------------------
       # Step 3: Create GitHub Release (upload packages + binaries)
       # -----------------------------------------------------------------------
+      - name: Download staging release artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
+        with:
+          name: staging-release-${{ github.sha }}
+          path: dist/
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
@@ -255,6 +259,18 @@ jobs:
           draft: false
           prerelease: false
           generate_release_notes: true
+
+      # -----------------------------------------------------------------------
+      # Step 3.5: Update Homebrew formula
+      # -----------------------------------------------------------------------
+      - name: Update Homebrew formula
+        run: |
+          .ci/scripts/release/update-homebrew-tap.sh \
+            --version ${{ needs.init.outputs.next_version }} \
+            --push
+        env:
+          GITHUB_PAT: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
 
       # -----------------------------------------------------------------------
       # Step 4: Download packages from Release for metadata (ensures exact match)

--- a/.github/workflows/ci-build-cli.yml
+++ b/.github/workflows/ci-build-cli.yml
@@ -10,6 +10,9 @@ on:
       GH_PAT:
         required: false
 
+# Note: Renet binaries are built by ci-build-renet.yml and downloaded as artifact
+# This workflow depends on build-renet completing first (configured in ci.yml)
+
 jobs:
   build-cli-executables:
     name: CLI (${{ matrix.platform }}-${{ matrix.arch }})
@@ -45,6 +48,13 @@ jobs:
             timeout: 30
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
+
+      # Download full renet binaries (with embedded CRIU/rsync) from unified build
+      - name: Download renet binaries
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
+        with:
+          name: renet-binaries-${{ github.sha }}
+          path: private/bin/
 
       - name: Apply version bump
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci-build-docker.yml
+++ b/.github/workflows/ci-build-docker.yml
@@ -124,7 +124,7 @@ jobs:
   build-plugins:
     name: Plugins & Docker
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
       - name: Apply version bump
@@ -431,73 +431,16 @@ jobs:
             --tag "${{ inputs.api_tag }}"
 
   # ============================================================
-  # RENET/BRIDGE: Native Binary Builds (no QEMU emulation)
+  # RENET/BRIDGE: Docker Images
+  # Note: Renet binaries (with embedded CRIU/rsync) are built by ci-build-renet.yml
+  # This workflow downloads the unified artifact and builds Docker images only
   # ============================================================
 
-  # Build native binaries (CRIU, rsync) on separate runners to avoid QEMU
-  # Note: renet Go binaries are built in build-renet-docker after all assets available
-  build-renet-native-amd64:
-    name: Renet Binaries (amd64)
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    if: inputs.bridge_exists != 'true'
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
-        with:
-          submodules: true
-          token: ${{ secrets.GH_PAT }}
-
-      - name: Restore native binary cache
-        id: cache-binaries
-        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7  # v5
-        with:
-          path: binaries/
-          key: native-binaries-amd64-${{ hashFiles('.ci/scripts/docker/build-native-binaries.sh') }}
-
-      - name: Build native binaries (amd64 host)
-        if: steps.cache-binaries.outputs.cache-hit != 'true'
-        run: .ci/scripts/docker/build-native-binaries.sh --output ./binaries --cross-rsync
-
-      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
-        with:
-          name: renet-binaries-amd64
-          path: binaries/
-          retention-days: 1
-
-  build-renet-native-arm64:
-    name: Renet Binaries (arm64)
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 45
-    if: inputs.bridge_exists != 'true'
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
-        with:
-          submodules: true
-          token: ${{ secrets.GH_PAT }}
-
-      - name: Restore native binary cache
-        id: cache-binaries
-        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7  # v5
-        with:
-          path: binaries/
-          key: native-binaries-arm64-${{ hashFiles('.ci/scripts/docker/build-native-binaries.sh') }}
-
-      - name: Build CRIU arm64 natively
-        if: steps.cache-binaries.outputs.cache-hit != 'true'
-        run: .ci/scripts/docker/build-native-binaries.sh --output ./binaries --criu-only
-
-      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
-        with:
-          name: renet-binaries-arm64
-          path: binaries/
-          retention-days: 1
-
-  # Build renet Go binaries with embedded assets and Docker images
+  # Build Docker images from unified renet binaries
   build-renet-docker:
     name: Renet Docker
     runs-on: ubuntu-latest
-    timeout-minutes: 25
-    needs: [build-renet-native-amd64, build-renet-native-arm64]
+    timeout-minutes: 15
     if: inputs.bridge_exists != 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
@@ -505,45 +448,27 @@ jobs:
           submodules: true
           token: ${{ secrets.GH_PAT }}
 
-      - name: Apply version bump
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: .ci/scripts/version/bump.sh --version ${{ inputs.next_version }}
-
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6
-        with:
-          go-version: '1.24'
-          cache: true
-          cache-dependency-path: private/renet/go.sum
-
+      # Download full renet binaries (with embedded CRIU/rsync) from unified build
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
         with:
-          name: renet-binaries-amd64
+          name: renet-binaries-${{ github.sha }}
+          path: binaries/
+
+      # Download native CRIU/rsync binaries (also from unified build)
+      # These are copied to /opt/ in Docker image for remote machine distribution
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
+        with:
+          name: native-amd64-${{ github.sha }}
           path: binaries/
 
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
         with:
-          name: renet-binaries-arm64
+          name: native-arm64-${{ github.sha }}
           path: binaries/
           merge-multiple: true
 
       - name: List binaries
         run: ls -la binaries/
-
-      # Embed assets into Go binary by placing compressed binaries in pkg/embed/assets/
-      - name: Prepare embedded assets for Go build
-        run: |
-          mkdir -p private/renet/pkg/embed/assets
-          gzip -c binaries/criu-linux-amd64 > private/renet/pkg/embed/assets/criu-linux-amd64.gz
-          gzip -c binaries/criu-linux-arm64 > private/renet/pkg/embed/assets/criu-linux-arm64.gz
-          gzip -c binaries/rsync-linux-amd64 > private/renet/pkg/embed/assets/rsync-linux-amd64.gz
-          gzip -c binaries/rsync-linux-arm64 > private/renet/pkg/embed/assets/rsync-linux-arm64.gz
-          ls -la private/renet/pkg/embed/assets/
-
-      - name: Build renet Go binaries with embedded assets
-        run: |
-          cd private/renet
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X main.Version=${{ inputs.next_version }}" -o ../../binaries/renet-linux-amd64 ./cmd/renet
-          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-s -w -X main.Version=${{ inputs.next_version }}" -o ../../binaries/renet-linux-arm64 ./cmd/renet
 
       - uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/ci-build-renet.yml
+++ b/.github/workflows/ci-build-renet.yml
@@ -1,0 +1,166 @@
+name: Console CI - Build (Renet)
+
+on:
+  workflow_call:
+    inputs:
+      next_version:
+        required: true
+        type: string
+      skip_build:
+        description: 'Skip build if renet already exists in registry'
+        required: false
+        type: boolean
+        default: false
+      bridge_tag:
+        description: 'Existing bridge tag to extract renet from (when skip_build=true)'
+        required: false
+        type: string
+        default: ''
+    outputs:
+      artifact_name:
+        description: 'Name of the renet binaries artifact'
+        value: ${{ jobs.build-renet.outputs.artifact_name || jobs.extract-renet.outputs.artifact_name }}
+    secrets:
+      GH_PAT:
+        required: false
+
+jobs:
+  # Build native CRIU/rsync binaries (amd64) - cached
+  build-native-amd64:
+    name: Native (amd64)
+    runs-on: ubuntu-latest
+    if: ${{ !inputs.skip_build }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
+        with:
+          submodules: true
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Restore native binary cache
+        id: cache
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7  # v5
+        with:
+          path: binaries/
+          key: native-amd64-${{ hashFiles('.ci/scripts/docker/build-native-binaries.sh') }}
+
+      - name: Build native binaries
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: .ci/scripts/docker/build-native-binaries.sh --output ./binaries --cross-rsync
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
+        with:
+          name: native-amd64-${{ github.sha }}
+          path: binaries/
+          retention-days: 1
+
+  # Build native CRIU binary (arm64) - requires native runner
+  build-native-arm64:
+    name: Native (arm64)
+    runs-on: ubuntu-24.04-arm
+    if: ${{ !inputs.skip_build }}
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
+        with:
+          submodules: true
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Restore native binary cache
+        id: cache
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7  # v5
+        with:
+          path: binaries/
+          key: native-arm64-${{ hashFiles('.ci/scripts/docker/build-native-binaries.sh') }}
+
+      - name: Build CRIU arm64
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: .ci/scripts/docker/build-native-binaries.sh --output ./binaries --criu-only
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
+        with:
+          name: native-arm64-${{ github.sha }}
+          path: binaries/
+          retention-days: 1
+
+  # Build full renet binaries with embedded CRIU/rsync
+  # These binaries are used by BOTH CLI and Docker
+  build-renet:
+    name: Renet (Full)
+    runs-on: ubuntu-latest
+    needs: [build-native-amd64, build-native-arm64]
+    if: ${{ !inputs.skip_build }}
+    timeout-minutes: 15
+    outputs:
+      artifact_name: renet-binaries-${{ github.sha }}
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
+        with:
+          submodules: true
+          token: ${{ secrets.GH_PAT }}
+
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6
+        with:
+          go-version: 'stable'
+          cache: true
+          cache-dependency-path: private/renet/go.sum
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
+        with:
+          name: native-amd64-${{ github.sha }}
+          path: binaries/
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
+        with:
+          name: native-arm64-${{ github.sha }}
+          path: binaries/
+          merge-multiple: true
+
+      - name: List native binaries
+        run: ls -la binaries/
+
+      - name: Build full renet with embedded assets (release)
+        run: |
+          .ci/scripts/build/build-renet.sh \
+            --version "${{ inputs.next_version }}" \
+            --assets-dir ./binaries \
+            --output ./private/bin
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
+        with:
+          name: renet-binaries-${{ github.sha }}
+          path: |
+            private/bin/renet-linux-*
+            private/bin/checksums.sha256
+          retention-days: 1
+          if-no-files-found: error
+
+  # Extract renet binaries from existing bridge image when build is skipped
+  # This ensures CLI always has access to renet binaries, even when using cached images
+  extract-renet:
+    name: Renet (cached)
+    runs-on: ubuntu-latest
+    if: ${{ inputs.skip_build && inputs.bridge_tag != '' }}
+    outputs:
+      artifact_name: renet-binaries-${{ github.sha }}
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_PAT }}
+
+      - name: Extract renet binaries from existing bridge image
+        run: .ci/scripts/build/extract-renet-from-image.sh --tag "${{ inputs.bridge_tag }}" --output ./private/bin
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
+        with:
+          name: renet-binaries-${{ github.sha }}
+          path: |
+            private/bin/renet-linux-*
+            private/bin/checksums.sha256
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -207,7 +207,7 @@ jobs:
 
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6
         with:
-          go-version: '1.24'
+          go-version: 'stable'
           cache: true
           cache-dependency-path: private/renet/go.sum
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: .ci/scripts/ci/cancel-older-runs.sh --timeout 300 --poll-interval 15
+        run: .ci/scripts/ci/cancel-older-runs.sh --timeout 60 --poll-interval 10
 
       - name: Monitor all jobs and cancel on failure
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
@@ -180,12 +180,26 @@ jobs:
 
   # ============================================================================
   # COLUMN 3: BUILD & DOCKER
-  # Jobs: build-docker, build-desktop, build-cli (parallel reusable workflows)
-  # Dependencies: quality + review-gate
+  # Jobs: build-renet (unified), build-docker, build-desktop (parallel reusable workflows)
+  # Dependencies: quality + review-gate -> build-renet -> build-docker, build-cli
   # ============================================================================
+
+  # Unified renet build - produces full binaries with embedded CRIU/rsync
+  # Used by BOTH CLI (SEA embedding) and Docker (bridge images)
+  build-renet:
+    name: Build (Renet)
+    needs: [initialize, quality, review-gate]
+    if: always() && needs.initialize.result == 'success' && needs.quality.result == 'success' && (needs.review-gate.result == 'success' || needs.review-gate.result == 'skipped')
+    uses: ./.github/workflows/ci-build-renet.yml
+    with:
+      next_version: ${{ needs.initialize.outputs.next_version }}
+      skip_build: ${{ needs.initialize.outputs.bridge_exists == 'true' }}
+      bridge_tag: ${{ needs.initialize.outputs.bridge_tag }}
+    secrets: inherit
+
   build-docker:
     name: Build (Docker)
-    needs: [initialize, quality, review-gate]
+    needs: [initialize, quality, review-gate, build-renet]
     if: always() && needs.initialize.result == 'success' && needs.quality.result == 'success' && (needs.review-gate.result == 'success' || needs.review-gate.result == 'skipped')
     uses: ./.github/workflows/ci-build-docker.yml
     with:
@@ -213,7 +227,7 @@ jobs:
 
   build-cli:
     name: Build (CLI)
-    needs: [initialize, quality, review-gate]
+    needs: [initialize, quality, review-gate, build-renet]
     if: always() && needs.initialize.result == 'success' && needs.quality.result == 'success' && (needs.review-gate.result == 'success' || needs.review-gate.result == 'skipped')
     uses: ./.github/workflows/ci-build-cli.yml
     with:

--- a/.github/workflows/ct-tests.yml
+++ b/.github/workflows/ct-tests.yml
@@ -645,7 +645,7 @@ jobs:
 
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6
         with:
-          go-version: '1.24'
+          go-version: 'stable'
           cache: true
           cache-dependency-path: private/renet/go.sum
 

--- a/eslint-rules/require-translation.js
+++ b/eslint-rules/require-translation.js
@@ -101,6 +101,8 @@ const splitKey = (key) => {
 const isNotTranslationKey = (key) => {
   // Shared namespace keys - validated in packages/shared/src/i18n/locales/
   if (key.startsWith('shared:')) return true;
+  // Node.js built-in module specifiers (e.g., node:fs, node:path, node:sea)
+  if (key.startsWith('node:')) return true;
   // Commander event names (e.g., command:*)
   if (key === 'command:*') return true;
   // URLs (http, https, or any protocol like rediacc://)

--- a/package-lock.json
+++ b/package-lock.json
@@ -14032,6 +14032,32 @@
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
     },
+    "node_modules/inquirer": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.2.2.tgz",
+      "integrity": "sha512-+hlN8I88JE9T3zjWHGnMhryniRDbSgFNJHJTyD2iKO5YNpMRyfghQ6wVoe+gV4ygMM4r4GzlsBxNa1g/UUZixA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.3",
+        "@inquirer/core": "^11.1.1",
+        "@inquirer/prompts": "^8.2.0",
+        "@inquirer/type": "^4.0.3",
+        "mute-stream": "^3.0.0",
+        "run-async": "^4.0.6",
+        "rxjs": "^7.8.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -24114,7 +24140,7 @@
         "@vitest/runner": "^4.0.18",
         "@vitest/ui": "^4.0.18",
         "@vitest/utils": "^4.0.18",
-        "inquirer": "^13.2.1",
+        "inquirer": "^13.2.2",
         "react-i18next": "^16.5.4",
         "unist-util-visit": "^5.1.0",
         "zod": "^4.3.6"
@@ -24686,7 +24712,7 @@
       "version": "22.19.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
       "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -24741,32 +24767,6 @@
       },
       "peerDependencies": {
         "vitest": "4.0.18"
-      }
-    },
-    "packages/cli/node_modules/inquirer": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.2.1.tgz",
-      "integrity": "sha512-kjIN+joqgbSncQJ6GfN7gV9AbDQlMA+hJ96xcwkQUwP9KN/ZIusoJ2mAfdt0LPrZJQsEyk5i/YrgJQTxSgzlPw==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^2.0.3",
-        "@inquirer/core": "^11.1.1",
-        "@inquirer/prompts": "^8.2.0",
-        "@inquirer/type": "^4.0.3",
-        "mute-stream": "^3.0.0",
-        "run-async": "^4.0.6",
-        "rxjs": "^7.8.2"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
       }
     },
     "packages/cli/node_modules/ora": {
@@ -24840,7 +24840,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "packages/cli/node_modules/unist-util-visit": {

--- a/packages/cli/bundle.mjs
+++ b/packages/cli/bundle.mjs
@@ -1,5 +1,18 @@
 import * as esbuild from 'esbuild';
 
+/** Plugin to exclude native .node bindings from the bundle.
+ *  ssh2 and cpu-features have optional native bindings wrapped in try/catch,
+ *  so they gracefully fall back to pure JavaScript when unavailable. */
+const nativeModulesPlugin = {
+  name: 'native-node-modules',
+  setup(build) {
+    build.onResolve({ filter: /\.node$/ }, (args) => ({
+      path: args.path,
+      external: true,
+    }));
+  },
+};
+
 await esbuild.build({
   entryPoints: ['src/index.ts'],
   bundle: true,
@@ -9,6 +22,7 @@ await esbuild.build({
   format: 'cjs',
   // Note: shebang comes from src/index.ts - no banner needed
   external: [],
+  plugins: [nativeModulesPlugin],
 });
 
 console.log('✓ CLI bundled to dist/cli-bundle.cjs');

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,7 @@
     "@vitest/runner": "^4.0.18",
     "@vitest/ui": "^4.0.18",
     "@vitest/utils": "^4.0.18",
-    "inquirer": "^13.2.1",
+    "inquirer": "^13.2.2",
     "react-i18next": "^16.5.4",
     "unist-util-visit": "^5.1.0",
     "zod": "^4.3.6"

--- a/packages/cli/sea-config.json
+++ b/packages/cli/sea-config.json
@@ -3,5 +3,10 @@
   "output": "dist/sea-prep.blob",
   "disableExperimentalSEAWarning": true,
   "useSnapshot": false,
-  "useCodeCache": true
+  "useCodeCache": false,
+  "assets": {
+    "renet-linux-amd64": "dist/assets/renet-linux-amd64",
+    "renet-linux-arm64": "dist/assets/renet-linux-arm64",
+    "renet-metadata.json": "dist/assets/renet-metadata.json"
+  }
 }

--- a/packages/cli/src/services/embedded-assets.ts
+++ b/packages/cli/src/services/embedded-assets.ts
@@ -1,0 +1,140 @@
+/**
+ * Embedded Assets - SEA asset extraction utilities
+ *
+ * Provides utilities for working with embedded assets in Node.js
+ * Single Executable Applications (SEA). Used to extract renet binaries
+ * for provisioning to remote Linux machines.
+ */
+
+import * as crypto from 'node:crypto';
+import { createRequire } from 'node:module';
+
+/** Supported Linux architectures for renet */
+export type LinuxArch = 'amd64' | 'arm64';
+
+/** Metadata for embedded renet binaries */
+export interface RenetMetadata {
+  version: string;
+  generatedAt: string;
+  binaries: Record<LinuxArch, { size: number; sha256: string }>;
+}
+
+/** SEA module interface for type safety */
+interface SEAModule {
+  getAsset(key: string): ArrayBuffer;
+}
+
+/**
+ * Try to load the node:sea module for SEA asset access
+ * Returns null if not running as SEA
+ */
+function tryLoadSEA(): SEAModule | null {
+  try {
+    const require = createRequire(import.meta.url);
+    const sea = require('node:sea') as SEAModule;
+    if (typeof sea.getAsset === 'function') {
+      return sea;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if running as a Node.js Single Executable Application
+ *
+ * @returns true if running as SEA with embedded assets
+ */
+export function isSEA(): boolean {
+  return tryLoadSEA() !== null;
+}
+
+/**
+ * Get an embedded renet binary for a specific Linux architecture
+ *
+ * @param arch - Target architecture (amd64 or arm64)
+ * @returns Binary data as Buffer
+ * @throws Error if not running as SEA or asset not found
+ */
+export function getEmbeddedRenetBinary(arch: LinuxArch): Buffer {
+  const sea = tryLoadSEA();
+  if (!sea) {
+    throw new Error('Not running as SEA - embedded assets not available');
+  }
+
+  // Note: getAsset throws if the asset is not found, no need for a falsy check
+  const asset = sea.getAsset(`renet-linux-${arch}`);
+  return Buffer.from(asset);
+}
+
+/**
+ * Validate that parsed data conforms to RenetMetadata interface
+ *
+ * @param data - Parsed JSON data to validate
+ * @returns true if data is valid RenetMetadata
+ */
+function isValidRenetMetadata(data: unknown): data is RenetMetadata {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+
+  const obj = data as Record<string, unknown>;
+
+  if (typeof obj.version !== 'string' || typeof obj.generatedAt !== 'string') {
+    return false;
+  }
+
+  if (typeof obj.binaries !== 'object' || obj.binaries === null) {
+    return false;
+  }
+
+  const binaries = obj.binaries as Record<string, unknown>;
+  const requiredArchs: LinuxArch[] = ['amd64', 'arm64'];
+
+  for (const arch of requiredArchs) {
+    const binary = binaries[arch];
+    if (typeof binary !== 'object' || binary === null) {
+      return false;
+    }
+    const binaryObj = binary as Record<string, unknown>;
+    if (typeof binaryObj.size !== 'number' || typeof binaryObj.sha256 !== 'string') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Get the embedded renet metadata (versions, hashes, sizes)
+ *
+ * @returns Parsed metadata object
+ * @throws Error if not running as SEA, asset not found, or metadata is invalid
+ */
+export function getEmbeddedMetadata(): RenetMetadata {
+  const sea = tryLoadSEA();
+  if (!sea) {
+    throw new Error('Not running as SEA - embedded assets not available');
+  }
+
+  // Note: getAsset throws if the asset is not found, no need for a falsy check
+  const asset = sea.getAsset('renet-metadata.json');
+  const parsed: unknown = JSON.parse(Buffer.from(asset).toString('utf-8'));
+
+  if (!isValidRenetMetadata(parsed)) {
+    throw new Error('Embedded renet-metadata.json has invalid format');
+  }
+
+  return parsed;
+}
+
+/**
+ * Compute SHA256 hash of data
+ *
+ * @param data - Data to hash
+ * @returns Lowercase hex-encoded SHA256 hash
+ */
+export function computeSha256(data: Buffer): string {
+  return crypto.createHash('sha256').update(data).digest('hex');
+}

--- a/packages/cli/src/services/renet-provisioner.ts
+++ b/packages/cli/src/services/renet-provisioner.ts
@@ -1,0 +1,194 @@
+/**
+ * Renet Provisioner - Remote binary provisioning via SFTP
+ *
+ * Provisions the appropriate renet binary to remote Linux machines
+ * before execution. Handles architecture detection, verification, and caching.
+ */
+
+import { SFTPClient, type SFTPClientConfig } from '@rediacc/shared-desktop/sftp';
+import { DEFAULTS } from '@rediacc/shared/config';
+import {
+  isSEA,
+  getEmbeddedRenetBinary,
+  getEmbeddedMetadata,
+  computeSha256,
+  type LinuxArch,
+} from './embedded-assets.js';
+
+/** Default remote path for provisioned renet binary */
+const DEFAULT_REMOTE_PATH = '/tmp/.rdc/renet';
+
+/** Cache TTL in milliseconds (1 hour) */
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+/** Result of a provisioning operation */
+export interface ProvisionResult {
+  /** Whether provisioning succeeded */
+  success: boolean;
+  /** Action taken: uploaded new binary, verified existing, skipped (not SEA), or failed */
+  action: 'uploaded' | 'verified' | 'skipped' | 'failed';
+  /** Remote path where renet is available */
+  remotePath: string;
+  /** Detected architecture (undefined if detection failed) */
+  arch?: LinuxArch;
+  /** Error message if failed */
+  error?: string;
+}
+
+/** Cache entry for a provisioned host */
+interface CacheEntry {
+  hash: string;
+  provisionedAt: number;
+}
+
+/**
+ * Service for provisioning renet binaries to remote Linux machines.
+ *
+ * When running as SEA, extracts the appropriate architecture binary
+ * from embedded assets and uploads via SFTP. Uses a verification flow:
+ * 1. Check if remote binary exists
+ * 2. Compare size with expected
+ * 3. Compare SHA256 hash with expected
+ * 4. Upload only if verification fails
+ *
+ * Maintains an in-memory cache to avoid redundant checks within TTL.
+ */
+class RenetProvisionerService {
+  private readonly cache = new Map<string, CacheEntry>();
+
+  /**
+   * Provision renet to a remote Linux machine
+   *
+   * @param config - SFTP connection configuration
+   * @param remotePath - Remote path for the binary (default: /tmp/.rdc/renet)
+   * @returns Provision result with action taken
+   */
+  async provision(
+    config: SFTPClientConfig,
+    remotePath = DEFAULT_REMOTE_PATH
+  ): Promise<ProvisionResult> {
+    // Not running as SEA - use local renet path
+    if (!isSEA()) {
+      return { success: true, action: 'skipped', remotePath: 'renet', arch: 'amd64' };
+    }
+
+    const sftp = new SFTPClient(config);
+
+    try {
+      await sftp.connect();
+
+      // Detect remote architecture
+      const arch = await this.detectArch(sftp);
+      const metadata = getEmbeddedMetadata().binaries[arch];
+
+      // Check in-memory cache
+      const cacheKey = `${config.host}:${config.port ?? DEFAULTS.SSH.PORT}`;
+      const cached = this.cache.get(cacheKey);
+      if (cached?.hash === metadata.sha256 && Date.now() - cached.provisionedAt < CACHE_TTL_MS) {
+        return { success: true, action: 'skipped', remotePath, arch };
+      }
+
+      // Verify remote binary
+      const needsUpload = await this.needsUpload(sftp, remotePath, metadata);
+
+      if (!needsUpload) {
+        this.cache.set(cacheKey, { hash: metadata.sha256, provisionedAt: Date.now() });
+        return { success: true, action: 'verified', remotePath, arch };
+      }
+
+      // Extract and upload binary
+      const binary = getEmbeddedRenetBinary(arch);
+      const parentDir = remotePath.substring(0, remotePath.lastIndexOf('/'));
+      await sftp.mkdirRecursive(parentDir);
+      await sftp.writeFile(remotePath, binary);
+      await sftp.chmod(remotePath, 0o755);
+
+      this.cache.set(cacheKey, { hash: metadata.sha256, provisionedAt: Date.now() });
+      return { success: true, action: 'uploaded', remotePath, arch };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        action: 'failed',
+        remotePath,
+        error: `Failed to provision renet: ${errorMessage}`,
+      };
+    } finally {
+      sftp.close();
+    }
+  }
+
+  /**
+   * Detect the remote machine's architecture.
+   * Uses `uname -m` output which is reliable across all Linux distributions.
+   */
+  private async detectArch(sftp: SFTPClient): Promise<LinuxArch> {
+    try {
+      // uname -m returns the machine hardware name, which is the most reliable
+      // cross-distribution method for architecture detection:
+      // - x86_64 for AMD64/Intel 64-bit
+      // - aarch64 for ARM64
+      const arch = await sftp.exec('uname -m');
+      const archStr = arch.trim().toLowerCase();
+
+      if (archStr === 'aarch64' || archStr === 'arm64') {
+        return 'arm64';
+      }
+      // Default to amd64 for x86_64 and any other architecture
+      return 'amd64';
+    } catch {
+      // If exec fails (e.g., restricted shell), fall back to filesystem detection
+      // Check multiple paths that indicate ARM64 across different distros:
+      // - /lib/aarch64-linux-gnu: Debian/Ubuntu multiarch
+      // - /lib64/ld-linux-aarch64.so.1: RHEL/CentOS/Fedora ARM64 dynamic linker
+      const arm64Paths = ['/lib/aarch64-linux-gnu', '/lib64/ld-linux-aarch64.so.1'];
+      for (const path of arm64Paths) {
+        if (await sftp.exists(path)) {
+          return 'arm64';
+        }
+      }
+      return 'amd64';
+    }
+  }
+
+  /**
+   * Check if the remote binary needs to be uploaded.
+   * Verifies existence, size, and SHA256 hash.
+   */
+  private async needsUpload(
+    sftp: SFTPClient,
+    path: string,
+    expected: { size: number; sha256: string }
+  ): Promise<boolean> {
+    try {
+      // Check existence
+      if (!(await sftp.exists(path))) {
+        return true;
+      }
+
+      // Check size first (fast check)
+      const stat = await sftp.stat(path);
+      if (stat.size !== expected.size) {
+        return true;
+      }
+
+      // Verify SHA256 hash (slow but thorough)
+      const content = await sftp.readFile(path);
+      return computeSha256(content) !== expected.sha256;
+    } catch {
+      // Any error means we need to upload
+      return true;
+    }
+  }
+
+  /**
+   * Clear the in-memory cache.
+   * Useful for testing or forcing re-verification.
+   */
+  clearCache(): void {
+    this.cache.clear();
+  }
+}
+
+/** Singleton instance of the renet provisioner */
+export const renetProvisioner = new RenetProvisionerService();

--- a/packages/shared/src/config/defaults.ts
+++ b/packages/shared/src/config/defaults.ts
@@ -285,6 +285,9 @@ export const PROCESS_DEFAULTS = {
 
   /** Default shell for bash execution */
   SHELL: '/bin/bash',
+
+  /** Default error message for renet provisioning failure */
+  RENET_PROVISION_ERROR: 'Failed to provision renet',
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

Unify renet binary builds between CLI and Docker workflows to reduce duplication and CI time. CLI now embeds renet binaries for local provisioning to remote machines.

## Changes

### New Unified Renet Build Workflow
- Add `ci-build-renet.yml` - single workflow that builds renet binaries with embedded CRIU/rsync assets for both CLI and Docker
- When bridge image exists (cached), extract renet from image instead of rebuilding
- Both CLI and Docker workflows now depend on this unified build

### CLI Renet Embedding
- Add `embedded-assets.ts` - extracts embedded renet binaries at runtime
- Add `renet-provisioner.ts` - provisions renet to remote Linux machines
- Update `local-executor.ts` to use embedded renet for local execution
- Add `prepare-cli-assets.sh` - prepares renet binaries for SEA embedding

### Build Scripts
- Add `build-renet.sh` - builds full renet with embedded CRIU/rsync
- Add `extract-renet-from-image.sh` - extracts renet from cached bridge
- Simplify `update-homebrew-tap.sh` - remove unused local checksum mode

### CI Improvements
- Block build jobs when Review Gate fails
- Fix attribution check to be more precise (allow legitimate tool mentions)
- Add shellcheck suppression for intentional glob matching
- Consolidate version commit with homebrew-tap update

### Other
- Add `exec` method to SFTP client for remote command execution
- Update sea-config.json to include embedded assets

## Test Plan
- [ ] CI passes quality checks
- [ ] Renet build workflow produces artifacts
- [ ] CLI build embeds renet binaries correctly
- [ ] Docker build uses shared renet artifacts