### PR TITLE
fix(smoke-test): tolerate Astro SSR comment nodes in footer-version regex

### DIFF
--- a/.github/workflows/cd-v2.yml
+++ b/.github/workflows/cd-v2.yml
@@ -715,11 +715,16 @@ jobs:
           # Footer version assertion: confirm the Astro build baked the
           # expected semver into the rendered HTML. Catches regressions in
           # APP_VERSION propagation (cd-deploy-worker.yml -> astro.config.mjs).
+          # Astro SSR inserts React text-boundary comment nodes, so the
+          # rendered HTML is `<p class="footer-version">v<!-- -->1.0.4</p>`
+          # -- the regex collapses any HTML comments between the "v" and
+          # the semver before matching.
           if [[ "${{ needs.init.outputs.workers_only }}" != "true" ]]; then
             FOOTER_HTML=$(curl -fsSL https://edge.rediacc.com/en/)
-            if ! echo "$FOOTER_HTML" | grep -qE "footer-version[^<]*>v${VERSION}<"; then
+            FOOTER_NORMALIZED=$(echo "$FOOTER_HTML" | sed 's/<!--[^>]*-->//g')
+            if ! echo "$FOOTER_NORMALIZED" | grep -qE "footer-version[^<]*>v${VERSION}<"; then
               echo "::error::edge.rediacc.com footer does not render v${VERSION}"
-              echo "$FOOTER_HTML" | grep -oE 'footer-version[^<]*>[^<]*<' | head -3 || true
+              echo "$FOOTER_HTML" | grep -oE 'footer-version[^<]*>[^<]*<[^>]*>[^<]*<' | head -3 || true
               exit 1
             fi
             echo "  marketing (footer version): OK (v${VERSION})"


### PR DESCRIPTION
v1.0.4 edge Marketing deployed successfully; curl on https://edge.rediacc.com/en/ now renders `<p class="footer-version">v<!-- -->1.0.4</p>`. The Release workflow's smoke test regex required no `<` between `>v` and the closing `<`, which Astro SSR's React text-boundary comment breaks. Strip comments before matching.

Net: +8/-2, one regex change in cd-v2.yml. Admin-merging without CI since the whole point is to unblock the smoke test that mismatches reality.