### PR TITLE
fix(cli): use blueBright for info logs so output is readable on dark terminals

### DIFF
--- a/packages/cli/src/services/output.ts
+++ b/packages/cli/src/services/output.ts
@@ -200,7 +200,11 @@ class OutputService {
 
   info(message: string): void {
     if (this._quiet) return;
-    console.error(this.colorEnabled ? chalk.blue(message) : message);
+    // chalk.blueBright (ANSI 12) reads cleanly on both light and dark
+    // terminal backgrounds. The default chalk.blue (ANSI 4) renders as a
+    // dark navy on standard 16-color palettes and was reported unreadable
+    // against black backgrounds (see `rdc repo template list` output).
+    console.error(this.colorEnabled ? chalk.blueBright(message) : message);
   }
 
   dim(text: string): string {


### PR DESCRIPTION
## Summary

Fixes the unreadable dark-blue rendering of `outputService.info()` output on dark terminal backgrounds. Reported against `rdc repo template list`, but applies to every CLI command that emits informational text.

### What changed

`packages/cli/src/services/output.ts:201-208` — `chalk.blue(message)` → `chalk.blueBright(message)` (one-line behavioural change, four lines of explanatory comment).

`chalk.blue` maps to ANSI color 4 (dark navy on every standard 16-color palette). Against black backgrounds — the default in gnome-terminal, Apple Terminal "Pro", Windows Terminal "One Half Dark", VS Code integrated terminal, etc. — it renders as low-contrast and is hard to read. `chalk.blueBright` maps to ANSI color 12 (lighter blue), preserves the "this is informational" visual cue, and reads cleanly on every default terminal theme tested (light or dark). No-color environments (non-TTY pipes, `NO_COLOR=1`, `--no-color`) are unaffected — chalk's detection still strips the escape codes.

### Scope

Deliberately limited to the `OutputService.info` call site. Three related sites use `chalk.blue` in similar roles and share the readability issue; flagged inline in the commit message as possible follow-ups:

- `packages/cli/src/utils/logFormatters.ts:19` — log-level color map, `info → chalk.blue`. Same semantic, same fix.
- `packages/cli/src/utils/queueFormatters.ts:103` — queue-event severity, `info → chalk.blue`. Same.
- `packages/cli/src/utils/queueFormatters.ts:37` and `:80` — queue state / priority palettes (`PROCESSING/ASSIGNED/ACTIVE` and `priority 3` respectively). Not strictly "info" but render the same dark blue. They're part of a wider state/priority color palette though, so changing them risks visual conflict with neighbors (`chalk.cyan` is in the same palette at `priority 4`); deferred for a design call.

Want any of those rolled in, say the word and I'll do it; otherwise this PR stays single-line-with-comment.

## Test plan

- [x] CLI typecheck (`tsc --noEmit`) clean.
- [x] CLI ESLint clean on the changed file.
- [x] `vitest run` — 918/918 pass.
- [ ] Manual: `rdc repo template list` (and any `outputService.info` call) renders in light blue, readable on a dark terminal.
