### PR TITLE
fix(workers/www): drop dead CONFIG_BUCKET R2 binding

### DIFF
--- a/workers/www/wrangler.edge.toml
+++ b/workers/www/wrangler.edge.toml
@@ -29,13 +29,6 @@ not_found_handling = "404-page"
 html_handling = "drop-trailing-slash"
 run_worker_first = ["/*"]
 
-# No D1 binding. Account API on edge.rediacc.com is served by the regional
-# edge workers (edge-{eu,us,asia}.rediacc.com -> edge-rediacc-account-*
-# bound to edge-account-db-{eu,us,asia}); this worker serves marketing +
-# static assets only.
-
-[[r2_buckets]]
-binding = "CONFIG_BUCKET"
-bucket_name = "edge-rediacc-configs"
-
-# Secrets set via deploy-edge.sh (same crypto keys as production, sandbox Stripe)
+# No D1 or R2 bindings. Account API + config storage on edge.rediacc.com
+# are served by the regional edge workers (edge-{eu,us,asia}.rediacc.com ->
+# edge-rediacc-account-*); this worker serves marketing + static assets only.

--- a/workers/www/wrangler.toml
+++ b/workers/www/wrangler.toml
@@ -31,14 +31,11 @@ not_found_handling = "404-page"
 html_handling = "drop-trailing-slash"
 run_worker_first = ["/*"]
 
-# No D1 binding. Account API on www.rediacc.com is served by the regional
-# workers (eu/us/asia.rediacc.com -> rediacc-account-{eu,us,asia}); this
-# worker serves marketing + static assets only. PR previews get their own
-# DB via deploy-www.sh -> wrangler.preview.toml.
-
-[[r2_buckets]]
-binding = "CONFIG_BUCKET"
-bucket_name = "rediacc-configs"
+# No D1 or R2 bindings. Account API + config storage on www.rediacc.com
+# are served by the regional workers (eu/us/asia.rediacc.com ->
+# rediacc-account-{eu,us,asia}); this worker serves marketing + static
+# assets only. PR previews get their own DB via deploy-www.sh ->
+# wrangler.preview.toml.
 
 # All account env vars set via `wrangler secret put` in CI.
 # See org secrets: ACCOUNT_*, AWS_SES_*, STRIPE_*


### PR DESCRIPTION
Supersedes #455 (same change, clean single-commit history).

Unblocks edge Marketing deploy (CF 10042 on R2 precheck against edge-rediacc-configs). env.CONFIG_BUCKET has no consumer in workers/www/src/index.ts after #453; wrangler's pre-deploy precheck was the only thing touching it.

Accepting the `/account/api/*` 410 on www/edge as called out by reviewer -- account-db was already gone, those endpoints were 500ing pre-PR. Follow-up to route contact/newsletter forms through a regional worker tracked separately.