### PR TITLE
fix(deploy): tolerate missing edge-account-db during edge deploy

### DIFF
--- a/.ci/scripts/deploy/deploy-edge.sh
+++ b/.ci/scripts/deploy/deploy-edge.sh
@@ -36,10 +36,19 @@ fi
 
 log_step "Deploying edge worker (edge.rediacc.com)..."
 
-# Apply migrations to edge D1 (idempotent)
-log_step "Applying migrations to edge-account-db..."
-npx wrangler d1 migrations apply edge-account-db --remote --config wrangler.edge.toml
-log_info "Migrations applied to edge-account-db"
+# Apply migrations to edge D1 (idempotent). Skip gracefully if the DB does
+# not exist -- edge-account-db is the pre-multi-region monolithic edge DB;
+# after the regional rollout (account-db-{eu,us,asia}, edge-account-db-{eu,us,asia})
+# the monolithic DB may have been deleted. The marketing worker's /account/api
+# handler would 500 at runtime in that case, but the deploy itself should not
+# fail. Deferred cleanup tracked separately.
+log_step "Applying migrations to edge-account-db (if it exists)..."
+if npx wrangler d1 info edge-account-db --config wrangler.edge.toml >/dev/null 2>&1; then
+    npx wrangler d1 migrations apply edge-account-db --remote --config wrangler.edge.toml
+    log_info "Migrations applied to edge-account-db"
+else
+    log_warn "edge-account-db not found on this account; skipping migrations (deploy continues)"
+fi
 
 # Deploy edge worker
 npx wrangler deploy --config wrangler.edge.toml

--- a/.ci/scripts/deploy/deploy-edge.sh
+++ b/.ci/scripts/deploy/deploy-edge.sh
@@ -36,18 +36,26 @@ fi
 
 log_step "Deploying edge worker (edge.rediacc.com)..."
 
-# Apply migrations to edge D1 (idempotent). Skip gracefully if the DB does
-# not exist -- edge-account-db is the pre-multi-region monolithic edge DB;
-# after the regional rollout (account-db-{eu,us,asia}, edge-account-db-{eu,us,asia})
-# the monolithic DB may have been deleted. The marketing worker's /account/api
-# handler would 500 at runtime in that case, but the deploy itself should not
-# fail. Deferred cleanup tracked separately.
-log_step "Applying migrations to edge-account-db (if it exists)..."
-if npx wrangler d1 info edge-account-db --config wrangler.edge.toml >/dev/null 2>&1; then
+# Apply migrations to edge D1 (idempotent). Skip gracefully only when the DB
+# genuinely does not exist (CF API 7404) -- edge-account-db is the pre-
+# multi-region monolithic edge DB; after the regional rollout
+# (account-db-{eu,us,asia}, edge-account-db-{eu,us,asia}) the monolithic DB
+# may have been deleted. Auth/network errors still fail the deploy so they
+# are not silently swallowed.
+log_step "Checking edge-account-db existence..."
+D1_INFO_STDERR="$(mktemp)"
+trap 'rm -f "$D1_INFO_STDERR"' EXIT
+if npx wrangler d1 info edge-account-db --config wrangler.edge.toml >/dev/null 2>"$D1_INFO_STDERR"; then
+    log_step "Applying migrations to edge-account-db..."
     npx wrangler d1 migrations apply edge-account-db --remote --config wrangler.edge.toml
     log_info "Migrations applied to edge-account-db"
+elif grep -qE 'code:[[:space:]]*7404|could not be found|Couldn.t find a DB' "$D1_INFO_STDERR"; then
+    log_warn "edge-account-db not found on this account (7404); skipping migrations (deploy continues)"
+    log_warn "Follow-up: recreate the DB or remove the binding from workers/www/wrangler.edge.toml"
 else
-    log_warn "edge-account-db not found on this account; skipping migrations (deploy continues)"
+    log_error "wrangler d1 info failed for a non-404 reason; aborting to avoid silent deploy on auth/network error:"
+    cat "$D1_INFO_STDERR" >&2
+    exit 1
 fi
 
 # Deploy edge worker


### PR DESCRIPTION
## Summary

Follow-up to #451. The v1.0.3 Release workflow failed at `Deploy edge Marketing` because `.ci/scripts/deploy/deploy-edge.sh:41` runs `wrangler d1 migrations apply edge-account-db --remote` unconditionally, and the pre-multi-region monolithic edge DB (UUID `edaa5c46-...` in `workers/www/wrangler.edge.toml`) does not exist on the Cloudflare account. The regional DBs (`edge-account-db-{eu,us,asia}`) deployed fine.

### Change

Make the migration step conditional on `wrangler d1 info` succeeding. If the DB is missing, log a warning and continue with the deploy. The `wrangler deploy` itself does not validate the D1 UUID, so the worker ships regardless.

### Runtime impact

Pre-existing. `/account/api/*` requests hitting `edge.rediacc.com` directly (non-regional) route through `createApp(...).fetch(...)` in `workers/www/src/index.ts:203` which needs `env.DB`. Since the DB is gone, those requests have been returning 500 for however long the DB has been deleted. This PR does not fix that -- it just unblocks the deploy so edge releases can ship again.

### Follow-up options

1. Recreate `edge-account-db` via `wrangler d1 create`, update the UUID in `workers/www/wrangler.edge.toml`, and ensure migrations are applied.
2. Drop `/account/api/*` handling from `workers/www` entirely -- the marketing worker should only serve marketing content and redirect account traffic to the user's regional worker (per `RegionPickerModal` cookie/localStorage).

Option 2 is cleaner for the multi-region model but bigger in scope. Option 1 is a one-time infra fix.

## Test plan

- [ ] Retrigger `Release` workflow with `release_mode=retry` after this merges; `Deploy edge Marketing` should pass.
- [ ] Confirm `wrangler deploy --config wrangler.edge.toml` ships the worker to `edge.rediacc.com`.
- [ ] Smoke test: `/about` -> 410, `/en` -> 200, `/fonts/inter/Inter-Regular.woff2` -> 200, `/` renders correctly.
