### PR TITLE
fix(ci): cleanup-preview workflow needs app-token for private account submodule

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -17,6 +17,23 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
+        with:
+          sparse-checkout: .github/actions
+
+      - uses: ./.github/actions/app-token
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          preset: ci
+          repositories: console,account
+
+      # Re-checkout with the app token so the later `git submodule update`
+      # can reach the private account repo. Plain actions/checkout above
+      # uses GITHUB_TOKEN which has no access to private sister repos.
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f  # v6
         with:


### PR DESCRIPTION
## Summary

Cleanup PR Preview failed on PR #449's close event ([run 24755214370](https://github.com/rediacc/console/actions/runs/24755214370)) because the workflow ran \`git submodule update --init --depth 1 private/account\` with only \`GITHUB_TOKEN\` — which has no access to the private \`rediacc/account\` repo.

```
fatal: could not read Username for 'https://github.com': No such device or address
fatal: clone of 'https://github.com/rediacc/account.git' into submodule path '…/private/account' failed
```

Every other workflow that touches \`private/account\` (ci.yml, ci-quality.yml, cd-deploy-\*.yml, cd-v2.yml) uses the same pattern: sparse-checkout \`.github/actions\` first to reach \`app-token\`, mint an app token with \`repositories: console,account\`, then re-checkout with that token. Applying the same pattern here.

## Test plan
- [ ] Next PR close triggers this workflow and the submodule clone succeeds.