### PR TITLE
fix(ci,cli): cleanup-preview submodule auth + standalone-run hardening + info-color readability

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -16,7 +16,25 @@ jobs:
     # Skip fork PRs (no access to secrets)
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
+      # Mint a GitHub App token scoped to console + account so the later
+      # `git submodule update --init private/account` step has credentials.
+      # This composite action also configures global git credentials via
+      # `url."https://x-access-token:$TOKEN@github.com/".insteadOf "https://github.com/"`,
+      # which is what makes submodule fetches authenticate (actions/checkout's
+      # token applies via `includeIf.gitdir` in the parent repo's local scope
+      # only — submodule gitdirs don't pick that up, hence the previous
+      # "could not read Username for 'https://github.com'" failure).
+      - uses: ./.github/actions/app-token
+        id: app-token
+        with:
+          client-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          preset: readonly
+          repositories: console,account
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -16,14 +16,21 @@ jobs:
     # Skip fork PRs (no access to secrets)
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      # Mint a GitHub App token scoped to console + account so the later
-      # `git submodule update --init private/account` step has credentials.
-      # This composite action also configures global git credentials via
-      # `url."https://x-access-token:$TOKEN@github.com/".insteadOf "https://github.com/"`,
-      # which is what makes submodule fetches authenticate (actions/checkout's
-      # token applies via `includeIf.gitdir` in the parent repo's local scope
-      # only — submodule gitdirs don't pick that up, hence the previous
-      # "could not read Username for 'https://github.com'" failure).
+      # Initial checkout uses the default GITHUB_TOKEN. We need this to land
+      # before the local `./.github/actions/app-token` reference because
+      # local composite actions are loaded from the workspace — without the
+      # repo on disk first, the runner can't resolve them.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      # Mint a GitHub App token scoped to console + account. The composite's
+      # last step is `git config --global
+      # url."https://x-access-token:$TOKEN@github.com/".insteadOf
+      # "https://github.com/"`, which is what makes the later
+      # `git submodule update --init private/account` authenticate.
+      # actions/checkout's own token writes credentials at parent-repo local
+      # scope via includeIf.gitdir, which doesn't apply to submodule gitdirs —
+      # hence the "could not read Username for 'https://github.com'" failure
+      # this PR is fixing.
       - uses: ./.github/actions/app-token
         id: app-token
         with:
@@ -31,10 +38,6 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           preset: readonly
           repositories: console,account
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:

--- a/.github/workflows/standalone-run.yml
+++ b/.github/workflows/standalone-run.yml
@@ -198,7 +198,15 @@ jobs:
       # first, then in the next step wipe everything around it.
       - name: Pre-build renet (so harden can wipe source while keeping the binary)
         if: inputs.enable-debug || inputs.desktop-environment != 'none'
-        run: .ci/scripts/infra/build-renet.sh
+        run: |
+          # renet's eBPF generator (pkg/ebpf/gen.go) shells out to clang +
+          # llvm-strip + needs libbpf headers. provision-vms installs these
+          # later, but we have to compile renet *before* harden, which is
+          # before that step — so install them here. apt is idempotent so
+          # the redundant install in provision-vms is a cheap no-op.
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq clang llvm libbpf-dev linux-headers-generic
+          .ci/scripts/infra/build-renet.sh
 
       - name: Harden runner for debug access
         if: inputs.enable-debug || inputs.desktop-environment != 'none'

--- a/.github/workflows/standalone-run.yml
+++ b/.github/workflows/standalone-run.yml
@@ -190,14 +190,52 @@ jobs:
       - name: Install sqlcmd (go-sqlcmd)
         run: sudo private/middleware/scripts/install-sqlcmd.sh
 
+      # When debug or desktop is enabled we will strip private/renet/ down to
+      # just bin/renet so a tmate/vnc user cannot read the source. Provision
+      # VMs (further down) only needs the compiled binary at
+      # private/renet/bin/renet — see ci-provision-start.sh and build-renet.sh,
+      # which both no-op cleanly once that file already exists. So compile
+      # first, then in the next step wipe everything around it.
+      - name: Pre-build renet (so harden can wipe source while keeping the binary)
+        if: inputs.enable-debug || inputs.desktop-environment != 'none'
+        run: .ci/scripts/infra/build-renet.sh
+
       - name: Harden runner for debug access
         if: inputs.enable-debug || inputs.desktop-environment != 'none'
         run: |
-          # Remove app token from git config (prevents cloning private repos)
-          git config --global --unset-all 'url.https://x-access-token' || true
+          # 1. Strip the app token from git config. The previous form
+          #    `--unset-all 'url.https://x-access-token'` doesn't match because
+          #    the actual key looks like
+          #      url.https://x-access-token:<TOKEN>@github.com/.insteadOf
+          #    so we list all keys under the url.https://x-access-token prefix
+          #    and unset each. The `|| true` keeps a (legitimate) "no entries"
+          #    case from failing the step.
+          git config --global --get-regexp '^url\.https://x-access-token' \
+            | awk '{print $1}' \
+            | while read -r key; do
+                git config --global --unset "$key" || true
+              done
+          git config --global --get-regexp '^url\.https://x-access-token' \
+            && { echo "::error::Failed to remove app-token git config entries"; exit 1; } \
+            || true
 
-          # Remove renet source code from disk
-          rm -rf private/renet
+          # 2. Wipe renet source files but keep bin/renet so VM provisioning
+          #    (which still runs after tmate) can exec the binary. -mindepth 1
+          #    avoids deleting the directory itself; -maxdepth 1 keeps us from
+          #    descending into bin/.
+          find private/renet -mindepth 1 -maxdepth 1 ! -name 'bin' \
+            -exec rm -rf {} +
+
+          # 3. Wipe the submodule's git directory. Without this,
+          #    .git/modules/private/renet/ holds the full source history of
+          #    the private repo even though private/renet/.git was removed.
+          rm -rf .git/modules/private/renet
+
+          # 4. Strip the ELF symbol table from the binary. Best-effort scrub
+          #    of source-hint metadata; Go's runtime keeps some package-name
+          #    strings, so this is partial protection. Full opacity needs
+          #    -ldflags='-s -w' -trimpath in renet's build.sh dev path.
+          strip private/renet/bin/renet 2>/dev/null || true
 
       - name: Create Debug Session
         if: inputs.enable-debug
@@ -209,8 +247,10 @@ jobs:
 
       # SECURITY NOTE: Debug sessions are hardened before tmate starts:
       # 1. App token removed from git config (no cloning private repos)
-      # 2. private/renet source removed from disk
-      # 3. GITHUB_TOKEN not present (images pre-pulled, no auth needed from here)
+      # 2. private/renet source removed from disk; only bin/renet remains
+      # 3. .git/modules/private/renet removed (no source via git history)
+      # 4. ELF symbol table stripped from the renet binary
+      # 5. GITHUB_TOKEN not present (images pre-pulled, no auth needed from here)
 
       - name: Start Backend Services
         id: backend

--- a/.github/workflows/standalone-run.yml
+++ b/.github/workflows/standalone-run.yml
@@ -245,6 +245,46 @@ jobs:
           #    -ldflags='-s -w' -trimpath in renet's build.sh dev path.
           strip private/renet/bin/renet 2>/dev/null || true
 
+          # 5. Scrub actions/checkout's GitHub credentials so a tmate user
+          #    can't re-clone private repos. The credential storage uses an
+          #    indirection: .git/config holds an `includeIf gitdir:...` entry
+          #    pointing at /home/runner/work/_temp/git-credentials-<uuid>.config,
+          #    which holds the actual `Authorization: basic <base64>`
+          #    extraheader (where base64 = x-access-token:<TOKEN>). The
+          #    actions/checkout post-step normally cleans both halves, but
+          #    that runs at the end of the job — long after tmate gets shell.
+          #    Scrub all three layers (defensive: extraheader, includeIf, file).
+          git config --local --unset http.https://github.com/.extraheader 2>/dev/null || true
+          git submodule foreach --recursive \
+            'git config --local --unset http.https://github.com/.extraheader 2>/dev/null || true' \
+            2>/dev/null || true
+          for cfg in .git/config $(find .git/modules -maxdepth 4 -name config -type f 2>/dev/null); do
+            git config --file "$cfg" --get-regexp '^includeIf' 2>/dev/null \
+              | awk '{print $1}' \
+              | while read -r key; do
+                  git config --file "$cfg" --unset "$key" 2>/dev/null || true
+                done
+          done
+          rm -f /home/runner/work/_temp/git-credentials-*.config
+
+          # 6. Sanity check: any of the above failing silently is worse than
+          #    a loud failure here, because a half-cleaned runner that *looks*
+          #    hardened is the worst kind of leak. Fail the job if a
+          #    `Authorization: basic` header survives anywhere or any
+          #    git-credentials-*.config file is still on disk.
+          if git config --list --show-origin 2>/dev/null \
+              | grep -i 'authorization: basic' >/dev/null; then
+            echo "::error::extraheader credentials still present after harden"
+            git config --list --show-origin | grep -i 'authorization: basic' || true
+            exit 1
+          fi
+          if find /home/runner/work/_temp -maxdepth 1 -name 'git-credentials-*' \
+              -print 2>/dev/null | grep -q .; then
+            echo "::error::git-credentials temp files still on disk after harden"
+            exit 1
+          fi
+          echo "Harden complete: no GitHub credentials reachable from this runner."
+
       - name: Create Debug Session
         if: inputs.enable-debug
         id: tmate

--- a/packages/cli/src/services/output.ts
+++ b/packages/cli/src/services/output.ts
@@ -200,7 +200,11 @@ class OutputService {
 
   info(message: string): void {
     if (this._quiet) return;
-    console.error(this.colorEnabled ? chalk.blue(message) : message);
+    // chalk.blueBright (ANSI 12) reads cleanly on both light and dark
+    // terminal backgrounds. The default chalk.blue (ANSI 4) renders as a
+    // dark navy on standard 16-color palettes and was reported unreadable
+    // against black backgrounds (see `rdc repo template list` output).
+    console.error(this.colorEnabled ? chalk.blueBright(message) : message);
   }
 
   dim(text: string): string {


### PR DESCRIPTION
## Summary

Bundles three small CI/CLI hygiene fixes that surfaced from a single thread of investigation. Single-review surface, no overlap.

### 1. Cleanup PR Preview can fetch the private `account` submodule

`cleanup-preview.yml` was using `actions/checkout` without a custom token. The default `GITHUB_TOKEN` is workflow-repo-scoped, so when the workflow later ran `git submodule update --init private/account`, git fell through to interactive credential input and died:

```
fatal: could not read Username for 'https://github.com': No such device or address
fatal: clone of 'https://github.com/rediacc/account.git' into submodule path
'/home/runner/work/console/console/private/account' failed
```

The downstream `Cleanup Stripe sandbox` + `Cleanup PR Turnstile widget` steps then never ran, so per-PR Stripe customers and Turnstile widgets have been leaking on every PR close.

Fix: mint a GitHub App installation token via the existing `.github/actions/app-token` composite action, pass it to `actions/checkout`. The composite's last step is `git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"` (action.yml:81-89) — this is what makes downstream submodule fetches authenticate, since `actions/checkout`'s own token is written via `includeIf.gitdir` in the parent repo's local scope only and doesn't apply to submodule gitdirs. Same pattern `ci.yml` uses.

`actions/checkout` runs *before* the local composite reference (caught by chatgpt-codex-connector) so the workspace contains the action files when the runner tries to resolve them.

Worth a follow-up: audit existing leaked per-PR Stripe customers / Turnstile widgets created since this regressed and reap them.

### 2. Standalone Run debug mode actually hides renet source + tokens before tmate

The `Harden runner for debug access` step in `standalone-run.yml` was supposed to scrub the runner before tmate, but had three issues:

- `rm -rf private/renet` killed the source as intended, but the later `Provision VMs` step calls `build-renet.sh` which exits 1 if `private/renet/` is missing. The combination `enable-debug=true && vm-os != 'none'` has been broken since the step was introduced (`git blame` confirmed: hasn't been touched since `4a952648`, the file was added with this conflict already present — just no one had hit the combination until now).
- `git config --global --unset-all 'url.https://x-access-token'` silently failed every run — the actual key shape is `url.https://x-access-token:<TOKEN>@github.com/.insteadOf`, so the prefix-only key matched nothing and emitted `error: invalid key: url.https://x-access-token` (masked by `|| true`). The app token was never actually being scrubbed.
- `actions/checkout` stores the token in two places that survived both the failed `git config --unset` and the `rm -rf private/renet`: `/home/runner/work/_temp/git-credentials-<uuid>.config` (the actual `Authorization: basic <base64>` extraheader), and `includeIf.gitdir:` entries in `.git/config` and every `.git/modules/<sub>/config` pointing at that file. A tmate user could `cat /home/runner/work/_temp/git-credentials-*.config`, base64-decode, and clone any of `console,middleware,renet,account,sql,elite,homebrew-tap` (the app token's scope). Defeats the whole point.

Fix:

- New `Pre-build renet` step (gated on the same `enable-debug || desktop-environment != 'none'` condition) — installs clang/llvm/libbpf for renet's eBPF generator, then runs `build-renet.sh` so the binary lands at `private/renet/bin/renet` *before* harden.
- Rewritten harden step:
  - Properly remove app-token git config entries (`--get-regexp` + per-key `--unset`, with assertion that nothing's left).
  - `find private/renet -mindepth 1 -maxdepth 1 ! -name 'bin' -exec rm -rf {} +` — keep only the binary.
  - `rm -rf .git/modules/private/renet` — wipes the source git history (without this, full source recoverable via `git --git-dir=.git/modules/private/renet log -p --all`).
  - `strip private/renet/bin/renet` — best-effort scrub of ELF symbol table.
  - Walk `.git/config` and every `.git/modules/*/config`: unset `http.https://github.com/.extraheader` and every `includeIf` entry, then `rm -f /home/runner/work/_temp/git-credentials-*.config`.
  - **Fail-loud assertion**: if any `Authorization: basic` survives in any git config, or any `git-credentials-*.config` file remains, the step exits 1. So a future regression in actions/checkout's storage layout fails the harden step explicitly instead of silently leaking.

Verified end-to-end on two test dispatches of `Standalone Run` from this branch with `enable-debug=true && vm-os=ubuntu-24.04`:
- [Run 25272043195](https://github.com/rediacc/console/actions/runs/25272043195) confirmed the pre-build + source-removal flow works (Provision VMs succeeded after the source wipe).
- [Run 25272378134](https://github.com/rediacc/console/actions/runs/25272378134) confirmed the credential scrub: the harden step printed `Harden complete: no GitHub credentials reachable from this runner.` and Provision VMs still succeeded.

Caveat documented inline: full opacity of the binary still needs `-ldflags='-s -w' -trimpath` in renet's `build.sh dev` path. Strip is best-effort.

### 3. CLI `info` log color is readable on dark terminals

`outputService.info()` was wrapping every informational log line in `chalk.blue` (ANSI 4 — dark navy on standard 16-color palettes). Reported against `rdc repo template list` but applies to every CLI command that emits informational text. Switched to `chalk.blueBright` (ANSI 12 — lighter blue) which keeps the visual cue but reads cleanly on both light and dark terminal backgrounds.

Three related sites use `chalk.blue` similarly (`logFormatters.ts:19`, `queueFormatters.ts:103`, `queueFormatters.ts:37/80`); flagged in the commit message as possible follow-ups, deliberately not changed in this PR.

## Test plan

- [x] `npm run check:format` / `check:i18n` / `check:deps` / `check:lint` clean locally.
- [x] CLI typecheck (`tsc --noEmit`) clean.
- [x] CLI vitest suite — 918/918 pass.
- [x] Standalone Run dispatched twice with `enable-debug=true && vm-os=ubuntu-24.04` — both green; harden step's assertion passed; Provision VMs succeeded post-harden.
- [ ] CI green on this PR.
- [ ] After merge: confirm next PR-close run of `Cleanup PR Preview` is green and that the `Cleanup Stripe sandbox` + `Cleanup PR Turnstile widget` steps actually execute.
- [ ] Manual: `rdc repo template list` (and any `outputService.info` call) renders in light blue, readable on a dark terminal.
