### PR TITLE
feat: tag-based versioning, R2 stable channel, CD git tags

### DIFF
--- a/.ci/scripts/build/build-cli-executables.sh
+++ b/.ci/scripts/build/build-cli-executables.sh
@@ -111,6 +111,8 @@ fi
 
 # Step 1: Build the CJS bundle
 log_step "Building CLI bundle..."
+export CLI_VERSION="${CLI_VERSION:-0.0.0-dev}"
+log_info "CLI version: $CLI_VERSION"
 cd "$CLI_DIR"
 node bundle.mjs
 require_file "$CLI_DIR/dist/cli-bundle.cjs"

--- a/.ci/scripts/build/build-cli-musl.sh
+++ b/.ci/scripts/build/build-cli-musl.sh
@@ -91,6 +91,7 @@ docker run --rm \
     -v "$REPO_ROOT:/workspace" \
     -w /workspace \
     -e CI="${CI:-}" \
+    -e CLI_VERSION="${CLI_VERSION:-0.0.0-dev}" \
     node:22-alpine sh -c '
 set -e
 

--- a/.ci/scripts/ci/initialize.sh
+++ b/.ci/scripts/ci/initialize.sh
@@ -155,10 +155,10 @@ BUMP_TYPE=$(.ci/scripts/version/detect-bump-type.sh --verbose)
 log_info "Bump type: $BUMP_TYPE"
 write_output "bump_type" "$BUMP_TYPE"
 
-log_step "Calculating next version..."
-NEXT_VERSION=$(.ci/scripts/version/bump.sh --${BUMP_TYPE} --dry-run | tail -n 1)
+log_step "Calculating next version from git tags..."
+NEXT_VERSION=$(.ci/scripts/version/resolve-version.sh --bump-type "$BUMP_TYPE")
 write_output "next_version" "$NEXT_VERSION"
-log_info "Next version: $NEXT_VERSION"
+log_info "Next version: $NEXT_VERSION (from tag: $(.ci/scripts/version/resolve-version.sh --current))"
 
 # On push-to-main, append version to ALL image tags to invalidate CI/merge-queue cache.
 # CI builds (merge_group event) don't embed version, CD builds (push event) do —

--- a/.ci/scripts/deploy/upload-to-r2.sh
+++ b/.ci/scripts/deploy/upload-to-r2.sh
@@ -260,7 +260,18 @@ if [[ -d "$CLI_DIR" ]]; then
     r2_put "{\"version\":\"${VERSION}\"}" "$(r2_path "cli/edge/latest.json")"
     ((UPLOADED++)) || true
 
-    log_info "CLI: uploaded to $(r2_path "cli/v${VERSION}/") + $(r2_path "cli/edge/")"
+    # Also publish to stable channel (same content, both channels always in sync)
+    if [[ -f "$CLI_DIR/manifest.json" ]]; then
+        r2_cp "$CLI_DIR/manifest.json" "$(r2_path "cli/stable/manifest.json")"
+    fi
+    for binary in "$CLI_DIR"/rdc-*; do
+        [[ -f "$binary" ]] || continue
+        local_name="$(basename "$binary")"
+        r2_cp "$binary" "$(r2_path "cli/stable/${local_name}")"
+    done
+    r2_put "{\"version\":\"${VERSION}\"}" "$(r2_path "cli/stable/latest.json")"
+
+    log_info "CLI: uploaded to $(r2_path "cli/v${VERSION}/") + $(r2_path "cli/edge/") + $(r2_path "cli/stable/")"
 
     # Track CLI versions for retention cleanup (production only)
     if [[ -z "$STAGING" ]]; then

--- a/.ci/scripts/test/test-install-methods.sh
+++ b/.ci/scripts/test/test-install-methods.sh
@@ -479,7 +479,6 @@ test_quick_install() {
 
     docker run --rm \
         -e "REDIACC_RELEASES_URL=${RELEASES_BASE_URL}" \
-        -e "REDIACC_CHANNEL=edge" \
         "$distro" bash -c "
         set -e
         apt-get update -qq

--- a/.ci/scripts/version/resolve-version.sh
+++ b/.ci/scripts/version/resolve-version.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Resolve version from git tags (replaces file-based versioning).
+#
+# Uses the latest v* tag as the current version and calculates the next
+# version based on semver bump type.
+#
+# Usage:
+#   resolve-version.sh --current          # Output current version (e.g., 0.8.2)
+#   resolve-version.sh --bump-type patch  # Output next patch (e.g., 0.8.3)
+#   resolve-version.sh --bump-type minor  # Output next minor (e.g., 0.9.0)
+#   resolve-version.sh --bump-type major  # Output next major (e.g., 1.0.0)
+#
+# Exit codes:
+#   0 - Success
+#   1 - Error
+
+set -euo pipefail
+
+BUMP_TYPE=""
+CURRENT_ONLY=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --current)
+            CURRENT_ONLY=true
+            shift
+            ;;
+        --bump-type)
+            BUMP_TYPE="$2"
+            shift 2
+            ;;
+        *)
+            echo "Usage: resolve-version.sh [--current | --bump-type patch|minor|major]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Get latest version tag
+LATEST_TAG=$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || echo "v0.0.0")
+CURRENT="${LATEST_TAG#v}"
+
+if [[ "$CURRENT_ONLY" == "true" ]]; then
+    echo "$CURRENT"
+    exit 0
+fi
+
+if [[ -z "$BUMP_TYPE" ]]; then
+    echo "Error: --bump-type or --current required" >&2
+    exit 1
+fi
+
+# Parse semver
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+case "$BUMP_TYPE" in
+    patch)
+        PATCH=$((PATCH + 1))
+        ;;
+    minor)
+        MINOR=$((MINOR + 1))
+        PATCH=0
+        ;;
+    major)
+        MAJOR=$((MAJOR + 1))
+        MINOR=0
+        PATCH=0
+        ;;
+    *)
+        echo "Error: invalid bump type '$BUMP_TYPE' (expected patch, minor, or major)" >&2
+        exit 1
+        ;;
+esac
+
+echo "${MAJOR}.${MINOR}.${PATCH}"

--- a/.github/workflows/cd-v2.yml
+++ b/.github/workflows/cd-v2.yml
@@ -655,7 +655,7 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           preset: housekeeping
-          repositories: console,renet,middleware,elite
+          repositories: console,renet,middleware,elite,account
 
       - name: Cleanup old releases, tags, and packages
         run: .ci/scripts/housekeeping/cleanup-versions.sh
@@ -683,13 +683,7 @@ jobs:
           repositories: console,account
 
       - name: Initialize account submodule
-        run: |
-          # Clear the checkout extraheader (uses housekeeping token without account access)
-          git config --local --unset-all http.https://github.com/.extraheader || true
-          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
-          git submodule update --init private/account
-        env:
-          TOKEN: ${{ steps.app-token-stripe.outputs.token }}
+        run: git submodule update --init private/account
 
       - name: Install account dependencies
         run: npm install

--- a/.github/workflows/cd-v2.yml
+++ b/.github/workflows/cd-v2.yml
@@ -1,26 +1,26 @@
-name: Console CD v2
+name: Console CD
 
-# Publish-only CD workflow triggered when CI completes on main.
-# All builds run in CI; CD only publishes artifacts produced by CI.
-# 1. init: Resolve CI run context, recalculate version, guard against duplicates
-# 2. publish: Promote Docker images, create Release, deploy Pages
+# Publish workflow -- called from CI on push-to-main, or manually.
+# Promotes Docker images, creates git tag + GitHub Release, deploys edge worker.
+# Version comes from git tags (no version bump commits).
 
 on:
-  workflow_run:
-    workflows: ["Console CI"]
-    types: [completed]
-    branches: [main]
-  workflow_dispatch:
+  workflow_call:
     inputs:
-      ci_run_id:
-        description: 'CI workflow run ID to publish from'
+      next_version:
+        description: 'Version to publish (calculated from git tags)'
         required: true
         type: string
-      dry_run:
-        description: 'Dry-run mode (validate without publishing)'
-        required: false
-        type: boolean
-        default: false
+      bump_type:
+        description: 'Bump type (patch, minor, major)'
+        required: true
+        type: string
+      staging_tag:
+        description: 'Docker staging tag to promote'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
       release_mode:
         description: 'Release mode'
         required: true
@@ -52,19 +52,12 @@ jobs:
   init:
     name: Initialize
     runs-on: ubuntu-latest
-    if: >-
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event_name == 'workflow_run'
-        && github.event.workflow_run.conclusion == 'success'
-        && github.event.workflow_run.event == 'push')
     outputs:
-      ci_run_id: ${{ steps.resolve.outputs.ci_run_id }}
-      ci_sha: ${{ steps.resolve.outputs.ci_sha }}
-      next_version: ${{ steps.override.outputs.next_version || steps.version.outputs.next_version || steps.init.outputs.next_version }}
-      bump_type: ${{ steps.override.outputs.bump_type || steps.version.outputs.bump_type || steps.init.outputs.bump_type }}
-      staging_tag: ${{ steps.staging.outputs.staging_tag }}
-      skip_release: ${{ steps.skip-check.outputs.skip_release }}
-      retry_mode: ${{ steps.skip-check.outputs.retry_mode }}
+      next_version: ${{ steps.resolve.outputs.next_version }}
+      bump_type: ${{ steps.resolve.outputs.bump_type }}
+      staging_tag: ${{ steps.resolve.outputs.staging_tag }}
+      skip_release: ${{ steps.resolve.outputs.skip_release }}
+      retry_mode: ${{ steps.resolve.outputs.retry_mode }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
         with:
@@ -154,10 +147,10 @@ jobs:
         if: steps.skip-check.outputs.retry_mode == 'true'
         id: version
         run: |
-          VERSION=$(jq -r '.version' package.json)
+          VERSION=$(.ci/scripts/version/resolve-version.sh --current)
           echo "next_version=$VERSION" >> $GITHUB_OUTPUT
           echo "bump_type=none" >> $GITHUB_OUTPUT
-          echo "::notice::Retry mode: using existing version $VERSION"
+          echo "::notice::Retry mode: using existing version $VERSION (from latest tag)"
 
       # Normal mode: recalculate version from git state
       - name: Initialize CI
@@ -178,7 +171,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch' && inputs.release_mode != 'retry' && inputs.release_mode != 'patch'
         run: |
           BUMP="${{ inputs.release_mode }}"
-          NEXT=$(.ci/scripts/version/bump.sh --${BUMP} --dry-run | tail -n 1)
+          NEXT=$(.ci/scripts/version/resolve-version.sh --bump-type "${BUMP}")
           echo "bump_type=${BUMP}" >> $GITHUB_OUTPUT
           echo "next_version=${NEXT}" >> $GITHUB_OUTPUT
           echo "::notice::Manual bump override: ${BUMP} -> v${NEXT}"
@@ -232,8 +225,6 @@ jobs:
       success() &&
       needs.init.outputs.skip_release != 'true' &&
       !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
-    outputs:
-      pre_bump_version: ${{ steps.pre-bump.outputs.version }}
     environment:
       name: edge
       url: https://edge.rediacc.com
@@ -345,26 +336,28 @@ jobs:
             echo "::warning::Some artifacts lack attestation — this is expected during the transition period"
           fi
 
-      # Detect the actual version baked into the CLI binary (may differ from package.json
-      # if a previous CD run bumped the version after the CI build, or if a squash merge
-      # reset the version). This is the ground truth for install validation.
-      # The CI build workflow applies `bump.sh --version next_version` BEFORE compiling,
-      # so the binary reports next_version. No detection needed -- it matches the version
-      # we're about to publish.
-      - name: Set pre-bump version
-        id: pre-bump
-        run: |
-          echo "version=${{ needs.init.outputs.next_version }}" >> "$GITHUB_OUTPUT"
-          echo "::notice::Binary compiled with version: ${{ needs.init.outputs.next_version }}"
-
-      - name: Version bump
-        if: needs.init.outputs.retry_mode != 'true'
-        run: .ci/scripts/version/bump.sh --version ${{ needs.init.outputs.next_version }}
-
-      - name: Bump submodule versions
+      # Tag-based versioning: create git tag instead of version bump commit.
+      # No file changes needed -- version is injected at build time.
+      - name: Create version tag
         if: needs.init.outputs.retry_mode != 'true'
         run: |
-          .ci/scripts/version/bump-submodules.sh --version ${{ needs.init.outputs.next_version }} --stage-only
+          VERSION="${{ needs.init.outputs.next_version }}"
+          git tag -a "v${VERSION}" -m "v${VERSION}"
+          git push origin "v${VERSION}"
+          echo "::notice::Created tag v${VERSION}"
+
+      - name: Tag submodules
+        if: needs.init.outputs.retry_mode != 'true'
+        run: |
+          VERSION="${{ needs.init.outputs.next_version }}"
+          for sub in private/renet private/middleware; do
+            if [[ -d "$sub/.git" ]] || [[ -f "$sub/.git" ]]; then
+              cd "$sub"
+              git tag -a "v${VERSION}" -m "v${VERSION}" 2>/dev/null || echo "Tag v${VERSION} already exists in $(basename $sub)"
+              git push origin "v${VERSION}" 2>/dev/null || echo "Tag v${VERSION} already pushed in $(basename $sub)"
+              cd "$GITHUB_WORKSPACE"
+            fi
+          done
         env:
           GITHUB_PAT: ${{ steps.app-token.outputs.token }}
 
@@ -374,18 +367,9 @@ jobs:
           .ci/scripts/release/update-homebrew-tap.sh \
             --version ${{ needs.init.outputs.next_version }} \
             --local-checksums dist/cli \
-            --stage-only
+            --push
         env:
           GITHUB_PAT: ${{ steps.app-token.outputs.token }}
-
-      - name: Version commit
-        if: needs.init.outputs.retry_mode != 'true'
-        id: commit
-        run: |
-          .ci/scripts/version/commit.sh --version ${{ needs.init.outputs.next_version }} --bump-type ${{ needs.init.outputs.bump_type }} --push --include-submodules
-          echo "release_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_HEAD_REF: main
 
       # -----------------------------------------------------------------------
       # Step 3: Create GitHub Release (upload packages + binaries)
@@ -396,7 +380,7 @@ jobs:
         with:
           tag_name: v${{ needs.init.outputs.next_version }}
           name: v${{ needs.init.outputs.next_version }}
-          target_commitish: ${{ steps.commit.outputs.release_sha }}
+          target_commitish: ${{ github.sha }}
           files: |
             dist/desktop/**/*
             dist/cli/**/*
@@ -554,7 +538,6 @@ jobs:
     uses: ./.github/workflows/ct-install-methods.yml
     with:
       version: ${{ needs.init.outputs.next_version }}
-      expected_version: ${{ needs.publish.outputs.pre_bump_version }}
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 

--- a/.github/workflows/ci-build-cli.yml
+++ b/.github/workflows/ci-build-cli.yml
@@ -83,11 +83,6 @@ jobs:
           name: renet-binaries-${{ github.sha }}
           path: private/bin/
 
-      - name: Apply version bump
-        if: env.SKIP_THIS != 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        shell: bash
-        run: .ci/scripts/version/bump.sh --version ${{ inputs.next_version }}
-
       # Native build steps (skip for musl — handled inside Docker)
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f  # v6
         if: env.SKIP_THIS != 'true' && matrix.platform != 'linux-musl'
@@ -106,12 +101,16 @@ jobs:
         if: env.SKIP_THIS != 'true' && matrix.platform != 'linux-musl'
         shell: bash
         run: .ci/scripts/build/build-cli-executables.sh --platform ${{ matrix.platform }} --arch ${{ matrix.arch }}
+        env:
+          CLI_VERSION: ${{ inputs.next_version || '0.0.0-dev' }}
 
       # Musl build (runs entire build inside Alpine Docker container)
       - name: Build CLI SEA executable (musl)
         if: env.SKIP_THIS != 'true' && matrix.platform == 'linux-musl'
         shell: bash
         run: .ci/scripts/build/build-cli-musl.sh --arch ${{ matrix.arch }}
+        env:
+          CLI_VERSION: ${{ inputs.next_version || '0.0.0-dev' }}
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
         if: env.SKIP_THIS != 'true'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rediacc-console",
-  "version": "0.8.1",
+  "version": "0.0.0-dev",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/bridge-tests/package.json
+++ b/packages/bridge-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rediacc/bridge-tests",
-  "version": "0.8.1",
+  "version": "0.0.0-dev",
   "private": true,
   "type": "commonjs",
   "scripts": {

--- a/packages/cli/bundle.mjs
+++ b/packages/cli/bundle.mjs
@@ -26,6 +26,7 @@ const result = await esbuild.build({
   logLevel: 'silent',
   define: {
     '__OTLP_AUTH_TOKEN__': JSON.stringify(process.env.OTLP_AUTH_TOKEN || ''),
+    '__CLI_VERSION__': JSON.stringify(process.env.CLI_VERSION || '0.0.0-dev'),
   },
 });
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rediacc/cli",
-  "version": "0.8.1",
+  "version": "0.0.0-dev",
   "type": "module",
   "scripts": {
     "prebuild": "tsx scripts/embed-templates.ts",

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,10 +1,8 @@
 /**
- * Version information for @rediacc/cli package.
- *
- * This file is the single source of truth for the package version.
- * It is updated programmatically during the build/publish process.
+ * CLI version -- injected at build time via esbuild define.
+ * Source of truth: git tags (e.g., v0.8.2).
+ * Dev builds show '0.0.0-dev'.
  */
-
-// This is automatically updated during ./go deploy publish
-// DO NOT modify manually - changes will be overwritten
-export const VERSION = '0.8.1';
+declare const __CLI_VERSION__: string;
+export const VERSION: string =
+  typeof __CLI_VERSION__ !== 'undefined' ? __CLI_VERSION__ : '0.0.0-dev';

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rediacc/desktop",
-  "version": "0.8.1",
+  "version": "0.0.0-dev",
   "private": true,
   "scripts": {
     "build": "electron-vite build",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rediacc/e2e",
-  "version": "0.8.1",
+  "version": "0.0.0-dev",
   "private": true,
   "type": "commonjs",
   "scripts": {

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rediacc/json",
-  "version": "0.8.1",
+  "version": "0.0.0-dev",
   "private": true,
   "scripts": {
     "build": "./generate.sh",

--- a/packages/shared-desktop/package.json
+++ b/packages/shared-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rediacc/shared-desktop",
-  "version": "0.8.1",
+  "version": "0.0.0-dev",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rediacc/shared",
-  "version": "0.8.1",
+  "version": "0.0.0-dev",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rediacc/web",
-  "version": "0.8.1",
+  "version": "0.0.0-dev",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/www/package.json
+++ b/packages/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rediacc/www",
-  "version": "0.8.1",
+  "version": "0.0.0-dev",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Replaces file-based versioning with git-tag-based versioning, fixing the structural problems that caused version mismatch bugs, duplicate CI runs, and install validation failures.

### Phase 0: Bug Fixes
- **Housekeeping auth**: Add `account` to housekeeping token repositories
- **R2 stable channel**: Upload CLI binaries to both `cli/edge/` and `cli/stable/`
- **Quick install**: Remove hardcoded `REDIACC_CHANNEL=edge` from Docker test

### Phase 1: Tag-Based Versioning
- `resolve-version.sh`: Calculate version from git tags (replaces bump.sh --dry-run)
- CLI version injected via esbuild `--define:__CLI_VERSION__` (no file mutation)
- All 10 package.json files set to `0.0.0-dev` placeholder
- Renet version.go: const -> var for ldflags injection
- Middleware .csproj: version placeholder
- initialize.sh uses resolve-version.sh

### Phase 2: CD Git Tags
- Version tag (`v0.8.3`) replaces version bump commit + push
- No more CI retrigger from version commits
- No more `expected_version` workaround (closes #417)
- Submodule tagging without file changes
- Retry mode reads from latest git tag

## Breaking Changes
- Version files are now `0.0.0-dev` placeholders (dev builds show this)
- `bump.sh` / `commit.sh` are deprecated (still exist but unused by CI/CD)
- Requires initial version tag on main before first publish

## Test plan
- [ ] CI builds with correct version from tag
- [ ] Dry-run validation passes
- [ ] Quick Install test passes (stable channel)
- [ ] CD creates git tag (no version commit)
- [ ] Housekeeping submodule clone works
- [ ] `rdc --version` reports correct version