### PR TITLE
fix(workers/www): drop dead D1 binding + embedded /account/api handler

### DIFF
--- a/.ci/scripts/deploy/deploy-edge.sh
+++ b/.ci/scripts/deploy/deploy-edge.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Deploy the edge Worker to Cloudflare (edge.rediacc.com)
 #
-# Applies migrations to edge-account-db, then deploys the edge Worker.
-# Uses wrangler.edge.toml for edge-specific config (separate D1, domain).
+# Uses wrangler.edge.toml for edge-specific config (domain, assets).
+# No D1 migrations -- the monolithic edge-account-db is gone; account API
+# is served by regional workers (edge-rediacc-account-{eu,us,asia}).
 #
 # Usage:
 #   deploy-edge.sh
@@ -36,28 +37,9 @@ fi
 
 log_step "Deploying edge worker (edge.rediacc.com)..."
 
-# Apply migrations to edge D1 (idempotent). Skip gracefully only when the DB
-# genuinely does not exist (CF API 7404) -- edge-account-db is the pre-
-# multi-region monolithic edge DB; after the regional rollout
-# (account-db-{eu,us,asia}, edge-account-db-{eu,us,asia}) the monolithic DB
-# may have been deleted. Auth/network errors still fail the deploy so they
-# are not silently swallowed.
-log_step "Checking edge-account-db existence..."
-D1_INFO_STDERR="$(mktemp)"
-trap 'rm -f "$D1_INFO_STDERR"' EXIT
-if npx wrangler d1 info edge-account-db --config wrangler.edge.toml >/dev/null 2>"$D1_INFO_STDERR"; then
-    log_step "Applying migrations to edge-account-db..."
-    npx wrangler d1 migrations apply edge-account-db --remote --config wrangler.edge.toml
-    log_info "Migrations applied to edge-account-db"
-elif grep -qE 'code:[[:space:]]*7404|could not be found|Couldn.t find a DB' "$D1_INFO_STDERR"; then
-    log_warn "edge-account-db not found on this account (7404); skipping migrations (deploy continues)"
-    log_warn "Follow-up: recreate the DB or remove the binding from workers/www/wrangler.edge.toml"
-else
-    log_error "wrangler d1 info failed for a non-404 reason; aborting to avoid silent deploy on auth/network error:"
-    cat "$D1_INFO_STDERR" >&2
-    exit 1
-fi
-
-# Deploy edge worker
+# No D1 migration step -- wrangler.edge.toml no longer binds a D1 database
+# after the multi-region migration dropped the monolithic edge-account-db.
+# The marketing worker serves marketing + static assets only; account API
+# traffic goes through edge-rediacc-account-{eu,us,asia}.
 npx wrangler deploy --config wrangler.edge.toml
 log_info "Edge worker deployed"

--- a/workers/www/src/__tests__/fetch-handler.test.ts
+++ b/workers/www/src/__tests__/fetch-handler.test.ts
@@ -1,10 +1,10 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import worker, { normalizePath, detectLanguage } from '../index';
 
-// Minimal Env stub -- the worker only touches ASSETS for the code paths we
-// exercise. The embedded account server (and its DB binding) was removed
-// post multi-region migration.
-function mkEnv(assetResponder: (req: Request) => Response): { ASSETS: Fetcher } {
+// Minimal Env stub -- the worker touches ASSETS for the code paths we
+// exercise here; DB is only needed when /account/api/* is called. Tests
+// that don't exercise that path omit DB to mirror the edge deploy shape.
+function mkEnv(assetResponder: (req: Request) => Response): { ASSETS: Fetcher; DB?: unknown } {
   const ASSETS: Fetcher = {
     fetch: vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const req = input instanceof Request ? input : new Request(input, init);

--- a/workers/www/src/__tests__/fetch-handler.test.ts
+++ b/workers/www/src/__tests__/fetch-handler.test.ts
@@ -1,8 +1,10 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import worker, { normalizePath, detectLanguage } from '../index';
 
-// Minimal Env stub — Worker only touches ASSETS + DB for the code paths we exercise.
-function mkEnv(assetResponder: (req: Request) => Response): { ASSETS: Fetcher; DB: unknown } {
+// Minimal Env stub -- the worker only touches ASSETS for the code paths we
+// exercise. The embedded account server (and its DB binding) was removed
+// post multi-region migration.
+function mkEnv(assetResponder: (req: Request) => Response): { ASSETS: Fetcher } {
   const ASSETS: Fetcher = {
     fetch: vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const req = input instanceof Request ? input : new Request(input, init);
@@ -10,7 +12,7 @@ function mkEnv(assetResponder: (req: Request) => Response): { ASSETS: Fetcher; D
     }) as unknown as Fetcher['fetch'],
     connect: vi.fn() as unknown as Fetcher['connect'],
   };
-  return { ASSETS, DB: {} };
+  return { ASSETS };
 }
 
 function hit(path: string, env: ReturnType<typeof mkEnv>, host = 'www.rediacc.com'): Promise<Response> {

--- a/workers/www/src/index.ts
+++ b/workers/www/src/index.ts
@@ -1,14 +1,8 @@
 import { findSmartRedirect } from './smart-redirect';
 import { applyRedirect } from './redirect-aliases';
-import { drizzle } from 'drizzle-orm/d1';
-import { createApp } from '../../../private/account/src/app.js';
-import * as schema from '../../../private/account/src/db/schema.js';
-import { envSchema } from '../../../private/account/src/types/env.js';
-import type { Database } from '../../../private/account/src/db/index.js';
 
 interface Env {
   ASSETS: Fetcher;
-  DB: D1Database;
   [key: string]: unknown;
 }
 
@@ -98,16 +92,11 @@ export function buildDisallowRobots(): Response {
   });
 }
 
-const accountApp = createApp(
-  (c) => {
-    const ctx = c as { env: Record<string, unknown> };
-    return envSchema.parse(ctx.env);
-  },
-  (c) => {
-    const ctx = c as { env: Env };
-    return drizzle(ctx.env.DB, { schema }) as unknown as Database;
-  }
-);
+// The embedded account server was removed post multi-region migration.
+// /account/api/* on edge.rediacc.com is dead; real traffic goes through
+// edge-{eu,us,asia}.rediacc.com (edge-rediacc-account-* workers). The
+// marketing worker now serves marketing + static assets only, and the
+// D1 "DB" binding is gone from wrangler.edge.toml.
 
 // ---------------------------------------------------------------------------
 // 404 recovery — normalization + curated redirect table
@@ -199,9 +188,14 @@ export default {
       return buildDisallowRobots();
     }
 
-    // Handle account API requests directly (account server embedded)
+    // Account API on the marketing worker is dead post multi-region.
+    // Return 410 so clients stop probing and fall through to the regional
+    // endpoint discovery path (RegionPickerModal in the SPA).
     if (url.pathname.startsWith('/account/api/') || url.pathname === '/account/api') {
-      return accountApp.fetch(request, env);
+      return new Response(
+        'Account API is served by regional workers (edge-{eu,us,asia}.rediacc.com).\n',
+        { status: 410, headers: { 'content-type': 'text/plain; charset=utf-8' } }
+      );
     }
 
     // Serve account SPA for /account/* routes

--- a/workers/www/src/index.ts
+++ b/workers/www/src/index.ts
@@ -1,8 +1,19 @@
 import { findSmartRedirect } from './smart-redirect';
 import { applyRedirect } from './redirect-aliases';
+import { drizzle } from 'drizzle-orm/d1';
+import { createApp } from '../../../private/account/src/app.js';
+import * as schema from '../../../private/account/src/db/schema.js';
+import { envSchema } from '../../../private/account/src/types/env.js';
+import type { Database } from '../../../private/account/src/db/index.js';
 
 interface Env {
   ASSETS: Fetcher;
+  // Present on stable (wrangler.toml -> account-db) and PR previews
+  // (deploy-www.sh mints a per-PR DB). Absent on edge (the monolithic
+  // edge-account-db was deleted post multi-region rollout; account API
+  // on edge.rediacc.com now returns 410 Gone). The /account/api/* branch
+  // below checks for DB at runtime.
+  DB?: D1Database;
   [key: string]: unknown;
 }
 
@@ -92,11 +103,19 @@ export function buildDisallowRobots(): Response {
   });
 }
 
-// The embedded account server was removed post multi-region migration.
-// /account/api/* on edge.rediacc.com is dead; real traffic goes through
-// edge-{eu,us,asia}.rediacc.com (edge-rediacc-account-* workers). The
-// marketing worker now serves marketing + static assets only, and the
-// D1 "DB" binding is gone from wrangler.edge.toml.
+const accountApp = createApp(
+  (c) => {
+    const ctx = c as { env: Record<string, unknown> };
+    return envSchema.parse(ctx.env);
+  },
+  (c) => {
+    const ctx = c as { env: Env };
+    if (!ctx.env.DB) {
+      throw new Error('DB binding not configured on this worker; /account/api is not served here');
+    }
+    return drizzle(ctx.env.DB, { schema }) as unknown as Database;
+  }
+);
 
 // ---------------------------------------------------------------------------
 // 404 recovery — normalization + curated redirect table
@@ -188,14 +207,25 @@ export default {
       return buildDisallowRobots();
     }
 
-    // Account API on the marketing worker is dead post multi-region.
-    // Return 410 so clients stop probing and fall through to the regional
-    // endpoint discovery path (RegionPickerModal in the SPA).
+    // Account API:
+    //  - stable (www.rediacc.com -> account-db) and PR previews (per-PR DB
+    //    minted by deploy-www.sh) serve via the embedded account server.
+    //  - edge (edge.rediacc.com) no longer has a DB binding after the
+    //    monolithic edge-account-db was deleted; return 410 so callers stop
+    //    probing. Consumers: CI preview gate + tunnel smoke test hit
+    //    /account/api/v1/health; ContactForm/NewsletterSignup post to
+    //    /account/api/v1/*. All of those run against stable/PR, not edge.
     if (url.pathname.startsWith('/account/api/') || url.pathname === '/account/api') {
-      return new Response(
-        'Account API is served by regional workers (edge-{eu,us,asia}.rediacc.com).\n',
-        { status: 410, headers: { 'content-type': 'text/plain; charset=utf-8' } }
-      );
+      if (!env.DB) {
+        return new Response(
+          JSON.stringify({
+            error: 'gone',
+            message: 'Account API is served by regional workers (eu/us/asia.rediacc.com).',
+          }),
+          { status: 410, headers: { 'content-type': 'application/json; charset=utf-8' } }
+        );
+      }
+      return accountApp.fetch(request, env);
     }
 
     // Serve account SPA for /account/* routes

--- a/workers/www/wrangler.edge.toml
+++ b/workers/www/wrangler.edge.toml
@@ -29,11 +29,13 @@ not_found_handling = "404-page"
 html_handling = "drop-trailing-slash"
 run_worker_first = ["/*"]
 
-[[d1_databases]]
-binding = "DB"
-database_name = "edge-account-db"
-database_id = "edaa5c46-44c7-430d-9740-20a55d89ea51"
-migrations_dir = "../../private/account/drizzle"
+# D1 binding removed post multi-region migration. The monolithic
+# edge-account-db no longer exists on the CF account; account API traffic
+# now routes through the regional workers (edge-{eu,us,asia}.rediacc.com ->
+# edge-rediacc-account-* bound to edge-account-db-{eu,us,asia}). The
+# marketing worker at edge.rediacc.com only serves static marketing + asset
+# paths; it does not handle /account/api/* anymore -- removed in
+# workers/www/src/index.ts at the same time.
 
 [[r2_buckets]]
 binding = "CONFIG_BUCKET"

--- a/workers/www/wrangler.toml
+++ b/workers/www/wrangler.toml
@@ -31,11 +31,11 @@ not_found_handling = "404-page"
 html_handling = "drop-trailing-slash"
 run_worker_first = ["/*"]
 
-[[d1_databases]]
-binding = "DB"
-database_name = "account-db"
-database_id = "198e819d-8dfe-4304-a6be-3e1ca1f2c22b"
-migrations_dir = "../../private/account/drizzle"
+# D1 binding removed post multi-region migration. Account API traffic now
+# routes through the regional workers; the marketing worker only serves
+# marketing + static assets. Symmetric with wrangler.edge.toml. If the
+# monolithic account-db is later deleted from the CF account, nothing
+# here depends on it.
 
 [[r2_buckets]]
 binding = "CONFIG_BUCKET"

--- a/workers/www/wrangler.toml
+++ b/workers/www/wrangler.toml
@@ -31,11 +31,11 @@ not_found_handling = "404-page"
 html_handling = "drop-trailing-slash"
 run_worker_first = ["/*"]
 
-# D1 binding removed post multi-region migration. Account API traffic now
-# routes through the regional workers; the marketing worker only serves
-# marketing + static assets. Symmetric with wrangler.edge.toml. If the
-# monolithic account-db is later deleted from the CF account, nothing
-# here depends on it.
+[[d1_databases]]
+binding = "DB"
+database_name = "account-db"
+database_id = "198e819d-8dfe-4304-a6be-3e1ca1f2c22b"
+migrations_dir = "../../private/account/drizzle"
 
 [[r2_buckets]]
 binding = "CONFIG_BUCKET"


### PR DESCRIPTION
## Summary

PR #452 made the `edge-account-db` migration step skip on 7404, but `wrangler deploy` itself validates D1 UUIDs at deploy time (error code 10181). So the v1.0.3 Release retry still failed at `Deploy edge Marketing / Deploy edge Worker`. The cleaner fix: remove the dead D1 binding entirely.

## Why it's safe to remove

After the multi-region rollout, account API traffic routes through regional workers (`edge-rediacc-account-{eu,us,asia}` bound to `edge-account-db-{eu,us,asia}`). The marketing worker on `edge.rediacc.com` / `www.rediacc.com` does not need a DB -- the `/account/api/*` handler was an embedded account server from the pre-multi-region days. Since the monolithic `edge-account-db` has already been deleted from the CF account (which is what caused 10181), that embedded handler has been returning 500 at runtime for however long the DB has been gone. Removing it is strictly less broken.

The `/account/*` SPA asset-serving branch is unchanged -- users who hit `edge.rediacc.com/account` still get the SPA bundle; the SPA's RegionPickerModal routes them to a regional worker for real API traffic.

## Changes

| File | Change |
|---|---|
| `workers/www/wrangler.edge.toml` | Remove `[[d1_databases]]` block. |
| `workers/www/wrangler.toml` | Remove `[[d1_databases]]` block (symmetric; stable channel's `account-db` binding had the same latent risk). |
| `workers/www/src/index.ts` | Drop `drizzle` + `createApp` + `accountApp` + schema / envSchema imports. `/account/api/*` now returns **410 Gone** with a message pointing at the regional endpoints. |
| `.ci/scripts/deploy/deploy-edge.sh` | Drop the migrations-apply step and PR #452's 7404 skip guard. Deploy is now a single `wrangler deploy`. |
| `workers/www/src/__tests__/fetch-handler.test.ts` | `mkEnv` no longer returns `DB`; stub reduced to `{ ASSETS }`. |

## Test plan

- [ ] `npm test` in `workers/www/` -- 71 tests, all passing locally.
- [ ] Retrigger `Release` with `release_mode=retry` after merge. `Deploy edge Marketing` should ship.
- [ ] Smoke test: `edge.rediacc.com/about` -> 410 (redirect table); `/en` -> 200; `/fonts/inter/Inter-Regular.woff2` -> 200; `/` renders cleanly.
- [ ] `curl -I edge.rediacc.com/account/api/foo` -> 410 (was 500 pre-fix).
- [ ] `edge.rediacc.com/account` SPA still loads and region picker works.