### PR TITLE
feat(ci): sentinel-based release commit contract + drift gate

### DIFF
--- a/.ci/scripts/ci/assert-job-succeeded.sh
+++ b/.ci/scripts/ci/assert-job-succeeded.sh
@@ -46,7 +46,7 @@ case "$RESULT" in
         log_error "  have caught this; investigate why it did not."
         exit 1
         ;;
-    cancelled|failure)
+    cancelled | failure)
         log_warn "${JOB_LABEL} result=${RESULT}; treating as externally-imposed or already-surfaced."
         log_warn "  Sentinel only fails on 'skipped' (the transitive-skip propagation signature)."
         log_warn "  cancelled => CI watchdog, concurrent-push auto-cancel, or manual cancel."

--- a/.ci/scripts/deploy/upload-to-r2.sh
+++ b/.ci/scripts/deploy/upload-to-r2.sh
@@ -219,8 +219,8 @@ r2_rm() {
 source "$SCRIPT_DIR/../lib/release-state-validator.sh"
 
 write_once_guard() {
-    local prefix="$1"    # e.g. "cli/v1.0.5/"
-    local context="$2"   # human label, e.g. "cli v1.0.5"
+    local prefix="$1"  # e.g. "cli/v1.0.5/"
+    local context="$2" # human label, e.g. "cli v1.0.5"
 
     if [[ "$DRY_RUN" == "true" ]]; then
         log_info "[DRY-RUN] sentinel-aware guard would check s3://${RELEASES_BUCKET}/${prefix} (${context})"

--- a/.ci/scripts/deploy/upload-to-r2.sh
+++ b/.ci/scripts/deploy/upload-to-r2.sh
@@ -192,45 +192,67 @@ r2_rm() {
         --endpoint-url "$R2_ENDPOINT" 2>/dev/null || true
 }
 
-# Abort if any object already exists under a versioned prefix on R2.
-# `cli/v${X}/*` and `desktop/v${X}/*` are cache-controlled immutable; writing
-# new bytes at a URL that has already served content breaks that promise and
-# pollutes long-lived CDN caches. resolve-version.sh should always bump
-# next_version past any previously-sealed tag; this is a safety net that
-# refuses the deploy if something upstream drifts.
+# Sentinel-aware write-once guard.
 #
-# Prefix-based (not key-based). The previous key-sentinel variant checked
-# `cli/v${X}/manifest.json` which is never actually written under the CLI
-# loop -- the sentinel stayed absent forever, so the guard silently let
-# retries overwrite binaries. Listing the prefix is robust to which
-# specific files the loop happens to write.
+# A versioned prefix (cli/v${X}/ or desktop/v${X}/) is COMMITTED iff a
+# `.released` sentinel exists under it. The sentinel is written by
+# write-release-sentinel.sh in the finalize-release-sentinel CI job, only
+# after every CI gate passes. See .ci/scripts/lib/release-state-validator.sh
+# for the invariant.
+#
+# Pre-upload logic:
+#   sentinel present       → hard fail (version is sealed; must bump)
+#   prefix empty           → proceed (clean slate)
+#   prefix non-empty + no sentinel → orphan from a cancelled prior run; the
+#                                     invariant says nothing downstream points
+#                                     at it, so we scrub and proceed. This is
+#                                     the recovery path for the #458 drift
+#                                     class where the prior guard would burn
+#                                     the version number forever.
+#
+# The older prefix-existence guard was overbroad: it counted byte uploads as
+# "committed," so a CI cancel between the first upload and the true commit
+# marker permanently blocked the version. The sentinel contract closes that
+# hole — bytes are cheap, the sentinel is the authoritative commit.
+#
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../lib/release-state-validator.sh"
+
 write_once_guard() {
-    local prefix="$1"
-    local context="$2"
+    local prefix="$1"    # e.g. "cli/v1.0.5/"
+    local context="$2"   # human label, e.g. "cli v1.0.5"
 
     if [[ "$DRY_RUN" == "true" ]]; then
-        log_info "[DRY-RUN] write-once guard would check s3://${RELEASES_BUCKET}/${prefix} (${context})"
+        log_info "[DRY-RUN] sentinel-aware guard would check s3://${RELEASES_BUCKET}/${prefix} (${context})"
         return 0
     fi
 
-    # Existence check via list-objects-v2 with --max-items 1. More efficient
-    # than `aws s3 ls` which can fetch a full page before `head -1` sees the
-    # first line; matters for prefixes that could contain many objects.
-    local count
-    count="$(aws s3api list-objects-v2 \
-        --bucket "${RELEASES_BUCKET}" \
-        --prefix "${prefix}" \
-        --max-items 1 \
-        --endpoint-url "$R2_ENDPOINT" \
-        --query 'KeyCount' \
-        --output text 2>/dev/null || echo 0)"
-    if [[ "$count" != "0" && "$count" != "None" ]]; then
-        log_error "Write-once guard blocked: s3://${RELEASES_BUCKET}/${prefix} is non-empty."
-        log_error "  A previous deploy of ${context} sealed this prefix; overwriting would break"
-        log_error "  the immutable-URL promise and poison long-lived CDN caches."
-        log_error "  resolve-version.sh should have bumped next_version. If you truly need to"
-        log_error "  replace the artifact, scrub it via scripts/dev/r2-oneshot-scrub.sh first."
+    # Parse product and version from prefix like "cli/v1.0.5/" → product=cli, version=v1.0.5.
+    local product version
+    product="${prefix%%/*}"
+    version="${prefix#*/}"
+    version="${version%/}"
+
+    if rsv_sentinel_exists "$product" "$version"; then
+        log_error "Write-once guard blocked: s3://${RELEASES_BUCKET}/${prefix} is sealed."
+        log_error "  A prior run completed the full release flow for ${context} and wrote the"
+        log_error "  .released sentinel. Overwriting would break the immutable-URL promise and"
+        log_error "  poison long-lived CDN caches."
+        log_error "  resolve-version.sh should have bumped next_version past this tag. If you"
+        log_error "  truly need to replace this release, scrub it via"
+        log_error "  scripts/dev/scrub-sentinel.sh ${version} --execute."
         exit 1
+    fi
+
+    # No sentinel — either a clean prefix or an orphan from a cancelled run.
+    if rsv_prefix_nonempty "$prefix"; then
+        log_warn "Orphan prefix detected at s3://${RELEASES_BUCKET}/${prefix} (no .released sentinel)."
+        log_warn "  A prior CI run uploaded bytes here but was cancelled before finalize"
+        log_warn "  sealed the version. Scrubbing orphan bytes so this run can upload cleanly."
+        aws s3 rm "s3://${RELEASES_BUCKET}/${prefix}" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --recursive
+        log_info "  orphan bytes removed; proceeding with upload"
     fi
 }
 

--- a/.ci/scripts/deploy/write-release-sentinel.sh
+++ b/.ci/scripts/deploy/write-release-sentinel.sh
@@ -43,17 +43,41 @@ INCLUDE_DESKTOP=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --version) VERSION="${2:-}"; shift 2 ;;
-        --channel) CHANNEL="${2:-}"; shift 2 ;;
-        --commit-sha) COMMIT_SHA="${2:-}"; shift 2 ;;
-        --desktop) INCLUDE_DESKTOP=true; shift ;;
-        *) log_error "unknown flag: $1"; exit 2 ;;
+        --version)
+            VERSION="${2:-}"
+            shift 2
+            ;;
+        --channel)
+            CHANNEL="${2:-}"
+            shift 2
+            ;;
+        --commit-sha)
+            COMMIT_SHA="${2:-}"
+            shift 2
+            ;;
+        --desktop)
+            INCLUDE_DESKTOP=true
+            shift
+            ;;
+        *)
+            log_error "unknown flag: $1"
+            exit 2
+            ;;
     esac
 done
 
-[[ -z "$VERSION" ]] && { log_error "--version required"; exit 2; }
-[[ -z "$CHANNEL" ]] && { log_error "--channel required"; exit 2; }
-[[ -z "$COMMIT_SHA" ]] && { log_error "--commit-sha required"; exit 2; }
+[[ -z "$VERSION" ]] && {
+    log_error "--version required"
+    exit 2
+}
+[[ -z "$CHANNEL" ]] && {
+    log_error "--channel required"
+    exit 2
+}
+[[ -z "$COMMIT_SHA" ]] && {
+    log_error "--commit-sha required"
+    exit 2
+}
 if [[ "$CHANNEL" != "edge" && "$CHANNEL" != "stable" ]]; then
     log_error "sentinel write is only valid on release channels (edge|stable); got: $CHANNEL"
     exit 2
@@ -101,8 +125,8 @@ write_sentinel() {
     payload="$(build_payload "$product")"
 
     log_step "writing sentinel: s3://${RSV_BUCKET}/${key}"
-    echo -n "$payload" \
-        | aws s3 cp - "s3://${RSV_BUCKET}/${key}" \
+    echo -n "$payload" |
+        aws s3 cp - "s3://${RSV_BUCKET}/${key}" \
             --endpoint-url "$R2_ENDPOINT" \
             --cache-control "no-cache" \
             --content-type "application/json"

--- a/.ci/scripts/deploy/write-release-sentinel.sh
+++ b/.ci/scripts/deploy/write-release-sentinel.sh
@@ -125,7 +125,9 @@ write_sentinel() {
     payload="$(build_payload "$product")"
 
     log_step "writing sentinel: s3://${RSV_BUCKET}/${key}"
-    echo -n "$payload" |
+    # printf '%s' over echo -n for portability: echo -n handling varies by
+    # shell/platform, printf is POSIX-guaranteed.
+    printf '%s' "$payload" |
         aws s3 cp - "s3://${RSV_BUCKET}/${key}" \
             --endpoint-url "$R2_ENDPOINT" \
             --cache-control "no-cache" \

--- a/.ci/scripts/deploy/write-release-sentinel.sh
+++ b/.ci/scripts/deploy/write-release-sentinel.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# Write the `.released` commit sentinels for a release.
+#
+# This is the ATOMIC COMMIT POINT of the release pipeline. It runs from the
+# finalize-release-sentinel CI job, AFTER every gate that must pass before a
+# version is considered released (stage-artifacts, validate-install,
+# validate-promote, all test suites). Writing the sentinel seals the version:
+# from this point on, write_once_guard in upload-to-r2.sh refuses to overwrite
+# the bytes, and the drift gate requires a matching git tag.
+#
+# See .ci/scripts/lib/release-state-validator.sh for the invariant.
+#
+# Usage:
+#   write-release-sentinel.sh --version 1.0.5 --channel edge --commit-sha <sha> \
+#     [--desktop]
+#
+# Flags:
+#   --version      (required) Semver version WITHOUT the leading `v`.
+#   --channel      (required) Release channel: edge | stable.
+#   --commit-sha   (required) Git commit SHA that produced the artifacts.
+#   --desktop      Emit desktop sentinel in addition to cli (platform-aware CI
+#                  sets this only if desktop artifacts were produced).
+#
+# Env (required):
+#   R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_ENDPOINT
+#   RELEASES_BUCKET (optional, default rediacc-releases)
+#
+# Exit 0 on successful write + readback of every sentinel. Exit 1 on any
+# failure — no partial commit. The finalize job must fail loud so the next
+# CI run's pre-upload scrub can recover from the orphaned state.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/../lib/common.sh"
+# shellcheck source=../lib/release-state-validator.sh
+source "$SCRIPT_DIR/../lib/release-state-validator.sh"
+
+VERSION=""
+CHANNEL=""
+COMMIT_SHA=""
+INCLUDE_DESKTOP=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --version) VERSION="${2:-}"; shift 2 ;;
+        --channel) CHANNEL="${2:-}"; shift 2 ;;
+        --commit-sha) COMMIT_SHA="${2:-}"; shift 2 ;;
+        --desktop) INCLUDE_DESKTOP=true; shift ;;
+        *) log_error "unknown flag: $1"; exit 2 ;;
+    esac
+done
+
+[[ -z "$VERSION" ]] && { log_error "--version required"; exit 2; }
+[[ -z "$CHANNEL" ]] && { log_error "--channel required"; exit 2; }
+[[ -z "$COMMIT_SHA" ]] && { log_error "--commit-sha required"; exit 2; }
+if [[ "$CHANNEL" != "edge" && "$CHANNEL" != "stable" ]]; then
+    log_error "sentinel write is only valid on release channels (edge|stable); got: $CHANNEL"
+    exit 2
+fi
+
+require_cmd aws
+require_cmd jq
+require_var R2_ACCESS_KEY_ID
+require_var R2_SECRET_ACCESS_KEY
+require_var R2_ENDPOINT
+export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+export AWS_DEFAULT_REGION="auto"
+
+VERSION_TAG="v${VERSION}"
+
+# Payload intentionally includes what a post-hoc forensic sweep needs to
+# reconstruct what CI intended: channel, commit, timestamp, and which product
+# prefixes were populated this run.
+build_payload() {
+    local product="$1"
+    jq -nc \
+        --arg version "$VERSION_TAG" \
+        --arg channel "$CHANNEL" \
+        --arg commit "$COMMIT_SHA" \
+        --arg product "$product" \
+        --arg released_at "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+        --argjson include_desktop "$INCLUDE_DESKTOP" \
+        '{
+            version: $version,
+            channel: $channel,
+            commit_sha: $commit,
+            product: $product,
+            released_at: $released_at,
+            artifacts_produced: (
+                ["cli"] + (if $include_desktop then ["desktop"] else [] end)
+            )
+        }'
+}
+
+write_sentinel() {
+    local product="$1"
+    local key="${product}/${VERSION_TAG}/${RSV_SENTINEL_KEY}"
+    local payload
+    payload="$(build_payload "$product")"
+
+    log_step "writing sentinel: s3://${RSV_BUCKET}/${key}"
+    echo -n "$payload" \
+        | aws s3 cp - "s3://${RSV_BUCKET}/${key}" \
+            --endpoint-url "$R2_ENDPOINT" \
+            --cache-control "no-cache" \
+            --content-type "application/json"
+
+    # Readback verification — do not trust a silent upload.
+    local readback
+    readback="$(rsv_get_sentinel_payload "$product" "$VERSION_TAG")"
+    if [[ -z "$readback" ]]; then
+        log_error "sentinel readback failed: s3://${RSV_BUCKET}/${key} is missing immediately after write"
+        return 1
+    fi
+    # Compare the version field; the timestamp may differ by seconds on R2.
+    local wanted_v got_v
+    wanted_v="$(jq -r '.version' <<<"$payload")"
+    got_v="$(jq -r '.version' <<<"$readback")"
+    if [[ "$wanted_v" != "$got_v" ]]; then
+        log_error "sentinel readback content mismatch at s3://${RSV_BUCKET}/${key}"
+        log_error "  wrote version=${wanted_v}, read back version=${got_v}"
+        return 1
+    fi
+    log_info "  sealed ${product}/${VERSION_TAG}/${RSV_SENTINEL_KEY}"
+}
+
+# Order matters: cli FIRST, desktop SECOND. The bijection assertion permits
+# cli-only (desktop absent) but forbids desktop-only (the library enforces
+# `desktop sentinel ⇒ cli sentinel`). Writing cli first keeps the half-written
+# state benign: a cancel between the two writes leaves cli committed and
+# desktop orphaned, which the drift gate flags as drift (not as a silent pass).
+
+write_sentinel cli
+
+if [[ "$INCLUDE_DESKTOP" == "true" ]]; then
+    write_sentinel desktop
+else
+    log_info "desktop sentinel skipped (--desktop not set)"
+fi
+
+log_info "release ${VERSION_TAG} on ${CHANNEL} is sealed"

--- a/.ci/scripts/housekeeping/cleanup-versions.sh
+++ b/.ci/scripts/housekeeping/cleanup-versions.sh
@@ -962,45 +962,56 @@ cleanup_r2() {
         fi
     done
 
-    # 8d. Orphan v<semver>/ under cli/ and desktop/ --------------------------
-    log_step "  8d: orphan v<semver>/ with no tracker entry and no git tag"
-    local git_tags
-    git_tags="$(gh api "repos/${RELEASE_REPO}/tags" --paginate --jq '.[].name' 2>/dev/null | grep -E '^v[0-9]' || true)"
-    local orphan_ver_deleted=0
+    # 8d. Sentinel-aware orphan v<semver>/ sweep + drift detection ------------
+    # Source of truth: cli/v${V}/.released sentinel (see
+    # .ci/scripts/lib/release-state-validator.sh). Rules:
+    #   sentinel AND git tag → committed release, keep.
+    #   no sentinel AND no git tag → orphan from a cancelled CI run, delete.
+    #   sentinel XOR git tag → drift, do NOT auto-delete. Emit a GHA error
+    #     annotation so humans investigate; the drift gate (runs per push)
+    #     would have caught this too, but housekeeping double-checks.
+    log_step "  8d: sentinel-aware orphan sweep + drift detection"
+    # shellcheck source=../lib/release-state-validator.sh
+    source "${SCRIPT_DIR}/../lib/release-state-validator.sh"
+    local git_tags drift_count=0 orphan_ver_deleted=0
+    git_tags="$(gh api "repos/${RELEASE_REPO}/tags" --paginate --jq '.[].name' 2>/dev/null | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)"
     for dir in "cli" "desktop"; do
-        local tracker
-        tracker="$(aws s3 cp "s3://${R2_BUCKET}/${dir}/versions.json" - \
-            --endpoint-url "$R2_ENDPOINT" 2>/dev/null || echo "[]")"
-        [[ -z "$tracker" ]] && tracker="[]"
         while IFS= read -r line; do
             local sub
             sub="$(echo "$line" | awk '/^[[:space:]]*PRE[[:space:]]v[0-9]+\./ {print $2}')"
             [[ -z "$sub" ]] && continue
-            local ver="${sub#v}"
-            ver="${ver%/}"
-            local tag="v${ver}"
-            # Keep if in tracker
-            if echo "$tracker" | jq -e --arg v "$ver" 'index($v) != null' >/dev/null 2>&1; then
-                continue
+            local ver="${sub%/}"                 # v1.2.3
+            [[ "$ver" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || continue
+
+            local has_sentinel=0 has_tag=0
+            rsv_sentinel_exists "$dir" "$ver" && has_sentinel=1
+            grep -qxF "$ver" <<<"$git_tags" && has_tag=1
+
+            if (( has_sentinel && has_tag )); then
+                continue  # committed release
             fi
-            # Keep if a git tag exists
-            if echo "$git_tags" | grep -qxF "$tag"; then
-                continue
-            fi
-            local prefix="${dir}/${sub}"
-            local last
-            last="$(r2_prefix_last_modified "$prefix")"
-            [[ -z "$last" ]] && continue
-            local last_epoch
-            last_epoch="$(date -u -d "$last" +%s 2>/dev/null || echo 0)"
-            [[ "$last_epoch" -eq 0 ]] && continue
-            if ((now_epoch - last_epoch > orphan_ver_max_age)); then
-                r2_rm_recursive "$prefix" "orphan ${tag} (not in versions.json, no git tag)"
+            if (( !has_sentinel && !has_tag )); then
+                r2_rm_recursive "${dir}/${ver}/" "orphan ${dir}/${ver} (no .released sentinel, no git tag)"
                 orphan_ver_deleted=$((orphan_ver_deleted + 1))
+                continue
             fi
+            # Drift: exactly one of sentinel/tag is present. Do not auto-heal.
+            if (( has_sentinel )); then
+                log_error "drift: ${dir}/${ver}/.released exists but git tag ${ver} missing"
+                log_error "  remediation: re-run CD to tag/release ${ver}, or scrub via scripts/dev/scrub-sentinel.sh ${ver} --execute"
+            else
+                log_error "drift: git tag ${ver} exists but ${dir}/${ver}/.released missing"
+                log_error "  remediation: re-run CI for ${ver}, or delete tag ${ver}"
+            fi
+            drift_count=$((drift_count + 1))
         done < <(r2_ls_prefix "${dir}/")
     done
-    log_info "  8d: deleted $orphan_ver_deleted orphan versioned prefix(es)"
+    log_info "  8d: deleted $orphan_ver_deleted orphan versioned prefix(es); found $drift_count drift finding(s)"
+    if (( drift_count > 0 )); then
+        log_error "  8d: release-state drift detected; housekeeping refuses to auto-heal"
+        log_error "  8d: see drift lines above for remediation"
+        return 1
+    fi
 
     # 8f. Channel artifact retention ----------------------------------------
     # Every release appends to <fmt>/<channel>/ without ever removing the

--- a/.ci/scripts/housekeeping/cleanup-versions.sh
+++ b/.ci/scripts/housekeeping/cleanup-versions.sh
@@ -980,23 +980,23 @@ cleanup_r2() {
             local sub
             sub="$(echo "$line" | awk '/^[[:space:]]*PRE[[:space:]]v[0-9]+\./ {print $2}')"
             [[ -z "$sub" ]] && continue
-            local ver="${sub%/}"                 # v1.2.3
+            local ver="${sub%/}" # v1.2.3
             [[ "$ver" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || continue
 
             local has_sentinel=0 has_tag=0
             rsv_sentinel_exists "$dir" "$ver" && has_sentinel=1
             grep -qxF "$ver" <<<"$git_tags" && has_tag=1
 
-            if (( has_sentinel && has_tag )); then
-                continue  # committed release
+            if ((has_sentinel && has_tag)); then
+                continue # committed release
             fi
-            if (( !has_sentinel && !has_tag )); then
+            if ((!has_sentinel && !has_tag)); then
                 r2_rm_recursive "${dir}/${ver}/" "orphan ${dir}/${ver} (no .released sentinel, no git tag)"
                 orphan_ver_deleted=$((orphan_ver_deleted + 1))
                 continue
             fi
             # Drift: exactly one of sentinel/tag is present. Do not auto-heal.
-            if (( has_sentinel )); then
+            if ((has_sentinel)); then
                 log_error "drift: ${dir}/${ver}/.released exists but git tag ${ver} missing"
                 log_error "  remediation: re-run CD to tag/release ${ver}, or scrub via scripts/dev/scrub-sentinel.sh ${ver} --execute"
             else
@@ -1007,7 +1007,7 @@ cleanup_r2() {
         done < <(r2_ls_prefix "${dir}/")
     done
     log_info "  8d: deleted $orphan_ver_deleted orphan versioned prefix(es); found $drift_count drift finding(s)"
-    if (( drift_count > 0 )); then
+    if ((drift_count > 0)); then
         log_error "  8d: release-state drift detected; housekeeping refuses to auto-heal"
         log_error "  8d: see drift lines above for remediation"
         return 1

--- a/.ci/scripts/housekeeping/cleanup-versions.sh
+++ b/.ci/scripts/housekeeping/cleanup-versions.sh
@@ -975,7 +975,18 @@ cleanup_r2() {
     source "${SCRIPT_DIR}/../lib/release-state-validator.sh"
     local git_tags drift_count=0 orphan_ver_deleted=0
     git_tags="$(gh api "repos/${RELEASE_REPO}/tags" --paginate --jq '.[].name' 2>/dev/null | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)"
+    # Pre-load sentinel and tag sets into associative arrays for O(1) lookup —
+    # otherwise rsv_sentinel_exists per version issues an aws head-object for
+    # every prefix (N+1 calls), and grep-per-version is O(N^2).
+    declare -A tag_set
+    while IFS= read -r t; do
+        [[ -n "$t" ]] && tag_set["$t"]=1
+    done <<<"$git_tags"
     for dir in "cli" "desktop"; do
+        declare -A sentinel_set=()
+        while IFS= read -r s; do
+            [[ -n "$s" ]] && sentinel_set["$s"]=1
+        done < <(rsv_list_sentinels "$dir")
         while IFS= read -r line; do
             local sub
             sub="$(echo "$line" | awk '/^[[:space:]]*PRE[[:space:]]v[0-9]+\./ {print $2}')"
@@ -984,8 +995,8 @@ cleanup_r2() {
             [[ "$ver" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || continue
 
             local has_sentinel=0 has_tag=0
-            rsv_sentinel_exists "$dir" "$ver" && has_sentinel=1
-            grep -qxF "$ver" <<<"$git_tags" && has_tag=1
+            [[ -n "${sentinel_set[$ver]:-}" ]] && has_sentinel=1
+            [[ -n "${tag_set[$ver]:-}" ]] && has_tag=1
 
             if ((has_sentinel && has_tag)); then
                 continue # committed release

--- a/.ci/scripts/lib/release-state-validator.sh
+++ b/.ci/scripts/lib/release-state-validator.sh
@@ -133,6 +133,20 @@ rsv_assert_bijection() {
         grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
         sort -uV)"
 
+    # Associative-array sets give O(1) membership tests; grep-per-version
+    # scaled as O(N^2) across the full release history.
+    declare -A cli_set=() desktop_set=() tag_set=()
+    local v
+    while IFS= read -r v; do
+        [[ -n "$v" ]] && cli_set["$v"]=1
+    done <<<"$cli_versions"
+    while IFS= read -r v; do
+        [[ -n "$v" ]] && desktop_set["$v"]=1
+    done <<<"$desktop_versions"
+    while IFS= read -r v; do
+        [[ -n "$v" ]] && tag_set["$v"]=1
+    done <<<"$tag_versions"
+
     local version has_cli has_desktop has_tag
     while IFS= read -r version; do
         [[ -z "$version" ]] && continue
@@ -141,9 +155,9 @@ rsv_assert_bijection() {
         has_cli=0
         has_desktop=0
         has_tag=0
-        grep -qxF "$version" <<<"$cli_versions" && has_cli=1
-        grep -qxF "$version" <<<"$desktop_versions" && has_desktop=1
-        grep -qxF "$version" <<<"$tag_versions" && has_tag=1
+        [[ -n "${cli_set[$version]:-}" ]] && has_cli=1
+        [[ -n "${desktop_set[$version]:-}" ]] && has_desktop=1
+        [[ -n "${tag_set[$version]:-}" ]] && has_tag=1
 
         if ((has_cli != has_tag)); then
             if ((has_cli)); then

--- a/.ci/scripts/lib/release-state-validator.sh
+++ b/.ci/scripts/lib/release-state-validator.sh
@@ -45,18 +45,18 @@ rsv_list_sentinels() {
         --prefix "${product}/v" \
         --endpoint-url "$R2_ENDPOINT" \
         --query "Contents[?ends_with(Key, \`/${RSV_SENTINEL_KEY}\`)].Key" \
-        --output text 2>/dev/null \
-        | tr '\t' '\n' \
-        | sed -n "s|^${product}/\(v[0-9][0-9.]*\)/${RSV_SENTINEL_KEY}\$|\1|p" \
-        | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-        | sort -uV
+        --output text 2>/dev/null |
+        tr '\t' '\n' |
+        sed -n "s|^${product}/\(v[0-9][0-9.]*\)/${RSV_SENTINEL_KEY}\$|\1|p" |
+        grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
+        sort -uV
 }
 
 # List every strict-semver git tag (v${X}.${Y}.${Z}); pre-release tags skipped.
 rsv_list_git_tags() {
-    git tag -l 'v*' \
-        | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-        | sort -uV
+    git tag -l 'v*' |
+        grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
+        sort -uV
 }
 
 # `0` if the R2 prefix contains at least one object.
@@ -89,8 +89,8 @@ rsv_sentinel_exists() {
 rsv_is_orphan() {
     local product="${1:?product required}"
     local version="${2:?version required}"
-    rsv_prefix_nonempty "${product}/${version}/" \
-        && ! rsv_sentinel_exists "$product" "$version"
+    rsv_prefix_nonempty "${product}/${version}/" &&
+        ! rsv_sentinel_exists "$product" "$version"
 }
 
 # Fetch and emit the JSON payload of `${product}/${version}/.released`.
@@ -129,22 +129,24 @@ rsv_assert_bijection() {
     local in_flight="${4:-}"
 
     local all drift=0
-    all="$(printf '%s\n%s\n%s\n' "$cli_versions" "$desktop_versions" "$tag_versions" \
-        | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-        | sort -uV)"
+    all="$(printf '%s\n%s\n%s\n' "$cli_versions" "$desktop_versions" "$tag_versions" |
+        grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
+        sort -uV)"
 
     local version has_cli has_desktop has_tag
     while IFS= read -r version; do
         [[ -z "$version" ]] && continue
         [[ -n "$in_flight" && "$version" == "$in_flight" ]] && continue
 
-        has_cli=0; has_desktop=0; has_tag=0
+        has_cli=0
+        has_desktop=0
+        has_tag=0
         grep -qxF "$version" <<<"$cli_versions" && has_cli=1
         grep -qxF "$version" <<<"$desktop_versions" && has_desktop=1
         grep -qxF "$version" <<<"$tag_versions" && has_tag=1
 
-        if (( has_cli != has_tag )); then
-            if (( has_cli )); then
+        if ((has_cli != has_tag)); then
+            if ((has_cli)); then
                 echo "DRIFT ${version}: cli sentinel present, git tag missing"
                 echo "  remediation: re-run CD to tag/release ${version}, or scrub the sentinel via scripts/dev/scrub-sentinel.sh ${version}"
             else
@@ -154,14 +156,14 @@ rsv_assert_bijection() {
             drift=1
         fi
 
-        if (( has_desktop && !has_cli )); then
+        if ((has_desktop && !has_cli)); then
             echo "DRIFT ${version}: desktop sentinel present, cli sentinel missing"
             echo "  remediation: inspect desktop/${version}/.released payload and reconcile; desktop should never release without cli"
             drift=1
         fi
     done <<<"$all"
 
-    if (( drift == 0 )); then
+    if ((drift == 0)); then
         echo "OK: release-state bijection holds (excluding in-flight ${in_flight:-<none>})"
         return 0
     fi

--- a/.ci/scripts/lib/release-state-validator.sh
+++ b/.ci/scripts/lib/release-state-validator.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# Release-state validator library.
+#
+# Single source of truth for the sentinel-based release-commit contract:
+#
+#   Committed(v${V}) ⇔
+#       cli/v${V}/.released      exists
+#     ∧ desktop/v${V}/.released  exists (when desktop artifacts were produced)
+#     ∧ git tag v${V}            exists
+#
+# Channel pointers (latest.json, manifest.json, Packages.gz, etc.) only ever
+# reference committed versions. `.released` sentinels are the commit markers;
+# they are written LAST, after every CI gate has passed. A prefix that is
+# non-empty but missing its sentinel is an orphan from a cancelled run and is
+# always safe to scrub.
+#
+# Sourced by:
+#   .ci/scripts/quality/check-release-state.sh           (the BLOCKER drift gate)
+#   .ci/scripts/deploy/upload-to-r2.sh                   (pre-upload orphan scrub)
+#   .ci/scripts/deploy/write-release-sentinel.sh         (commit-phase writer)
+#   .ci/scripts/housekeeping/cleanup-versions.sh         (Phase 8d orphan sweep)
+#   .github/workflows/cleanup-on-ci-cancel.yml           (belt-and-suspenders)
+#
+# The library is pure-bash and makes AWS / git calls lazily. Callers that want
+# to test the assertion logic should feed `rsv_assert_bijection` synthetic
+# version lists rather than shimming AWS.
+
+[[ -n "${__RELEASE_STATE_VALIDATOR_SH_SOURCED:-}" ]] && return 0
+readonly __RELEASE_STATE_VALIDATOR_SH_SOURCED=1
+
+RSV_BUCKET="${RELEASES_BUCKET:-rediacc-releases}"
+RSV_SENTINEL_KEY=".released"
+
+# =============================================================================
+# Live probes (AWS + git)
+# =============================================================================
+
+# List every `.released` sentinel under `${product}/v*/` on R2.
+# Emits one `v${VERSION}` per line, semver-sorted.
+# Requires: AWS env + R2_ENDPOINT.
+rsv_list_sentinels() {
+    local product="${1:?product (cli|desktop) required}"
+    aws s3api list-objects-v2 \
+        --bucket "$RSV_BUCKET" \
+        --prefix "${product}/v" \
+        --endpoint-url "$R2_ENDPOINT" \
+        --query "Contents[?ends_with(Key, \`/${RSV_SENTINEL_KEY}\`)].Key" \
+        --output text 2>/dev/null \
+        | tr '\t' '\n' \
+        | sed -n "s|^${product}/\(v[0-9][0-9.]*\)/${RSV_SENTINEL_KEY}\$|\1|p" \
+        | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+        | sort -uV
+}
+
+# List every strict-semver git tag (v${X}.${Y}.${Z}); pre-release tags skipped.
+rsv_list_git_tags() {
+    git tag -l 'v*' \
+        | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+        | sort -uV
+}
+
+# `0` if the R2 prefix contains at least one object.
+rsv_prefix_nonempty() {
+    local prefix="${1:?prefix required}"
+    local count
+    count="$(aws s3api list-objects-v2 \
+        --bucket "$RSV_BUCKET" \
+        --prefix "$prefix" \
+        --max-items 1 \
+        --endpoint-url "$R2_ENDPOINT" \
+        --query 'KeyCount' \
+        --output text 2>/dev/null || echo 0)"
+    [[ "$count" != "0" && "$count" != "None" ]]
+}
+
+# `0` if `${product}/${version}/.released` exists on R2.
+rsv_sentinel_exists() {
+    local product="${1:?product required}"
+    local version="${2:?version required}"
+    aws s3api head-object \
+        --bucket "$RSV_BUCKET" \
+        --key "${product}/${version}/${RSV_SENTINEL_KEY}" \
+        --endpoint-url "$R2_ENDPOINT" \
+        >/dev/null 2>&1
+}
+
+# `0` if the versioned prefix is an orphan: bytes present, no sentinel.
+# Orphans are always safe to scrub.
+rsv_is_orphan() {
+    local product="${1:?product required}"
+    local version="${2:?version required}"
+    rsv_prefix_nonempty "${product}/${version}/" \
+        && ! rsv_sentinel_exists "$product" "$version"
+}
+
+# Fetch and emit the JSON payload of `${product}/${version}/.released`.
+# Empty stdout if the sentinel does not exist.
+rsv_get_sentinel_payload() {
+    local product="${1:?product required}"
+    local version="${2:?version required}"
+    aws s3 cp "s3://${RSV_BUCKET}/${product}/${version}/${RSV_SENTINEL_KEY}" - \
+        --endpoint-url "$R2_ENDPOINT" 2>/dev/null || true
+}
+
+# =============================================================================
+# Assertion (pure; no I/O — feed strings)
+# =============================================================================
+
+# Assert the bijection: for every strict-semver version seen in any of the
+# three inputs, require either all three (committed) or none (absent). Desktop
+# sentinel is optional but must not appear without a matching cli sentinel
+# (desktop ⇒ cli is an invariant of the writer).
+#
+# Usage:
+#   rsv_assert_bijection <cli_versions> <desktop_versions> <tag_versions> [in_flight]
+#
+# Each input is a newline-separated list of `v${X}.${Y}.${Z}` values. Callers
+# should usually feed the outputs of rsv_list_sentinels / rsv_list_git_tags.
+# `in_flight` is the one version currently being built by this CI run; it is
+# excluded so the gate does not false-positive on its own in-flight release.
+#
+# Stdout: human-readable DRIFT lines, one finding per line, followed by an
+# `OK` line when there is no drift.
+# Exit: 0 on bijection, 1 on any drift finding.
+rsv_assert_bijection() {
+    local cli_versions="$1"
+    local desktop_versions="$2"
+    local tag_versions="$3"
+    local in_flight="${4:-}"
+
+    local all drift=0
+    all="$(printf '%s\n%s\n%s\n' "$cli_versions" "$desktop_versions" "$tag_versions" \
+        | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+        | sort -uV)"
+
+    local version has_cli has_desktop has_tag
+    while IFS= read -r version; do
+        [[ -z "$version" ]] && continue
+        [[ -n "$in_flight" && "$version" == "$in_flight" ]] && continue
+
+        has_cli=0; has_desktop=0; has_tag=0
+        grep -qxF "$version" <<<"$cli_versions" && has_cli=1
+        grep -qxF "$version" <<<"$desktop_versions" && has_desktop=1
+        grep -qxF "$version" <<<"$tag_versions" && has_tag=1
+
+        if (( has_cli != has_tag )); then
+            if (( has_cli )); then
+                echo "DRIFT ${version}: cli sentinel present, git tag missing"
+                echo "  remediation: re-run CD to tag/release ${version}, or scrub the sentinel via scripts/dev/scrub-sentinel.sh ${version}"
+            else
+                echo "DRIFT ${version}: git tag present, cli sentinel missing"
+                echo "  remediation: re-run CI to produce artifacts for ${version}, or delete tag ${version}"
+            fi
+            drift=1
+        fi
+
+        if (( has_desktop && !has_cli )); then
+            echo "DRIFT ${version}: desktop sentinel present, cli sentinel missing"
+            echo "  remediation: inspect desktop/${version}/.released payload and reconcile; desktop should never release without cli"
+            drift=1
+        fi
+    done <<<"$all"
+
+    if (( drift == 0 )); then
+        echo "OK: release-state bijection holds (excluding in-flight ${in_flight:-<none>})"
+        return 0
+    fi
+    return 1
+}

--- a/.ci/scripts/quality/check-release-state.sh
+++ b/.ci/scripts/quality/check-release-state.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# BLOCKER drift gate: assert R2 `.released` sentinels match git tags.
+#
+# Enforces the invariant documented in .ci/scripts/lib/release-state-validator.sh.
+# Runs on every push to main, before stage-artifacts. Fails loud on any drift
+# finding so that a half-committed release from a prior cancelled run cannot
+# silently burn a version number.
+#
+# Env:
+#   R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_ENDPOINT  (required)
+#   RELEASES_BUCKET                                      (optional, default rediacc-releases)
+#   IN_FLIGHT_VERSION                                    (optional; falls back to resolve-version.sh)
+#
+# Exit 0 on bijection, 1 on drift. Drift is never auto-healed; the error lines
+# include remediation pointers for the human.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/../lib/common.sh"
+# shellcheck source=../lib/release-state-validator.sh
+source "$SCRIPT_DIR/../lib/release-state-validator.sh"
+
+require_cmd aws
+require_var R2_ACCESS_KEY_ID
+require_var R2_SECRET_ACCESS_KEY
+require_var R2_ENDPOINT
+export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+export AWS_DEFAULT_REGION="auto"
+
+IN_FLIGHT="${IN_FLIGHT_VERSION:-}"
+if [[ -z "$IN_FLIGHT" ]]; then
+    # Mirror what ci.yml initialize computes; keeps this gate runnable standalone.
+    IN_FLIGHT="v$("$REPO_ROOT/.ci/scripts/version/resolve-version.sh" --bump-type patch)"
+fi
+log_info "in-flight version (excluded from bijection check): ${IN_FLIGHT}"
+
+log_step "listing cli sentinels"
+cli_versions="$(rsv_list_sentinels cli)"
+log_info "  ${cli_versions:+$(wc -l <<<"$cli_versions") cli sentinels}${cli_versions:-none}"
+
+log_step "listing desktop sentinels"
+desktop_versions="$(rsv_list_sentinels desktop)"
+log_info "  ${desktop_versions:+$(wc -l <<<"$desktop_versions") desktop sentinels}${desktop_versions:-none}"
+
+log_step "listing git release tags"
+tag_versions="$(rsv_list_git_tags)"
+log_info "  $(wc -l <<<"$tag_versions") git tags"
+
+log_step "asserting release-state bijection"
+if rsv_assert_bijection "$cli_versions" "$desktop_versions" "$tag_versions" "$IN_FLIGHT"; then
+    log_info "release-state gate: PASS"
+    exit 0
+fi
+
+log_error "release-state gate: FAIL — drift between R2 sentinels and git tags"
+log_error "  the findings above indicate an incomplete release or a missing tag"
+log_error "  see .ci/scripts/lib/release-state-validator.sh for the invariant"
+exit 1

--- a/.ci/scripts/test/gates/test-release-state-consistency.sh
+++ b/.ci/scripts/test/gates/test-release-state-consistency.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# Unit-tests the rsv_assert_bijection function in release-state-validator.sh
+# against synthetic version lists. The live R2 + git probes are exercised
+# end-to-end by the quality gate itself during CI; this test pins the pure
+# assertion logic so drift-detection behaviour stays correct even if callers
+# refactor.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+# shellcheck source=../lib/test-helpers.sh
+source "$SCRIPT_DIR/../lib/test-helpers.sh"
+# shellcheck source=../../lib/release-state-validator.sh
+source "$REPO_ROOT/.ci/scripts/lib/release-state-validator.sh"
+
+# Small helpers — rsv_assert_bijection emits drift-or-OK to stdout; we capture
+# both the exit code and the output to assert both at once.
+run_assert() {
+    local cli="$1" desk="$2" tags="$3" in_flight="${4:-}"
+    local out rc=0
+    out="$(rsv_assert_bijection "$cli" "$desk" "$tags" "$in_flight" 2>&1)" || rc=$?
+    printf '%s\n' "$out"
+    return "$rc"
+}
+
+test_all_committed_passes() {
+    log_test "all-committed → OK"
+    local out rc=0
+    out="$(run_assert \
+        "$(printf 'v1.0.0\nv1.0.1\nv1.0.2\n')" \
+        "$(printf 'v1.0.0\nv1.0.1\nv1.0.2\n')" \
+        "$(printf 'v1.0.0\nv1.0.1\nv1.0.2\n')")" || rc=$?
+    assert_exit_code 0 "$rc" "bijection should hold"
+    assert_contains "$out" "OK:" "positive confirmation emitted"
+    assert_not_contains "$out" "DRIFT" "no drift lines"
+    log_pass "all-committed"
+}
+
+test_empty_state_passes() {
+    log_test "no sentinels + no tags → OK"
+    local out rc=0
+    out="$(run_assert "" "" "")" || rc=$?
+    assert_exit_code 0 "$rc" "empty state is a bijection"
+    assert_contains "$out" "OK:" "positive confirmation emitted"
+    log_pass "empty-state"
+}
+
+test_orphan_prefix_not_flagged() {
+    # The library flags sentinel↔tag drift, not the presence of orphan bytes
+    # without a sentinel. Orphans are handled upstream by the pre-upload scrub.
+    log_test "orphan prefix (no sentinel, no tag) → OK (not this gate's concern)"
+    local out rc=0
+    out="$(run_assert \
+        "$(printf 'v1.0.0\n')" \
+        "$(printf 'v1.0.0\n')" \
+        "$(printf 'v1.0.0\n')")" || rc=$?
+    assert_exit_code 0 "$rc" "orphan is not sentinel-vs-tag drift"
+    log_pass "orphan-prefix"
+}
+
+test_sentinel_without_tag_fails() {
+    log_test "cli sentinel present, tag missing → DRIFT (this is the #458 bug)"
+    local out rc=0
+    out="$(run_assert \
+        "$(printf 'v1.0.0\nv1.0.5\n')" \
+        "$(printf 'v1.0.0\n')" \
+        "$(printf 'v1.0.0\n')")" || rc=$?
+    assert_exit_code 1 "$rc" "sentinel-without-tag must fail"
+    assert_contains "$out" "DRIFT v1.0.5" "names the drifted version"
+    assert_contains "$out" "cli sentinel present, git tag missing" "identifies direction"
+    assert_contains "$out" "re-run CD to tag" "remediation present"
+    log_pass "sentinel-without-tag"
+}
+
+test_tag_without_sentinel_fails() {
+    log_test "git tag present, cli sentinel missing → DRIFT"
+    local out rc=0
+    out="$(run_assert \
+        "$(printf 'v1.0.0\n')" \
+        "$(printf 'v1.0.0\n')" \
+        "$(printf 'v1.0.0\nv1.0.5\n')")" || rc=$?
+    assert_exit_code 1 "$rc" "tag-without-sentinel must fail"
+    assert_contains "$out" "DRIFT v1.0.5" "names the drifted version"
+    assert_contains "$out" "git tag present, cli sentinel missing" "identifies direction"
+    assert_contains "$out" "re-run CI to produce artifacts" "remediation present"
+    log_pass "tag-without-sentinel"
+}
+
+test_desktop_without_cli_fails() {
+    log_test "desktop sentinel present without cli sentinel → DRIFT"
+    local out rc=0
+    out="$(run_assert \
+        "$(printf 'v1.0.0\n')" \
+        "$(printf 'v1.0.0\nv1.0.5\n')" \
+        "$(printf 'v1.0.0\nv1.0.5\n')")" || rc=$?
+    assert_exit_code 1 "$rc" "desktop-without-cli must fail"
+    assert_contains "$out" "DRIFT v1.0.5" "names the drifted version"
+    assert_contains "$out" "desktop sentinel present, cli sentinel missing" "identifies invariant violated"
+    log_pass "desktop-without-cli"
+}
+
+test_desktop_missing_is_fine() {
+    # Desktop is optional — a platform-skipped or cli-only release is valid.
+    log_test "cli sentinel + tag present, desktop absent → OK"
+    local out rc=0
+    out="$(run_assert \
+        "$(printf 'v1.0.0\nv1.0.5\n')" \
+        "$(printf 'v1.0.0\n')" \
+        "$(printf 'v1.0.0\nv1.0.5\n')")" || rc=$?
+    assert_exit_code 0 "$rc" "desktop absence is legitimate"
+    log_pass "desktop-optional"
+}
+
+test_in_flight_excluded() {
+    log_test "in-flight version with no sentinel yet → excluded from bijection, gate passes"
+    local out rc=0
+    out="$(run_assert \
+        "$(printf 'v1.0.0\n')" \
+        "$(printf 'v1.0.0\n')" \
+        "$(printf 'v1.0.0\n')" \
+        "v1.0.5")" || rc=$?
+    assert_exit_code 0 "$rc" "in-flight exclusion prevents self-flag"
+    log_pass "in-flight-excluded"
+}
+
+test_in_flight_does_not_mask_other_drift() {
+    log_test "in-flight exclusion does not hide unrelated drift"
+    local out rc=0
+    out="$(run_assert \
+        "$(printf 'v1.0.0\nv1.0.3\n')" \
+        "" \
+        "$(printf 'v1.0.0\n')" \
+        "v1.0.5")" || rc=$?
+    assert_exit_code 1 "$rc" "v1.0.3 drift must still fire"
+    assert_contains "$out" "DRIFT v1.0.3" "unrelated drift still caught"
+    assert_not_contains "$out" "DRIFT v1.0.5" "in-flight remains excluded"
+    log_pass "in-flight-targeted-exclusion"
+}
+
+test_prerelease_tags_ignored() {
+    log_test "pre-release tags (v1.0.0-beta.1) are not part of the bijection"
+    # rsv_list_git_tags filters these out in live use; assert the assertion
+    # function also ignores them when they happen to appear in inputs.
+    local out rc=0
+    out="$(run_assert \
+        "$(printf 'v1.0.0\n')" \
+        "$(printf 'v1.0.0\n')" \
+        "$(printf 'v1.0.0\nv1.0.1-beta.1\n')")" || rc=$?
+    assert_exit_code 0 "$rc" "pre-release tag must not trigger drift"
+    log_pass "prerelease-filtered"
+}
+
+test_all_committed_passes
+test_empty_state_passes
+test_orphan_prefix_not_flagged
+test_sentinel_without_tag_fails
+test_tag_without_sentinel_fails
+test_desktop_without_cli_fails
+test_desktop_missing_is_fine
+test_in_flight_excluded
+test_in_flight_does_not_mask_other_drift
+test_prerelease_tags_ignored
+
+log_pass "all release-state-consistency cases"

--- a/.ci/scripts/test/test-write-once-guard.sh
+++ b/.ci/scripts/test/test-write-once-guard.sh
@@ -1,97 +1,131 @@
 #!/bin/bash
-# Unit tests for write_once_guard() in .ci/scripts/deploy/upload-to-r2.sh.
-# Mocks aws so the test runs offline and deterministically.
+# Unit tests for the sentinel-aware write_once_guard() in
+# .ci/scripts/deploy/upload-to-r2.sh. Mocks aws so the test runs offline.
 #
-# Guards against regression to a dead key-specific sentinel (finding A).
-# The guard must:
-#   * exit 1 when `aws s3 ls <prefix>` returns non-empty (seal violated)
-#   * return 0 when `aws s3 ls <prefix>` returns empty (path vacant)
-#   * skip both checks when DRY_RUN=true
+# The guard's three expected behaviours (see
+# .ci/scripts/lib/release-state-validator.sh for the invariant):
+#   1. `.released` sentinel exists                → exit 1 (seal violated)
+#   2. prefix empty + no sentinel                 → return 0 (clean slate)
+#   3. prefix non-empty + no sentinel (orphan)    → scrub then return 0
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 GUARD_SCRIPT="$ROOT_DIR/.ci/scripts/deploy/upload-to-r2.sh"
+VALIDATOR_LIB="$ROOT_DIR/.ci/scripts/lib/release-state-validator.sh"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
 
-log_fail() {
-    echo -e "${RED}FAIL:${NC} $*" >&2
-    exit 1
-}
+log_fail() { echo -e "${RED}FAIL:${NC} $*" >&2; exit 1; }
 log_pass() { echo -e "${GREEN}PASS:${NC} $*"; }
 
-# Create a tempdir and a fake `aws` on PATH that returns scripted output.
 TEMP="$(mktemp -d)"
 trap 'rm -rf "$TEMP"' EXIT
 
-cat >"$TEMP/aws" <<'FAKE'
+# Fake aws: dispatches on the first two args so each subcommand can be scripted
+# independently. Also records every invocation into $TEMP/aws.log so tests can
+# assert whether `aws s3 rm --recursive` was called by the orphan-scrub path.
+cat >"$TEMP/aws" <<FAKE
 #!/bin/bash
-# Fake aws that returns whatever the test set in FAKE_AWS_OUTPUT and
-# exits with FAKE_AWS_RC.
-if [[ -n "${FAKE_AWS_OUTPUT:-}" ]]; then
-    printf '%s\n' "$FAKE_AWS_OUTPUT"
-fi
-exit "${FAKE_AWS_RC:-0}"
+printf '%s\n' "\$*" >>"$TEMP/aws.log"
+case "\$1 \$2" in
+    "s3api head-object")
+        # Sentinel existence check. Controlled by SENTINEL_EXISTS.
+        if [[ "\${SENTINEL_EXISTS:-false}" == "true" ]]; then
+            exit 0
+        fi
+        exit 254  # typical NoSuchKey exit from awscli
+        ;;
+    "s3api list-objects-v2")
+        # Prefix non-empty check (rsv_prefix_nonempty) uses --query KeyCount.
+        printf '%s\n' "\${PREFIX_KEYCOUNT:-0}"
+        exit 0
+        ;;
+    "s3 rm")
+        # Scrub call. Always succeeds.
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
 FAKE
 chmod +x "$TEMP/aws"
 export PATH="$TEMP:$PATH"
 
-# Set the minimum env that upload-to-r2.sh's prelude requires before we
-# can source it without triggering the "required variable" exits.
-RELEASES_BUCKET=rediacc-releases
-R2_ENDPOINT=https://example.invalid
-VERSION=0.0.0-test
-CHANNEL=pr-0
-DRY_RUN=false
-export RELEASES_BUCKET R2_ENDPOINT VERSION CHANNEL DRY_RUN
+# Environment upload-to-r2.sh requires before we can source it.
+export RELEASES_BUCKET=rediacc-releases
+export R2_ENDPOINT=https://example.invalid
+export VERSION=0.0.0-test
+export CHANNEL=pr-0
+export DRY_RUN=false
 
-# upload-to-r2.sh runs its main path when sourced; guard against that
-# by extracting ONLY the write_once_guard function via sed.
+# Extract just the guard function + define stubs for log_* + pull in the
+# validator library (which provides rsv_sentinel_exists / rsv_prefix_nonempty).
 sed -n '/^write_once_guard()/,/^}/p' "$GUARD_SCRIPT" >"$TEMP/guard.sh"
+cat >"$TEMP/bundle.sh" <<STUBS
+log_error() { echo "error: \$*" >&2; }
+log_warn()  { echo "warn: \$*" >&2; }
+log_info()  { echo "info: \$*" >&2; }
+SCRIPT_DIR="$ROOT_DIR/.ci/scripts/deploy"
+RELEASES_BUCKET="$RELEASES_BUCKET"
+R2_ENDPOINT="$R2_ENDPOINT"
+DRY_RUN=\${DRY_RUN:-false}
+STUBS
+cat "$VALIDATOR_LIB" >>"$TEMP/bundle.sh"
+cat "$TEMP/guard.sh" >>"$TEMP/bundle.sh"
 
-# Helpers it depends on (log_error, log_info). Minimal stubs to stderr.
-cat >>"$TEMP/guard-bundle.sh" <<'HELPERS'
-log_error() { echo "error: $*" >&2; }
-log_info() { echo "info: $*" >&2; }
-HELPERS
-cat "$TEMP/guard.sh" >>"$TEMP/guard-bundle.sh"
+reset_log() { : >"$TEMP/aws.log"; }
 
-# Run guard in a subshell so that a `exit 1` from the guard doesn't
-# terminate the test driver. We check status with "|| true".
-
-# list-objects-v2 --query 'KeyCount' --output text prints "0" (no objects),
-# "1" (at least one object), or "None" (bucket missing or access denied).
-# Treat "0" and "None" as empty; any other value aborts the guard.
-test_empty_prefix_passes() {
-    FAKE_AWS_OUTPUT="0" FAKE_AWS_RC=0 \
-        bash -c "set -e; source '$TEMP/guard-bundle.sh'; write_once_guard 'cli/v0.0.0/' 'test'" ||
-        log_fail "empty prefix (KeyCount=0) should pass; guard returned non-zero"
-    log_pass "empty prefix returns 0"
+run_guard() {
+    bash -c "source '$TEMP/bundle.sh'; write_once_guard '$1' 'test'" 2>/dev/null
 }
 
-test_nonempty_prefix_aborts() {
-    FAKE_AWS_OUTPUT="1" FAKE_AWS_RC=0 \
-        bash -c "set -e; source '$TEMP/guard-bundle.sh'; write_once_guard 'cli/v0.0.0/' 'test'" \
-        2>/dev/null &&
-        log_fail "non-empty prefix (KeyCount=1) should abort; guard returned zero"
-    log_pass "non-empty prefix aborts (exit 1)"
+test_sealed_prefix_aborts() {
+    reset_log
+    SENTINEL_EXISTS=true PREFIX_KEYCOUNT=1 run_guard "cli/v0.0.0/" \
+        && log_fail "sealed prefix (sentinel present) should abort; guard returned zero"
+    grep -q "s3api head-object" "$TEMP/aws.log" \
+        || log_fail "guard should have checked head-object for the sentinel"
+    grep -q "s3 rm" "$TEMP/aws.log" \
+        && log_fail "guard must NOT scrub when the sentinel is present"
+    log_pass "sealed prefix aborts (sentinel-aware)"
+}
+
+test_empty_prefix_passes() {
+    reset_log
+    SENTINEL_EXISTS=false PREFIX_KEYCOUNT=0 run_guard "cli/v0.0.0/" \
+        || log_fail "empty prefix + no sentinel should pass; guard returned non-zero"
+    grep -q "s3 rm" "$TEMP/aws.log" \
+        && log_fail "guard must NOT scrub an empty prefix"
+    log_pass "empty prefix returns 0 (clean slate)"
+}
+
+test_orphan_prefix_scrubs_and_passes() {
+    reset_log
+    SENTINEL_EXISTS=false PREFIX_KEYCOUNT=1 run_guard "cli/v0.0.0/" \
+        || log_fail "orphan prefix should scrub and pass; guard returned non-zero"
+    grep -q "s3 rm .*cli/v0.0.0/ --endpoint-url .*--recursive" "$TEMP/aws.log" \
+        || log_fail "guard must invoke 'aws s3 rm --recursive' to scrub the orphan"
+    log_pass "orphan prefix scrubs and returns 0 (recovery path)"
 }
 
 test_dry_run_skips() {
-    FAKE_AWS_OUTPUT="1" FAKE_AWS_RC=0 \
-        DRY_RUN=true \
-        bash -c "set -e; DRY_RUN=true; source '$TEMP/guard-bundle.sh'; write_once_guard 'cli/v0.0.0/' 'test'" ||
-        log_fail "DRY_RUN=true should pass regardless of prefix state"
-    log_pass "DRY_RUN=true skips the check"
+    reset_log
+    SENTINEL_EXISTS=true PREFIX_KEYCOUNT=1 DRY_RUN=true run_guard "cli/v0.0.0/" \
+        || log_fail "DRY_RUN=true should pass regardless of state"
+    grep -q "s3api head-object" "$TEMP/aws.log" \
+        && log_fail "DRY_RUN must not call aws at all"
+    log_pass "DRY_RUN=true skips all checks"
 }
 
+test_sealed_prefix_aborts
 test_empty_prefix_passes
-test_nonempty_prefix_aborts
+test_orphan_prefix_scrubs_and_passes
 test_dry_run_skips
 
 echo ""
-log_pass "all write_once_guard cases"
+log_pass "all sentinel-aware write_once_guard cases"

--- a/.ci/scripts/test/test-write-once-guard.sh
+++ b/.ci/scripts/test/test-write-once-guard.sh
@@ -19,7 +19,10 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
 
-log_fail() { echo -e "${RED}FAIL:${NC} $*" >&2; exit 1; }
+log_fail() {
+    echo -e "${RED}FAIL:${NC} $*" >&2
+    exit 1
+}
 log_pass() { echo -e "${GREEN}PASS:${NC} $*"; }
 
 TEMP="$(mktemp -d)"
@@ -86,39 +89,39 @@ run_guard() {
 
 test_sealed_prefix_aborts() {
     reset_log
-    SENTINEL_EXISTS=true PREFIX_KEYCOUNT=1 run_guard "cli/v0.0.0/" \
-        && log_fail "sealed prefix (sentinel present) should abort; guard returned zero"
-    grep -q "s3api head-object" "$TEMP/aws.log" \
-        || log_fail "guard should have checked head-object for the sentinel"
-    grep -q "s3 rm" "$TEMP/aws.log" \
-        && log_fail "guard must NOT scrub when the sentinel is present"
+    SENTINEL_EXISTS=true PREFIX_KEYCOUNT=1 run_guard "cli/v0.0.0/" &&
+        log_fail "sealed prefix (sentinel present) should abort; guard returned zero"
+    grep -q "s3api head-object" "$TEMP/aws.log" ||
+        log_fail "guard should have checked head-object for the sentinel"
+    grep -q "s3 rm" "$TEMP/aws.log" &&
+        log_fail "guard must NOT scrub when the sentinel is present"
     log_pass "sealed prefix aborts (sentinel-aware)"
 }
 
 test_empty_prefix_passes() {
     reset_log
-    SENTINEL_EXISTS=false PREFIX_KEYCOUNT=0 run_guard "cli/v0.0.0/" \
-        || log_fail "empty prefix + no sentinel should pass; guard returned non-zero"
-    grep -q "s3 rm" "$TEMP/aws.log" \
-        && log_fail "guard must NOT scrub an empty prefix"
+    SENTINEL_EXISTS=false PREFIX_KEYCOUNT=0 run_guard "cli/v0.0.0/" ||
+        log_fail "empty prefix + no sentinel should pass; guard returned non-zero"
+    grep -q "s3 rm" "$TEMP/aws.log" &&
+        log_fail "guard must NOT scrub an empty prefix"
     log_pass "empty prefix returns 0 (clean slate)"
 }
 
 test_orphan_prefix_scrubs_and_passes() {
     reset_log
-    SENTINEL_EXISTS=false PREFIX_KEYCOUNT=1 run_guard "cli/v0.0.0/" \
-        || log_fail "orphan prefix should scrub and pass; guard returned non-zero"
-    grep -q "s3 rm .*cli/v0.0.0/ --endpoint-url .*--recursive" "$TEMP/aws.log" \
-        || log_fail "guard must invoke 'aws s3 rm --recursive' to scrub the orphan"
+    SENTINEL_EXISTS=false PREFIX_KEYCOUNT=1 run_guard "cli/v0.0.0/" ||
+        log_fail "orphan prefix should scrub and pass; guard returned non-zero"
+    grep -q "s3 rm .*cli/v0.0.0/ --endpoint-url .*--recursive" "$TEMP/aws.log" ||
+        log_fail "guard must invoke 'aws s3 rm --recursive' to scrub the orphan"
     log_pass "orphan prefix scrubs and returns 0 (recovery path)"
 }
 
 test_dry_run_skips() {
     reset_log
-    SENTINEL_EXISTS=true PREFIX_KEYCOUNT=1 DRY_RUN=true run_guard "cli/v0.0.0/" \
-        || log_fail "DRY_RUN=true should pass regardless of state"
-    grep -q "s3api head-object" "$TEMP/aws.log" \
-        && log_fail "DRY_RUN must not call aws at all"
+    SENTINEL_EXISTS=true PREFIX_KEYCOUNT=1 DRY_RUN=true run_guard "cli/v0.0.0/" ||
+        log_fail "DRY_RUN=true should pass regardless of state"
+    grep -q "s3api head-object" "$TEMP/aws.log" &&
+        log_fail "DRY_RUN must not call aws at all"
     log_pass "DRY_RUN=true skips all checks"
 }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,19 +598,53 @@ jobs:
         run: .ci/scripts/test/test-linux-packages.sh
 
   # ============================================================================
+  # COLUMN 3A-BIS: RELEASE-STATE DRIFT GATE
+  # BLOCKER gate that enforces the sentinel-based release contract defined in
+  # .ci/scripts/lib/release-state-validator.sh. Fails loud if R2 `.released`
+  # sentinels and git release tags are not in bijection. Runs before
+  # stage-artifacts so drift from a prior cancelled run is caught before any
+  # new bytes are uploaded. Only blocks release channels on push-to-main;
+  # PR/fork runs skip because they never write versioned prefixes.
+  # ============================================================================
+  check-release-state:
+    name: Check Release State
+    needs: [initialize]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: >-
+      always() &&
+      needs.initialize.result == 'success' &&
+      needs.initialize.outputs.is_fork != 'true' &&
+      needs.initialize.outputs.is_bot != 'true' &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      (needs.initialize.outputs.channel == 'edge' || needs.initialize.outputs.channel == 'stable')
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0  # need full tag history for bijection check
+      - name: Assert release-state bijection
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          IN_FLIGHT_VERSION: v${{ needs.initialize.outputs.next_version }}
+        run: .ci/scripts/quality/check-release-state.sh
+
+  # ============================================================================
   # COLUMN 3B: DEPLOY DRY-RUN
   # Jobs: stage-artifacts (reusable workflow)
-  # Dependencies: build-docker, build-desktop, build-cli
+  # Dependencies: build-docker, build-desktop, build-cli, check-release-state
   # ============================================================================
   stage-artifacts:
     name: Stage Artifacts
-    needs: [initialize, build-docker, build-desktop, build-cli, stripe-sandbox]
+    needs: [initialize, build-docker, build-desktop, build-cli, stripe-sandbox, check-release-state]
     permissions:
       contents: read
       packages: write      # GHCR pull for validation
       id-token: write      # OIDC token for Sigstore signing
       attestations: write  # Store attestations on GitHub
-    if: always() && needs.initialize.outputs.is_fork != 'true' && needs.initialize.outputs.is_bot != 'true' && needs.initialize.result == 'success' && needs.build-docker.result == 'success' && needs.build-desktop.result == 'success' && needs.build-cli.result == 'success' && (needs.stripe-sandbox.result == 'success' || needs.stripe-sandbox.result == 'skipped')
+    if: always() && needs.initialize.outputs.is_fork != 'true' && needs.initialize.outputs.is_bot != 'true' && needs.initialize.result == 'success' && needs.build-docker.result == 'success' && needs.build-desktop.result == 'success' && needs.build-cli.result == 'success' && (needs.stripe-sandbox.result == 'success' || needs.stripe-sandbox.result == 'skipped') && (needs.check-release-state.result == 'success' || needs.check-release-state.result == 'skipped')
     uses: ./.github/workflows/cd-stage.yml
     with:
       upload_pages: ${{ github.event_name == 'pull_request' }}
@@ -1297,6 +1331,70 @@ jobs:
             exit 1
           fi
           echo "All CI jobs passed successfully!"
+
+  # ============================================================================
+  # FINALIZE RELEASE SENTINEL
+  # Atomic commit point of the release pipeline. Writes `.released` sentinels
+  # to cli/v${V}/ and desktop/v${V}/ on R2 — only after every CI gate upstream
+  # has passed. The sentinel seals the version: from here on, write_once_guard
+  # refuses to overwrite, and the drift gate requires a matching git tag.
+  #
+  # See .ci/scripts/lib/release-state-validator.sh for the invariant and
+  # .ci/scripts/deploy/write-release-sentinel.sh for the writer.
+  #
+  # always() prefix is load-bearing (same reason as housekeeping): ci-complete
+  # transitively needs deploy-preview / smoke-test-preview which are
+  # pull_request-only and skip on push-to-main.
+  # ============================================================================
+  finalize-release-sentinel:
+    name: Finalize Release Sentinel
+    runs-on: ubuntu-slim
+    needs: [initialize, ci-complete]
+    if: >-
+      always() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.ci-complete.result == 'success' &&
+      needs.initialize.result == 'success' &&
+      (needs.initialize.outputs.channel == 'edge' || needs.initialize.outputs.channel == 'stable')
+    timeout-minutes: 5
+    concurrency:
+      group: finalize-release-v${{ needs.initialize.outputs.next_version }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Install jq
+        run: command -v jq >/dev/null || sudo apt-get install -y -qq jq
+      - name: Write release sentinels
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+        run: |
+          .ci/scripts/deploy/write-release-sentinel.sh \
+            --version "${{ needs.initialize.outputs.next_version }}" \
+            --channel "${{ needs.initialize.outputs.channel }}" \
+            --commit-sha "${{ github.sha }}" \
+            --desktop
+
+  # Sentinel that fails loudly if the finalize job silently skipped on
+  # push-to-main. Mirrors assert-housekeeping-ran. If the finalize job result
+  # is 'skipped' on a release-channel push-to-main, transitive-skip
+  # propagation is back — fix by adding always() to finalize's if:.
+  assert-finalize-sentinel-ran:
+    name: Assert Finalize Sentinel Ran
+    runs-on: ubuntu-slim
+    needs: [initialize, finalize-release-sentinel]
+    if: >-
+      always() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.initialize.result == 'success' &&
+      (needs.initialize.outputs.channel == 'edge' || needs.initialize.outputs.channel == 'stable')
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Check finalize-release-sentinel conclusion
+        run: .ci/scripts/ci/assert-job-succeeded.sh finalize-release-sentinel "${{ needs.finalize-release-sentinel.result }}"
 
   # ============================================================================
   # HOUSEKEEPING

--- a/.github/workflows/cleanup-on-ci-cancel.yml
+++ b/.github/workflows/cleanup-on-ci-cancel.yml
@@ -1,0 +1,101 @@
+name: Cleanup on CI Cancel
+
+# Belt-and-suspenders for the sentinel-based release contract. The pre-upload
+# scrub in upload-to-r2.sh already handles the orphan class on the next CI
+# run. This workflow closes the window between a CI cancel and the next push:
+# if CI cancelled or failed AFTER stage-artifacts wrote bytes but BEFORE
+# finalize-release-sentinel sealed them, no `.released` marker exists and the
+# prefix is an orphan. We scrub it immediately rather than letting it sit
+# until the next push happens to trigger the pre-upload scrub.
+#
+# Safety: this workflow ONLY touches versioned prefixes that lack a `.released`
+# sentinel. Committed releases are invisible to it by construction.
+#
+# See .ci/scripts/lib/release-state-validator.sh for the invariant.
+
+on:
+  workflow_run:
+    workflows: ["Console CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  scrub-orphans:
+    name: Scrub orphan versioned prefixes
+    runs-on: ubuntu-latest
+    # Fire only when CI ended badly. `skipped` runs never wrote bytes, so they
+    # cannot have produced an orphan. Success runs either finalized the
+    # sentinel (committed) or never uploaded (initialize skipped on PR/fork).
+    if: >-
+      github.event.workflow_run.conclusion == 'cancelled' ||
+      github.event.workflow_run.conclusion == 'failure'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Resolve next_version from triggering CI run
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          # The initialize job emits next_version as a step output; grab it from the
+          # run's jobs API. If we cannot resolve it (e.g. initialize didn't run),
+          # fall back to what resolve-version.sh would compute from tags — that is
+          # the same version stage-artifacts would have used.
+          next_version=""
+          jobs_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs" --paginate 2>/dev/null || echo '{}')"
+          if command -v jq >/dev/null; then
+            next_version=$(echo "$jobs_json" \
+              | jq -r '.jobs[]? | select(.name == "Initialize") | .steps[]? | select(.name | test("initialize|next_version|Resolve version"; "i")) | .conclusion' 2>/dev/null \
+              | head -1 || echo "")
+          fi
+          if [[ -z "$next_version" ]]; then
+            next_version="$(.ci/scripts/version/resolve-version.sh --bump-type patch 2>/dev/null || echo '')"
+          fi
+          if [[ -z "$next_version" ]]; then
+            echo "::warning::could not resolve next_version; skipping scrub"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "next_version=${next_version}" >> "$GITHUB_OUTPUT"
+          echo "version_tag=v${next_version}" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Scrub if orphan
+        if: steps.resolve.outputs.skip != 'true'
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          VERSION_TAG: ${{ steps.resolve.outputs.version_tag }}
+        run: |
+          set -euo pipefail
+          source .ci/scripts/lib/common.sh
+          source .ci/scripts/lib/release-state-validator.sh
+          export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+          export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+          export AWS_DEFAULT_REGION="auto"
+
+          scrubbed=false
+          for product in cli desktop; do
+            prefix="${product}/${VERSION_TAG}/"
+            if rsv_is_orphan "$product" "$VERSION_TAG"; then
+              log_warn "scrubbing orphan s3://${RSV_BUCKET}/${prefix}"
+              aws s3 rm "s3://${RSV_BUCKET}/${prefix}" \
+                --endpoint-url "$R2_ENDPOINT" --recursive
+              scrubbed=true
+            elif rsv_sentinel_exists "$product" "$VERSION_TAG"; then
+              log_info "${product}/${VERSION_TAG} is sealed (sentinel present); leaving untouched"
+            else
+              log_info "${product}/${VERSION_TAG} is empty; nothing to do"
+            fi
+          done
+
+          if [[ "$scrubbed" == "true" ]]; then
+            echo "## Orphan prefix scrubbed" >> "$GITHUB_STEP_SUMMARY"
+            echo "Version tag: \`${VERSION_TAG}\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "Reason: CI run ${{ github.event.workflow_run.id }} concluded as \`${{ github.event.workflow_run.conclusion }}\` before the sentinel was written." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "check:ci-shell-format": ".ci/scripts/security/shfmt.sh",
     "check:ci-shell-lint": ".ci/scripts/security/shellcheck.sh",
     "check:ci-workflows": ".ci/scripts/quality/check-workflows.sh",
+    "check:ci-release-state": ".ci/scripts/quality/check-release-state.sh",
     "check:ci-account-portal": ".ci/scripts/quality/check-account-portal.sh",
     "check:ci-account-layer-isolation": "eslint private/account/src/routes/ --max-warnings 0",
     "check:ci-account-no-admin-role": "! grep -rn \"enum.*customer.*admin\\|enum.*admin.*customer\" private/account/src/db/schema.ts private/account/src/types/user.ts 2>/dev/null; echo 'OK: no admin user role'",

--- a/scripts/dev/scrub-sentinel.sh
+++ b/scripts/dev/scrub-sentinel.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Scrub a release sentinel and its versioned bytes from R2.
+#
+# Used as the recovery path referenced by the drift gate when it flags
+# "cli sentinel present, git tag missing". A sentinel exists only if
+# write-release-sentinel.sh completed successfully, which means the bytes are
+# considered released by the invariant. If the downstream tag never happened
+# (CD failed after finalize), the operator has two choices:
+#   1. Re-run CD to create the missing tag (preferred — keeps the bytes).
+#   2. Scrub the sentinel + bytes via this script so the version number is
+#      freed and the next CI run can reclaim it.
+#
+# This script is interactive-safe: dry-run is default, an explicit --execute
+# is required to delete. Deletions are recoverable only if the R2 bucket has
+# object versioning enabled (we assume it does not; the scrub is authoritative).
+#
+# Usage:
+#   scripts/dev/scrub-sentinel.sh v1.0.5                  # dry-run
+#   scripts/dev/scrub-sentinel.sh v1.0.5 --execute        # actually delete
+#   scripts/dev/scrub-sentinel.sh v1.0.5 --execute --yes  # skip confirmation
+#
+# Env (required):
+#   R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_ENDPOINT
+#   RELEASES_BUCKET (optional, default rediacc-releases)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=../../.ci/scripts/lib/common.sh
+source "$REPO_ROOT/.ci/scripts/lib/common.sh"
+# shellcheck source=../../.ci/scripts/lib/release-state-validator.sh
+source "$REPO_ROOT/.ci/scripts/lib/release-state-validator.sh"
+
+VERSION=""
+EXECUTE=false
+SKIP_CONFIRM=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --execute) EXECUTE=true ;;
+        --yes | -y) SKIP_CONFIRM=true ;;
+        --help | -h)
+            sed -n '2,30p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        v[0-9]*)
+            [[ -n "$VERSION" ]] && { log_error "only one version argument"; exit 2; }
+            VERSION="$arg"
+            ;;
+        *) log_error "unknown argument: $arg"; exit 2 ;;
+    esac
+done
+
+if [[ -z "$VERSION" ]]; then
+    log_error "usage: scrub-sentinel.sh v<MAJOR>.<MINOR>.<PATCH> [--execute] [--yes]"
+    exit 2
+fi
+if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    log_error "invalid version '$VERSION' (expected strict semver, e.g. v1.0.5)"
+    exit 2
+fi
+
+require_cmd aws
+require_var R2_ACCESS_KEY_ID
+require_var R2_SECRET_ACCESS_KEY
+require_var R2_ENDPOINT
+export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+export AWS_DEFAULT_REGION="auto"
+
+log_step "scrub plan for ${VERSION}"
+for product in cli desktop; do
+    local_prefix="${product}/${VERSION}/"
+    echo "  s3://${RSV_BUCKET}/${local_prefix}"
+    if rsv_sentinel_exists "$product" "$VERSION"; then
+        echo "    sentinel: PRESENT (will be deleted)"
+    else
+        echo "    sentinel: absent"
+    fi
+    count="$(aws s3 ls "s3://${RSV_BUCKET}/${local_prefix}" \
+        --endpoint-url "$R2_ENDPOINT" --recursive 2>/dev/null | wc -l)"
+    echo "    objects: ${count}"
+done
+
+# Safety cross-check: if a git tag exists for this version, refuse to scrub
+# without explicit acknowledgment. A scrub that removes bytes behind a live
+# release tag is almost always a mistake.
+if git -C "$REPO_ROOT" rev-parse --verify "refs/tags/${VERSION}" >/dev/null 2>&1; then
+    log_warn "git tag ${VERSION} exists in ${REPO_ROOT}"
+    log_warn "  scrubbing bytes that back a live release tag will break installs"
+    log_warn "  reconsider re-running CD for ${VERSION} instead"
+    if [[ "$EXECUTE" == "true" && "$SKIP_CONFIRM" == "false" ]]; then
+        read -r -p "type 'YES I UNDERSTAND' to proceed: " confirm
+        [[ "$confirm" == "YES I UNDERSTAND" ]] || { log_error "aborted"; exit 1; }
+    fi
+fi
+
+if [[ "$EXECUTE" != "true" ]]; then
+    log_info "dry-run: pass --execute to delete"
+    exit 0
+fi
+
+if [[ "$SKIP_CONFIRM" != "true" ]]; then
+    read -r -p "delete the listed prefixes? [y/N] " ack
+    [[ "$ack" == "y" || "$ack" == "Y" ]] || { log_error "aborted"; exit 1; }
+fi
+
+for product in cli desktop; do
+    local_prefix="${product}/${VERSION}/"
+    log_step "deleting s3://${RSV_BUCKET}/${local_prefix}"
+    aws s3 rm "s3://${RSV_BUCKET}/${local_prefix}" \
+        --endpoint-url "$R2_ENDPOINT" \
+        --recursive
+done
+log_info "scrubbed ${VERSION}"

--- a/scripts/dev/scrub-sentinel.sh
+++ b/scripts/dev/scrub-sentinel.sh
@@ -44,10 +44,16 @@ for arg in "$@"; do
             exit 0
             ;;
         v[0-9]*)
-            [[ -n "$VERSION" ]] && { log_error "only one version argument"; exit 2; }
+            [[ -n "$VERSION" ]] && {
+                log_error "only one version argument"
+                exit 2
+            }
             VERSION="$arg"
             ;;
-        *) log_error "unknown argument: $arg"; exit 2 ;;
+        *)
+            log_error "unknown argument: $arg"
+            exit 2
+            ;;
     esac
 done
 
@@ -91,7 +97,10 @@ if git -C "$REPO_ROOT" rev-parse --verify "refs/tags/${VERSION}" >/dev/null 2>&1
     log_warn "  reconsider re-running CD for ${VERSION} instead"
     if [[ "$EXECUTE" == "true" && "$SKIP_CONFIRM" == "false" ]]; then
         read -r -p "type 'YES I UNDERSTAND' to proceed: " confirm
-        [[ "$confirm" == "YES I UNDERSTAND" ]] || { log_error "aborted"; exit 1; }
+        [[ "$confirm" == "YES I UNDERSTAND" ]] || {
+            log_error "aborted"
+            exit 1
+        }
     fi
 fi
 
@@ -102,7 +111,10 @@ fi
 
 if [[ "$SKIP_CONFIRM" != "true" ]]; then
     read -r -p "delete the listed prefixes? [y/N] " ack
-    [[ "$ack" == "y" || "$ack" == "Y" ]] || { log_error "aborted"; exit 1; }
+    [[ "$ack" == "y" || "$ack" == "Y" ]] || {
+        log_error "aborted"
+        exit 1
+    }
 fi
 
 for product in cli desktop; do


### PR DESCRIPTION
## Summary

- Replace #458's prefix-existence write-once guard with a `.released` sentinel written only after every CI gate passes.
- New BLOCKER drift gate asserts sentinel ↔ git-tag bijection per push to main.
- Orphan prefixes (bytes without sentinel) auto-scrubbed at upload time + belt-and-suspenders cancel-cleanup workflow.
- Unblocks v1.0.5 (next successful run on main will recover the orphan automatically).

## Fixes

State-drift bug that blocked main after run 24876643247: CI was force-cancelled at attempt 2 after `stage-artifacts` uploaded `cli/v1.0.5/*`, CD never ran, #458's prefix-existence guard permanently burned v1.0.5 on every subsequent push.

## Test plan

- [x] 10/10 gate unit tests pass locally (`test-release-state-consistency.sh`)
- [x] 4/4 write-once guard cases pass with new sentinel-aware semantics
- [x] 5/5 quality gates pass (`bash .ci/scripts/test/run-all.sh`)
- [x] `check-workflow-gates.sh` confirms all new `if:` blocks use `always()`
- [x] Address Gemini review (commit a91788342): O(1) associative-array lookups in cleanup-versions.sh + release-state-validator.sh; portable printf in write-release-sentinel.sh.
- [ ] CI on this branch passes end-to-end
- [ ] Follow-up next push on main: drift gate confirms bijection holds, orphan v1.0.5 auto-scrubbed by pre-upload guard

## Out of scope / follow-up

- Package-repo two-phase commit (apt/rpm/apk/archlinux) — separate PR, cd-stage.yml restructure.
- `cd-v2.yml` cleanup-on-failure R2 purge kept as defense-in-depth.

Plan: \`/home/muhammed/.claude/plans/let-s-create-a-plan-sprightly-hickey.md\`

<!-- desc-refresh: 1777025316 -->