### PR TITLE
Replace green accent tokens with neutral tokens and gradients

### DIFF
--- a/packages/www/public/styles/main.css
+++ b/packages/www/public/styles/main.css
@@ -123,7 +123,7 @@
 
   /* Primary/Accent Colors */
   --color-primary: #556b2f; /* Primary accent color */
-  --color-accent-green: #7fa03f; /* Accent green for highlights */
+  --color-accent-neutral: #fff; /* Neutral accent for highlights */
 
   /* Success/Validation Colors */
   --color-success: #28a745;
@@ -211,7 +211,7 @@
   /* Gradients */
   --gradient-dark: linear-gradient(135deg, var(--color-bg-dark) 0%, var(--color-bg-darker) 100%);
   --gradient-dark-alt: linear-gradient(135deg, var(--color-bg-darker) 0%, #1f1f1f 100%);
-  --gradient-dark-green: linear-gradient(135deg, var(--color-bg-darker) 0%, #232823 100%);
+  --gradient-dark-neutral: linear-gradient(135deg, #1f1f1f 0%, #000 100%);
 }
 
 /* Fallback for browsers without dvh support */

--- a/packages/www/src/styles/pricing-page.css
+++ b/packages/www/src/styles/pricing-page.css
@@ -331,7 +331,7 @@
 }
 
 .ps-teaser-card.popular:focus-visible {
-  outline: 2px solid var(--color-accent-green);
+  outline: 2px solid var(--color-accent-neutral);
   outline-offset: 2px;
 }
 
@@ -340,8 +340,8 @@
   top: calc(-1 * var(--space-2));
   left: 50%;
   transform: translateX(-50%);
-  background: var(--color-accent-green);
-  color: white;
+  background: var(--color-accent-neutral);
+  color: var(--color-bg-dark);
   padding: var(--space-1) var(--space-3);
   border-radius: var(--radius-lg);
   font-size: var(--font-size-xs);
@@ -585,8 +585,8 @@
 
 .savings-badge {
   display: inline-block;
-  background: var(--color-accent-green);
-  color: white;
+  background: var(--color-accent-neutral);
+  color: var(--color-bg-dark);
   padding: var(--space-1) var(--space-3);
   border-radius: var(--radius-lg);
   font-size: var(--font-size-xs);
@@ -673,7 +673,7 @@
 .post-cta-section .guarantee-badge {
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-semibold);
-  color: var(--color-accent-green);
+  color: var(--color-accent-neutral);
   text-transform: uppercase;
   letter-spacing: var(--tracking-wide);
 }
@@ -787,9 +787,9 @@
 }
 
 .service-package-card.popular {
-  border-color: var(--color-accent-green);
+  border-color: var(--color-accent-neutral);
   border-width: 2px;
-  background: var(--gradient-dark-green);
+  background: var(--gradient-dark-neutral);
 }
 
 .service-package-card .popular-badge {
@@ -797,8 +797,8 @@
   top: calc(-1 * var(--space-3));
   left: 50%;
   transform: translateX(-50%);
-  background: var(--color-accent-green);
-  color: white;
+  background: var(--color-accent-neutral);
+  color: var(--color-bg-dark);
   padding: var(--space-2) var(--space-4);
   border-radius: var(--radius-lg);
   font-size: var(--font-size-sm);
@@ -808,7 +808,7 @@
 .package-icon {
   text-align: center;
   margin-bottom: var(--space-4);
-  color: var(--color-accent-green);
+  color: var(--color-accent-neutral);
 }
 
 .package-header {
@@ -852,7 +852,7 @@
   font-size: var(--font-size-4xl);
   font-weight: var(--font-weight-bold);
   font-variant-numeric: tabular-nums;
-  color: var(--color-accent-green);
+  color: var(--color-accent-neutral);
 }
 
 .turnaround-time {
@@ -896,7 +896,7 @@
 .package-benefits li svg {
   flex-shrink: 0;
   margin-top: 2px;
-  color: var(--color-accent-green);
+  color: var(--color-accent-neutral);
 }
 
 .package-action {
@@ -939,7 +939,7 @@
 }
 
 .factor-icon {
-  color: var(--color-accent-green);
+  color: var(--color-accent-neutral);
   margin-bottom: var(--space-3);
 }
 
@@ -1024,7 +1024,7 @@
 
 .service-type-icon {
   flex-shrink: 0;
-  color: var(--color-accent-green);
+  color: var(--color-accent-neutral);
   display: flex;
   align-items: center;
 }
@@ -1074,7 +1074,7 @@
 
 .detail-badge.priority {
   background: rgba(127, 160, 63, var(--opacity-20));
-  color: var(--color-accent-green);
+  color: var(--color-accent-neutral);
 }
 
 .detail-badge.emergency {

--- a/packages/www/src/styles/professional-services-page.css
+++ b/packages/www/src/styles/professional-services-page.css
@@ -45,13 +45,13 @@
   background: rgba(127, 160, 63, var(--opacity-15));
   border: 1px solid rgba(127, 160, 63, var(--opacity-30));
   border-radius: var(--radius-2xl);
-  color: var(--color-accent-green);
+  color: var(--color-accent-neutral);
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-semibold);
 }
 
 .ps-hero .hero-badge svg {
-  color: var(--color-accent-green);
+  color: var(--color-accent-neutral);
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
### Motivation
- Replace the site-wide green accent and green gradient with neutral tokens to enable a neutral/monochrome styling option and avoid hard-coded green usage across pricing and services components.
- Maintain accessible contrast for badges and iconography after swapping the accent color to a neutral value.

### Description
- Added `--color-accent-neutral: #fff` and replaced `--color-accent-green` in `packages/www/public/styles/main.css`, and renamed `--gradient-dark-green` to `--gradient-dark-neutral` with a neutral black/gray gradient in the same file.
- Updated references in `packages/www/src/styles/pricing-page.css` to use `--color-accent-neutral` and `--gradient-dark-neutral`, and changed badge/icon/text colors to `var(--color-bg-dark)` or `var(--color-accent-neutral)` to preserve contrast.
- Updated `packages/www/src/styles/professional-services-page.css` to use `--color-accent-neutral` for hero badge text and SVG color.
- Committed the three modified files after verifying global replacements and local usages.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4321` which launched successfully and served the app.
- Captured a visual snapshot of the pricing page by running a Playwright script that navigated to `/en/pricing` and saved `artifacts/pricing-neutral-accent.png`, which completed successfully.
- Verified there are no remaining occurrences of `--color-accent-green` or `--gradient-dark-green` in `packages/www` using `rg`, which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a6087e3c083208de8e84f01f9fe87)