### PR TITLE
fix(cli): clean up term -c output, SSH agent warning, dev SEA self-update

### DIFF
--- a/.ci/scripts/housekeeping/cleanup-versions.sh
+++ b/.ci/scripts/housekeeping/cleanup-versions.sh
@@ -1202,8 +1202,11 @@ cleanup_r2() {
                     pkg_deleted=$((pkg_deleted + 1))
                     continue
                 fi
-                # Keep if semver is in top-N
-                if echo "$top_versions" | grep -qxF "$semver"; then
+                # Keep if semver is in top-N. Herestring avoids the
+                # `echo | grep -q` pipe: grep -q exits on the first match,
+                # SIGPIPE-ing echo and leaking "write error: Broken pipe"
+                # to stderr once per kept version (~6/run on this codebase).
+                if grep -qxF "$semver" <<<"$top_versions"; then
                     continue
                 fi
                 local tag="v${semver}, outside top-${R2_PACKAGE_KEEP_VERSIONS}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,14 @@ cd packages/www && npm run build
 cd packages/www && npm run dev
 ```
 
+### Iterating on a local SEA (`./rdc.sh --override-local`)
+
+`./rdc.sh --override-local` rebuilds the CLI SEA from local source and installs it over `~/.local/share/rediacc/bin/rdc`. Use it when iterating on SEA-only behaviors (embedded renet, auto-update gating) that the dev-mode `cli-bundle.cjs` path doesn't exercise.
+
+The flag runs `ensure_deps` + `ensure_packages_built` first, so edits to `packages/shared`, `packages/shared-desktop`, or `packages/provisioning` are picked up by the bundler — those packages resolve through their own `dist/` outputs, and forgetting to rebuild them was a silent footgun. Auto-update is short-circuited via the `VERSION === '0.0.0-dev'` guard in `packages/cli/src/utils/platform.ts::isUpdateDisabled`, so the override binary survives the next `rdc` invocation.
+
+The previous binary is preserved as a backup matching `getOldBinaryPath()` (`<base>.old<ext>` — `rdc.old` on Linux/macOS, `rdc.old.exe` on Windows) so `cleanupOldBinary()` removes it on the next successful update.
+
 ## Versioning
 
 Version source of truth: **git tags** (e.g., `v0.8.3`). No version bump commits.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9764,32 +9764,6 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
-    "node_modules/@tanstack/query-core": {
-      "version": "5.100.8",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.8.tgz",
-      "integrity": "sha512-ceYwSFOqjPwET5TA6IOYxzxlGc0ekyH/gfOtWkP0PX43rzX9bxW48Iuw8KAduKCToi4rJAQ6nRy2kAe8gszdmg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/react-query": {
-      "version": "5.100.8",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.8.tgz",
-      "integrity": "sha512-iNNEekixXU5vtAGKKZX2lx3jTooG5yNY+kv0wSgEdEYG0Mj0JM5bcuQtC35ZAP3nDopT6jciUK3xeX65U7AnfA==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-core": "5.100.8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -28234,7 +28208,7 @@
         "@opentelemetry/semantic-conventions": "^1.38.0",
         "@rediacc/shared": "*",
         "@reduxjs/toolkit": "^2.11.2",
-        "@tanstack/react-query": "^5.100.8",
+        "@tanstack/react-query": "^5.100.9",
         "@types/react-syntax-highlighter": "^15.5.13",
         "@vitest/runner": "^4.0.18",
         "@vitest/utils": "^4.0.18",
@@ -28277,6 +28251,32 @@
         "vite": "^7.3.2",
         "vite-tsconfig-paths": "^6.0.3",
         "vitest": "^4.0.16"
+      }
+    },
+    "packages/web/node_modules/@tanstack/query-core": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.9.tgz",
+      "integrity": "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "packages/web/node_modules/@tanstack/react-query": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.9.tgz",
+      "integrity": "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.9"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "packages/web/node_modules/axios": {

--- a/packages/cli/src/commands/__tests__/term-output-mode.test.ts
+++ b/packages/cli/src/commands/__tests__/term-output-mode.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { resolveTermOutputMode } from '../term.js';
+
+describe('resolveTermOutputMode', () => {
+  it('interactive shell: keep spinners + force TTY', () => {
+    expect(resolveTermOutputMode({})).toEqual({ quietOutput: false, noTTY: false });
+  });
+
+  it('plain command: silence chatter and drop TTY', () => {
+    expect(resolveTermOutputMode({ command: 'echo HELLO' })).toEqual({
+      quietOutput: true,
+      noTTY: true,
+    });
+  });
+
+  it('container exec with command: silence chatter but keep TTY for docker exec -it', () => {
+    expect(
+      resolveTermOutputMode({
+        command: 'bash',
+        container: 'web',
+        containerAction: 'exec',
+      })
+    ).toEqual({ quietOutput: true, noTTY: false });
+  });
+
+  it('container terminal with command: same TTY exception as exec', () => {
+    expect(
+      resolveTermOutputMode({
+        command: 'bash',
+        container: 'web',
+        containerAction: 'terminal',
+      })
+    ).toEqual({ quietOutput: true, noTTY: false });
+  });
+
+  it('container without explicit action: defaults to terminal mode, keep TTY', () => {
+    expect(
+      resolveTermOutputMode({
+        command: 'bash',
+        container: 'web',
+      })
+    ).toEqual({ quietOutput: true, noTTY: false });
+  });
+
+  it('container logs with command: NOT interactive, drop TTY', () => {
+    expect(
+      resolveTermOutputMode({
+        command: 'irrelevant',
+        container: 'web',
+        containerAction: 'logs',
+      })
+    ).toEqual({ quietOutput: true, noTTY: true });
+  });
+
+  it('container without command: silence chatter, keep TTY (interactive default)', () => {
+    expect(resolveTermOutputMode({ container: 'web' })).toEqual({
+      quietOutput: true,
+      noTTY: false,
+    });
+  });
+});

--- a/packages/cli/src/commands/repo-migrate.ts
+++ b/packages/cli/src/commands/repo-migrate.ts
@@ -115,8 +115,9 @@ async function assertNotMountedOnTarget(
   if (!targetCheck.success || !targetCheck.stdout) return;
   try {
     const repos = JSON.parse(targetCheck.stdout);
-    const mounted = (repos as { guid: string; mounted: boolean }[]).find(
-      (r) => r.guid === repoGuid && r.mounted
+    // renet's `list repositories --json` keys repos by GUID under `name` and has no `guid` field.
+    const mounted = (repos as { name: string; mounted: boolean }[]).find(
+      (r) => r.name === repoGuid && r.mounted
     );
     if (mounted) {
       throw new ValidationError(

--- a/packages/cli/src/commands/repo-migrate.ts
+++ b/packages/cli/src/commands/repo-migrate.ts
@@ -15,6 +15,7 @@ import type { Command } from 'commander';
 import { t } from '../i18n/index.js';
 import { configService } from '../services/config-resources.js';
 import { localExecutorService } from '../services/local-executor.js';
+import { parseRepositoryListOutput } from './repo-list-parser.js';
 import { outputService } from '../services/output.js';
 import { deployRepoKeyIfNeeded } from '../services/repo-key-deployment.js';
 import { assertCommandPolicy, CMD } from '../utils/command-policy.js';
@@ -114,11 +115,13 @@ async function assertNotMountedOnTarget(
   });
   if (!targetCheck.success || !targetCheck.stdout) return;
   try {
-    const repos = JSON.parse(targetCheck.stdout);
     // renet's `list repositories --json` keys repos by GUID under `name` and has no `guid` field.
-    const mounted = (repos as { name: string; mounted: boolean }[]).find(
-      (r) => r.name === repoGuid && r.mounted
-    );
+    // parseRepositoryListOutput tolerates log-prefixed / non-array stdout.
+    const repos = parseRepositoryListOutput(targetCheck.stdout) as {
+      name: string;
+      mounted: boolean;
+    }[];
+    const mounted = repos.find((r) => r.name === repoGuid && r.mounted);
     if (mounted) {
       throw new ValidationError(
         t('errors.repositoryAlreadyMounted', { name: repoName, machine: targetMachine })

--- a/packages/cli/src/commands/term.ts
+++ b/packages/cli/src/commands/term.ts
@@ -119,6 +119,7 @@ async function validateAndGetConnectionDetails(opts: {
   team?: string;
   machine?: string;
   repository?: string;
+  quiet?: boolean;
 }) {
   const provider = await getStateProvider();
   if (provider.isCloud && !opts.team) {
@@ -129,17 +130,22 @@ async function validateAndGetConnectionDetails(opts: {
   }
 
   const teamName = opts.team ?? '';
-  const connectionDetails = await withSpinner(t('commands.term.fetchingDetails'), () =>
-    getSSHConnectionDetails(teamName, opts.machine!, opts.repository)
-  );
+  const machineName = opts.machine;
+  const connectionDetails = opts.quiet
+    ? await getSSHConnectionDetails(teamName, machineName, opts.repository)
+    : await withSpinner(t('commands.term.fetchingDetails'), () =>
+        getSSHConnectionDetails(teamName, machineName, opts.repository)
+      );
 
-  const connectivityResult = await withSpinner(
-    t('commands.term.testingConnectivity', {
-      host: connectionDetails.host,
-      port: connectionDetails.port,
-    }),
-    () => testSSHConnectivity(connectionDetails.host, connectionDetails.port, 10000)
-  );
+  const connectivityResult = opts.quiet
+    ? await testSSHConnectivity(connectionDetails.host, connectionDetails.port, 10000)
+    : await withSpinner(
+        t('commands.term.testingConnectivity', {
+          host: connectionDetails.host,
+          port: connectionDetails.port,
+        }),
+        () => testSSHConnectivity(connectionDetails.host, connectionDetails.port, 10000)
+      );
 
   if (!connectivityResult.success) {
     throw new Error(
@@ -154,7 +160,7 @@ async function validateAndGetConnectionDetails(opts: {
   return {
     connectionDetails,
     teamName,
-    machineName: opts.machine,
+    machineName,
     repositoryName: opts.repository,
   };
 }
@@ -226,10 +232,11 @@ async function executeSSH(
   remoteCommand: string | undefined,
   title: string,
   connectionDetails: ConnectionDetails,
-  useExternal: boolean
+  useExternal: boolean,
+  quiet: boolean
 ): Promise<void> {
   if (!useExternal) {
-    await runInlineSSH(sshConnection, destination, remoteCommand, title, connectionDetails);
+    await runInlineSSH(sshConnection, destination, remoteCommand, title, connectionDetails, quiet);
     return;
   }
 
@@ -245,7 +252,7 @@ async function executeSSH(
     debugLog(
       `External terminal failed: ${error instanceof Error ? error.message : String(error)}, falling back to inline SSH`
     );
-    await runInlineSSH(sshConnection, destination, remoteCommand, title, connectionDetails);
+    await runInlineSSH(sshConnection, destination, remoteCommand, title, connectionDetails, quiet);
   }
 }
 
@@ -254,8 +261,14 @@ async function connectTerminal(options: TermConnectOptions): Promise<void> {
   const opts = await configService.applyDefaults(options);
   await enforceTermPolicy(opts);
 
+  // Non-interactive command mode (`-c "..."`) prints only the command's output:
+  // skip spinners + the "Connecting to..." line, and don't force a remote TTY
+  // (the remote sandbox banner is gated by `[ -t 1 ]`, and ssh prints
+  // "Connection to ... closed." only when -t allocates a PTY).
+  const quiet = !!opts.command;
+
   const { connectionDetails, teamName, machineName, repositoryName } =
-    await validateAndGetConnectionDetails(opts);
+    await validateAndGetConnectionDetails({ ...opts, quiet });
   const localConfig = await configService.getLocalConfig();
   const machine = localConfig.machines[machineName];
   if (!machine) {
@@ -276,7 +289,7 @@ async function connectTerminal(options: TermConnectOptions): Promise<void> {
   const sshConnection = new SSHConnection(
     connectionDetails.privateKey,
     connectionDetails.known_hosts,
-    { port: connectionDetails.port, forceTTY: true }
+    { port: connectionDetails.port, forceTTY: !quiet }
   );
 
   let success = true;
@@ -297,7 +310,8 @@ async function connectTerminal(options: TermConnectOptions): Promise<void> {
       remoteCommand,
       title,
       connectionDetails,
-      shouldUseExternalTerminal(options)
+      shouldUseExternalTerminal(options),
+      quiet
     );
   } catch (err) {
     success = false;
@@ -383,10 +397,12 @@ async function runInlineSSH(
   destination: string,
   remoteCommand: string | undefined,
   title: string,
-  connectionDetails: ConnectionDetails
+  connectionDetails: ConnectionDetails,
+  quiet: boolean
 ): Promise<void> {
-  // eslint-disable-next-line no-console
-  console.log(t('commands.term.connectingTo', { title }));
+  if (!quiet) {
+    process.stdout.write(`${t('commands.term.connectingTo', { title })}\n`);
+  }
 
   const child = spawnSSH(destination, sshConnection.sshOptions, remoteCommand, {
     env: { ...process.env, ...connectionDetails.environment },

--- a/packages/cli/src/commands/term.ts
+++ b/packages/cli/src/commands/term.ts
@@ -266,7 +266,7 @@ async function executeSSH(
 //   ssh prints "Connection to HOST closed." only when -t allocated a PTY.
 //   Exception: container exec/terminal wrap the command in `docker exec -it`,
 //   which requires a real TTY upstream — keep forceTTY for those.
-function resolveTermOutputMode(opts: TermConnectOptions): {
+export function resolveTermOutputMode(opts: TermConnectOptions): {
   quietOutput: boolean;
   noTTY: boolean;
 } {

--- a/packages/cli/src/commands/term.ts
+++ b/packages/cli/src/commands/term.ts
@@ -256,19 +256,39 @@ async function executeSSH(
   }
 }
 
+// Determines client-side output suppression and remote-TTY allocation for a
+// connectTerminal invocation.
+//
+// - quietOutput: skip the spinners and the "Connecting to..." stderr line so
+//   `term -c "..."` stdout stays clean (also applies to container modes since
+//   the user is asking for a specific docker action, not a shell session).
+// - noTTY: disable ssh -tt. Remote sandbox banner is gated by `[ -t 1 ]`, and
+//   ssh prints "Connection to HOST closed." only when -t allocated a PTY.
+//   Exception: container exec/terminal wrap the command in `docker exec -it`,
+//   which requires a real TTY upstream — keep forceTTY for those.
+function resolveTermOutputMode(opts: TermConnectOptions): {
+  quietOutput: boolean;
+  noTTY: boolean;
+} {
+  const isContainerInteractive =
+    !!opts.container &&
+    (opts.containerAction === 'exec' ||
+      opts.containerAction === 'terminal' ||
+      opts.containerAction === undefined);
+  const quietOutput = !!opts.command || !!opts.container;
+  const noTTY = !!opts.command && !isContainerInteractive;
+  return { quietOutput, noTTY };
+}
+
 async function connectTerminal(options: TermConnectOptions): Promise<void> {
   const startTime = Date.now();
   const opts = await configService.applyDefaults(options);
   await enforceTermPolicy(opts);
 
-  // Non-interactive command mode (`-c "..."`) prints only the command's output:
-  // skip spinners + the "Connecting to..." line, and don't force a remote TTY
-  // (the remote sandbox banner is gated by `[ -t 1 ]`, and ssh prints
-  // "Connection to ... closed." only when -t allocates a PTY).
-  const quiet = !!opts.command;
+  const { quietOutput, noTTY } = resolveTermOutputMode(opts);
 
   const { connectionDetails, teamName, machineName, repositoryName } =
-    await validateAndGetConnectionDetails({ ...opts, quiet });
+    await validateAndGetConnectionDetails({ ...opts, quiet: quietOutput });
   const localConfig = await configService.getLocalConfig();
   const machine = localConfig.machines[machineName];
   if (!machine) {
@@ -289,7 +309,7 @@ async function connectTerminal(options: TermConnectOptions): Promise<void> {
   const sshConnection = new SSHConnection(
     connectionDetails.privateKey,
     connectionDetails.known_hosts,
-    { port: connectionDetails.port, forceTTY: !quiet }
+    { port: connectionDetails.port, forceTTY: !noTTY }
   );
 
   let success = true;
@@ -311,7 +331,7 @@ async function connectTerminal(options: TermConnectOptions): Promise<void> {
       title,
       connectionDetails,
       shouldUseExternalTerminal(options),
-      quiet
+      quietOutput
     );
   } catch (err) {
     success = false;
@@ -401,7 +421,10 @@ async function runInlineSSH(
   quiet: boolean
 ): Promise<void> {
   if (!quiet) {
-    process.stdout.write(`${t('commands.term.connectingTo', { title })}\n`);
+    // Progress message on stderr — keeps stdout reserved for command output
+    // when -c piping is in play, matching the Unix convention used by ssh's
+    // own progress / banner messages.
+    process.stderr.write(`${t('commands.term.connectingTo', { title })}\n`);
   }
 
   const child = spawnSSH(destination, sshConnection.sshOptions, remoteCommand, {

--- a/packages/cli/src/services/__tests__/backup-schedule.test.ts
+++ b/packages/cli/src/services/__tests__/backup-schedule.test.ts
@@ -1,4 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// First-time module evaluation in CI runners can exceed the 5s default test
+// timeout (this file mocks 30+ deps before importing backup-schedule). Pull
+// the import into a single beforeAll with a generous timeout; the per-test
+// `await import` calls that follow then hit vitest's module cache and return
+// instantly. Cheaper than bumping every individual test's timeout.
+beforeAll(async () => {
+  await import('../backup-schedule.js');
+}, 30000);
 
 const mockExecStreaming = vi.fn();
 const mockConnect = vi.fn().mockResolvedValue(undefined);

--- a/packages/cli/src/services/__tests__/repo-mount-check.test.ts
+++ b/packages/cli/src/services/__tests__/repo-mount-check.test.ts
@@ -29,7 +29,7 @@ function cloudProvider() {
   return { isCloud: true };
 }
 
-function listResultStdout(repos: { guid: string; mounted: boolean }[]): string {
+function listResultStdout(repos: { name: string; mounted: boolean }[]): string {
   return JSON.stringify(repos);
 }
 
@@ -44,8 +44,8 @@ describe('assertRepoMountedOnMachine', () => {
       success: true,
       exitCode: 0,
       stdout: listResultStdout([
-        { guid: 'other-guid', mounted: true },
-        { guid: REPO_GUID, mounted: true },
+        { name: 'other-guid', mounted: true },
+        { name: REPO_GUID, mounted: true },
       ]),
     });
 
@@ -59,7 +59,7 @@ describe('assertRepoMountedOnMachine', () => {
     mockExecute.mockResolvedValue({
       success: true,
       exitCode: 0,
-      stdout: listResultStdout([{ guid: REPO_GUID, mounted: false }]),
+      stdout: listResultStdout([{ name: REPO_GUID, mounted: false }]),
     });
 
     await expect(assertRepoMountedOnMachine(REPO_NAME, REPO_GUID, MACHINE)).rejects.toBeInstanceOf(
@@ -71,7 +71,7 @@ describe('assertRepoMountedOnMachine', () => {
     mockExecute.mockResolvedValue({
       success: true,
       exitCode: 0,
-      stdout: listResultStdout([{ guid: 'someone-else', mounted: true }]),
+      stdout: listResultStdout([{ name: 'someone-else', mounted: true }]),
     });
 
     await expect(assertRepoMountedOnMachine(REPO_NAME, REPO_GUID, MACHINE)).rejects.toBeInstanceOf(

--- a/packages/cli/src/services/repo-mount-check.ts
+++ b/packages/cli/src/services/repo-mount-check.ts
@@ -38,7 +38,8 @@ export async function assertRepoMountedOnMachine(
     return;
   }
 
-  const entry = repos.find((r) => r.guid === repoGuid);
+  // renet's `list repositories --json` keys repos by GUID under `name` and has no `guid` field.
+  const entry = repos.find((r) => r.name === repoGuid);
   if (entry?.mounted !== true) {
     throw new ValidationError(
       t('errors.repoNotDeployed', { repository: repoName, machine: machineName })

--- a/packages/cli/src/utils/__tests__/platform.test.ts
+++ b/packages/cli/src/utils/__tests__/platform.test.ts
@@ -32,6 +32,9 @@ vi.mock('node:os', () => ({
   homedir: () => '/home/testuser',
 }));
 
+const versionMock = vi.hoisted(() => ({ VERSION: '1.2.3' }));
+vi.mock('../../version.js', () => versionMock);
+
 describe('utils/platform', () => {
   const originalExecPath = process.execPath;
   const originalPlatform = process.platform;
@@ -90,6 +93,7 @@ describe('utils/platform', () => {
       delete process.env.RDC_DISABLE_AUTOUPDATE;
       delete process.env.CI;
       Object.defineProperty(process, 'execPath', { value: '/usr/local/bin/rdc', writable: true });
+      versionMock.VERSION = '1.2.3';
     });
 
     it('returns true when RDC_DISABLE_AUTOUPDATE=1', () => {
@@ -123,6 +127,16 @@ describe('utils/platform', () => {
         value: '/home/user/project/build/rdc',
         writable: true,
       });
+      expect(isUpdateDisabled()).toBe(true);
+    });
+
+    it('returns true when VERSION is 0.0.0-dev (locally-built SEA)', () => {
+      versionMock.VERSION = '0.0.0-dev';
+      expect(isUpdateDisabled()).toBe(true);
+    });
+
+    it('returns true when VERSION ends with -dev', () => {
+      versionMock.VERSION = '1.0.13-dev';
       expect(isUpdateDisabled()).toBe(true);
     });
 

--- a/packages/cli/src/utils/platform.ts
+++ b/packages/cli/src/utils/platform.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import { getCacheDir, getStateDir } from '@rediacc/shared/paths';
 import lockfile from 'proper-lockfile';
+import { VERSION } from '../version.js';
 
 export const STAGED_UPDATE_DIR = join(getCacheDir(), 'staged-update');
 export const UPDATE_STATE_FILE = join(getStateDir(), 'update-state.json');
@@ -58,6 +59,14 @@ export function isUpdateDisabled(): boolean {
 
   // CI environments
   if (process.env.CI === 'true') return true;
+
+  // Dev / pre-release builds. A locally-built SEA carries 0.0.0-dev (or any
+  // -dev suffix) and is sitting somewhere like ~/.local/share/rediacc/bin/rdc.
+  // Auto-update would clobber it with the latest stable on every invocation,
+  // making local renet/CLI iteration impossible. The version constant is
+  // injected at build time, so this short-circuits identically across all
+  // platforms.
+  if (VERSION === '0.0.0-dev' || VERSION.endsWith('-dev')) return true;
 
   // Binary in build/dist/node_modules path
   const execDir = dirname(process.execPath);

--- a/packages/shared-desktop/src/ssh/__tests__/keyManager.test.ts
+++ b/packages/shared-desktop/src/ssh/__tests__/keyManager.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { decodeSSHKey } from '../keyManager.js';
+
+describe('decodeSSHKey normalization', () => {
+  const VALID_BODY = [
+    'b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAAB',
+    'AAAAMwAAAAtzc2gtZWQyNTUxOQAAACA1iaXz/V8Lwx9aB+r//AAA',
+    'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+  ].join('\n');
+
+  const wrap = (sep: string, trailing = '\n'): string =>
+    [`-----BEGIN OPENSSH PRIVATE KEY-----`, VALID_BODY, `-----END OPENSSH PRIVATE KEY-----`].join(
+      sep
+    ) + trailing;
+
+  it('strips CRLF line endings to LF (the ssh-add libcrypto trigger)', () => {
+    const crlfKey = wrap('\r\n', '\r\n');
+    const out = decodeSSHKey(crlfKey);
+    expect(out).not.toContain('\r');
+    expect(out.endsWith('\n')).toBe(true);
+  });
+
+  it('appends a trailing newline when missing (ssh-add expects one)', () => {
+    const noTrailing = wrap('\n', '');
+    const out = decodeSSHKey(noTrailing);
+    expect(out.endsWith('\n')).toBe(true);
+    expect(out.endsWith('\n\n')).toBe(false);
+  });
+
+  it('collapses multiple trailing newlines to exactly one', () => {
+    const tooManyNewlines = wrap('\n', '\n\n\n');
+    const out = decodeSSHKey(tooManyNewlines);
+    expect(out.endsWith('\n')).toBe(true);
+    expect(out.endsWith('\n\n')).toBe(false);
+  });
+
+  it('passes through an already-clean key unchanged in semantics', () => {
+    const clean = wrap('\n', '\n');
+    const out = decodeSSHKey(clean);
+    expect(out).toBe(clean);
+  });
+
+  it('rejects empty input', () => {
+    expect(() => decodeSSHKey('')).toThrow(/empty/i);
+    expect(() => decodeSSHKey('   \n  ')).toThrow(/empty/i);
+  });
+
+  it('rejects non-PEM input', () => {
+    expect(() => decodeSSHKey('not a key')).toThrow(/PEM format/i);
+  });
+
+  it('rejects PEM with unrecognized key type', () => {
+    const fake = '-----BEGIN GARBAGE-----\nzzz\n-----END GARBAGE-----\n';
+    expect(() => decodeSSHKey(fake)).toThrow(/key type not recognized/i);
+  });
+});

--- a/packages/shared-desktop/src/ssh/agent.ts
+++ b/packages/shared-desktop/src/ssh/agent.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { commandExists, getPlatform } from '../utils/platform.js';
+import { decodeSSHKey } from './keyManager.js';
 
 /**
  * Default timeout for SSH agent operations in milliseconds (10 seconds)
@@ -132,9 +133,14 @@ export async function addKeyToAgent(
     `key-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`
   );
 
+  // ssh-add uses libcrypto's stricter PEM parser — CRLF line endings or a
+  // missing trailing newline cause "error in libcrypto" even on keys that
+  // `ssh -i` accepts. Normalize before writing.
+  const normalizedKey = decodeSSHKey(privateKey);
+
   try {
     // Write the key to temp file with proper permissions
-    writeFileSync(tempKeyPath, privateKey, { mode: 0o600 });
+    writeFileSync(tempKeyPath, normalizedKey, { mode: 0o600 });
 
     await new Promise<void>((resolve, reject) => {
       let timedOut = false;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -36,7 +36,7 @@
     "@opentelemetry/semantic-conventions": "^1.38.0",
     "@rediacc/shared": "*",
     "@reduxjs/toolkit": "^2.11.2",
-    "@tanstack/react-query": "^5.100.8",
+    "@tanstack/react-query": "^5.100.9",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@vitest/runner": "^4.0.18",
     "@vitest/utils": "^4.0.18",

--- a/rdc.sh
+++ b/rdc.sh
@@ -28,11 +28,14 @@ source "$ROOT_DIR/.ci/lib/local-common.sh"
 #   3. Back up the existing user binary to *.old and replace it.
 if [[ "${1:-}" == "--override-local" ]]; then
     shift
-    # Detect platform + arch from uname.
+    # Detect platform + arch + executable suffix from uname. The .exe suffix
+    # matters because build-cli-executables.sh emits rdc-win-<arch>.exe and
+    # the auto-update housekeeping in packages/cli/src/utils/platform.ts
+    # expects the backup at <base>.old<ext> (rdc.old / rdc.old.exe).
     case "$(uname -s)" in
-        Linux)  _ovr_platform="linux" ;;
-        Darwin) _ovr_platform="mac" ;;
-        MINGW*|MSYS*|CYGWIN*) _ovr_platform="win" ;;
+        Linux)  _ovr_platform="linux"; _ovr_exe="" ;;
+        Darwin) _ovr_platform="mac"; _ovr_exe="" ;;
+        MINGW*|MSYS*|CYGWIN*) _ovr_platform="win"; _ovr_exe=".exe" ;;
         *) log_error "Unsupported platform $(uname -s) for --override-local"; exit 1 ;;
     esac
     case "$(uname -m)" in
@@ -62,22 +65,26 @@ if [[ "${1:-}" == "--override-local" ]]; then
     log_step "Building SEA for $_ovr_platform/$_ovr_arch"
     bash "$ROOT_DIR/.ci/scripts/build/build-cli-executables.sh" \
         --platform "$_ovr_platform" --arch "$_ovr_arch"
-    _ovr_built="$ROOT_DIR/dist/cli/rdc-${_ovr_platform}-${_ovr_arch}"
+    _ovr_built="$ROOT_DIR/dist/cli/rdc-${_ovr_platform}-${_ovr_arch}${_ovr_exe}"
     if [[ ! -f "$_ovr_built" ]]; then
         log_error "Built SEA not found at $_ovr_built"
         exit 1
     fi
-    _ovr_dest="$HOME/.local/share/rediacc/bin/rdc"
+    _ovr_dest="$HOME/.local/share/rediacc/bin/rdc${_ovr_exe}"
     if [[ ! -d "$(dirname "$_ovr_dest")" ]]; then
         log_error "Install dir $(dirname "$_ovr_dest") does not exist — is rdc installed?"
         exit 1
     fi
+    # Backup naming matches getOldBinaryPath() in
+    # packages/cli/src/utils/platform.ts so cleanupOldBinary() finds it:
+    # rdc.old on Linux/macOS, rdc.old.exe on Windows.
+    _ovr_backup="${_ovr_dest%${_ovr_exe}}.old${_ovr_exe}"
     if [[ -f "$_ovr_dest" ]]; then
-        cp -f "$_ovr_dest" "${_ovr_dest}.old"
+        cp -f "$_ovr_dest" "$_ovr_backup"
     fi
     cp -f "$_ovr_built" "$_ovr_dest"
     chmod +x "$_ovr_dest"
-    log_step "Installed dev SEA → $_ovr_dest (backup at ${_ovr_dest}.old)"
+    log_step "Installed dev SEA → $_ovr_dest (backup at $_ovr_backup)"
     "$_ovr_dest" --version
     exit 0
 fi

--- a/rdc.sh
+++ b/rdc.sh
@@ -11,6 +11,77 @@ ROOT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd -P)"
 source "$ROOT_DIR/.ci/config/constants.sh"
 source "$ROOT_DIR/.ci/lib/local-common.sh"
 
+# --override-local: rebuild the SEA from local source and install it over the
+# user's rdc binary at ~/.local/share/rediacc/bin/rdc. Useful when iterating on
+# CLI internals that aren't reachable through the dev-mode `node cli-bundle.cjs`
+# path (e.g. SEA-only behaviors, embedded renet, auto-update gating). The dev
+# SEA self-disables auto-update via the VERSION === "0.0.0-dev" gate in
+# packages/cli/src/utils/platform.ts::isUpdateDisabled, so it won't be clobbered
+# on the next invocation.
+#
+# Steps performed (must match the manual sequence documented in CLAUDE.md):
+#   1. Cross-build renet into private/bin/renet-linux-<arch> with -tags
+#      nolicense so license checks are off (CI does the same for dev SEAs).
+#      This is the slot the SEA's embedded provisioner reads from.
+#   2. Run .ci/scripts/build/build-cli-executables.sh --platform $P --arch $A
+#      to assemble the SEA at dist/cli/rdc-$P-$A.
+#   3. Back up the existing user binary to *.old and replace it.
+if [[ "${1:-}" == "--override-local" ]]; then
+    shift
+    # Detect platform + arch from uname.
+    case "$(uname -s)" in
+        Linux)  _ovr_platform="linux" ;;
+        Darwin) _ovr_platform="mac" ;;
+        MINGW*|MSYS*|CYGWIN*) _ovr_platform="win" ;;
+        *) log_error "Unsupported platform $(uname -s) for --override-local"; exit 1 ;;
+    esac
+    case "$(uname -m)" in
+        x86_64|amd64) _ovr_arch="x64"; _ovr_goarch="amd64" ;;
+        aarch64|arm64) _ovr_arch="arm64"; _ovr_goarch="arm64" ;;
+        *) log_error "Unsupported arch $(uname -m) for --override-local"; exit 1 ;;
+    esac
+    # The SEA bundler resolves shared-desktop / shared / provisioning through
+    # their published dist/ outputs. Without rebuilding them first, edits to
+    # those packages get silently dropped from the bundle.
+    check_node_version "$NODE_VERSION_MIN"
+    ensure_deps
+    ensure_packages_built
+    # The build-cli-executables script's slot for renet:
+    #   private/bin/renet-${platform-key}-${goarch}  (linux only — that's
+    #   what gets embedded; the SEA only ever runs on linux/mac/win but
+    #   embeds a linux renet for remote provisioning).
+    _ovr_embed_renet="$ROOT_DIR/private/bin/renet-linux-${_ovr_goarch}"
+    log_step "Cross-building renet → $_ovr_embed_renet"
+    mkdir -p "$ROOT_DIR/private/bin"
+    (cd "$ROOT_DIR/private/renet" && \
+        CGO_ENABLED=0 GOOS=linux GOARCH="$_ovr_goarch" go build \
+            -tags nolicense \
+            -ldflags="-s -w -X main.Version=0.0.0-dev" \
+            -o "$_ovr_embed_renet" \
+            ./cmd/renet)
+    log_step "Building SEA for $_ovr_platform/$_ovr_arch"
+    bash "$ROOT_DIR/.ci/scripts/build/build-cli-executables.sh" \
+        --platform "$_ovr_platform" --arch "$_ovr_arch"
+    _ovr_built="$ROOT_DIR/dist/cli/rdc-${_ovr_platform}-${_ovr_arch}"
+    if [[ ! -f "$_ovr_built" ]]; then
+        log_error "Built SEA not found at $_ovr_built"
+        exit 1
+    fi
+    _ovr_dest="$HOME/.local/share/rediacc/bin/rdc"
+    if [[ ! -d "$(dirname "$_ovr_dest")" ]]; then
+        log_error "Install dir $(dirname "$_ovr_dest") does not exist — is rdc installed?"
+        exit 1
+    fi
+    if [[ -f "$_ovr_dest" ]]; then
+        cp -f "$_ovr_dest" "${_ovr_dest}.old"
+    fi
+    cp -f "$_ovr_built" "$_ovr_dest"
+    chmod +x "$_ovr_dest"
+    log_step "Installed dev SEA → $_ovr_dest (backup at ${_ovr_dest}.old)"
+    "$_ovr_dest" --version
+    exit 0
+fi
+
 check_node_version "$NODE_VERSION_MIN"
 
 if [[ "${REDIACC_SKIP_MACHINE_ACTIVATION:-0}" == "1" ]]; then


### PR DESCRIPTION
## Summary

CLI ergonomics fixes that surfaced while iterating on a local dev SEA, plus a few unrelated drive-bys bundled in. Includes follow-up commits responding to Gemini + Codex review feedback, plus targeted unit tests covering the two non-trivial fixes (`resolveTermOutputMode` and `decodeSSHKey` normalization).

### CLI ergonomics
- **SSH agent warning gone**: `shared-desktop/src/ssh/agent.ts` now normalizes the private key before writing the temp file consumed by `ssh-add`. `ssh-add`'s libcrypto parser is stricter about CRLF / trailing newlines than `ssh -i`, so vault keys were failing agent setup but succeeding via the file-based fallback — producing a misleading warning on every connect. Covered by new tests in `packages/shared-desktop/src/ssh/__tests__/keyManager.test.ts`.
- **`term -c` is quiet now (and stays correct for container exec)**: skip spinners + the "Connecting to ..." log (now sent to **stderr** per Unix convention), drop the forced remote TTY for plain shell commands. The sandbox banner is gated by `[ -t 1 ]`, and ssh prints "Connection to HOST closed." only when `-t` allocates a PTY. **Container exec / terminal modes** (`--container ID --container-action exec/terminal`) wrap in `docker exec -it` upstream and **keep `forceTTY: true`** so docker doesn't fail with "the input device is not a TTY". Logic factored into `resolveTermOutputMode()` (covered by new tests in `packages/cli/src/commands/__tests__/term-output-mode.test.ts`) so connectTerminal stays under the cognitive-complexity ceiling.
- **Dev SEA self-update disabled**: `isUpdateDisabled` now short-circuits on `0.0.0-dev` or any `*-dev` VERSION. Without this, a locally-built SEA at `~/.local/share/rediacc/bin/rdc` got clobbered by the auto-updater on every run.
- **`./rdc.sh --override-local` rebuilds shared packages and supports Windows**: now calls `ensure_deps` + `ensure_packages_built` before the SEA build (the bundler resolves shared/shared-desktop/provisioning through their `dist/` outputs, so edits were being silently dropped). Detects platform `.exe` suffix on Windows so both the built artifact path (`dist/cli/rdc-win-x64.exe`) and the install destination (`~/.local/share/rediacc/bin/rdc.exe`) work, and the backup path now matches `getOldBinaryPath()` in `packages/cli/src/utils/platform.ts` — `<base>.old<ext>` (i.e. `rdc.old` on Linux/macOS, `rdc.old.exe` on Windows) — so the CLI's auto-cleanup actually finds and removes the backup.

### Drive-bys
- **Repo mount preflight fix**: `renet list repositories --json` keys repos by GUID under `name` and has no `guid` field. The mount preflight was matching the wrong key. Routed parsing through `parseRepositoryListOutput` so log-prefixed / non-array stdout can no longer crash with `TypeError` on `.find` (same parser already used by `services/repo-mount-check.ts`).
- **Housekeeping SIGPIPE noise**: replace `echo | grep -q` with a herestring in `cleanup-versions.sh` to stop leaking one `write error: Broken pipe` per kept version.
- **CI flake**: hoist the `await import('../backup-schedule.js')` of one heavy test file into a single `beforeAll(timeout=30s)` so the per-test imports hit vitest's module cache and don't trip the 5s default on slower CI runners.
- **Dep bump**: `@tanstack/react-query` 5.100.8 → 5.100.9 (web). Patch flagged by `check:deps`; the other 10 outdated packages remain blocked per `.deps-upgrade-blocklist`.

### Submodule bump
- `private/renet` → 71b7789 (rediacc/renet#66) — centralizes the `cgroup_configs` preseed inside `EnsureRediaccConfig` so apply-template + repo up no longer have to remember to call it separately. Includes a follow-up commit reordering `EnsureRediaccConfig` to run **before** `ChownRootOwnedToUser` in `apply-template`, so `.rediacc.json` (written by root) gets reassigned to the universal user — otherwise sandbox-side `renet dev up` would `EACCES` on its first slot update.

## Test plan
- [x] `npm run check:format` clean
- [x] `npm run lint` clean
- [x] `npm run check:types` clean
- [x] `npm run check:test-cli` clean (now includes `term-output-mode` + `keyManager` tests)
- [x] `npm run check:i18n` clean
- [x] `npm run check:ci-renet` clean
- [x] `npm run check:ci-shell-lint` + `check:ci-shell-format` clean
- [x] `npm run check:deps` clean
- [x] All 6 review threads from Gemini + Codex resolved
- [ ] CI green (will follow)
