### PR TITLE
fix(release-state): root-cause hardening + generic backfill recovery

### DIFF
--- a/.ci/scripts/deploy/upload-to-r2.sh
+++ b/.ci/scripts/deploy/upload-to-r2.sh
@@ -249,10 +249,29 @@ write_once_guard() {
         log_warn "Orphan prefix detected at s3://${RELEASES_BUCKET}/${prefix} (no .released sentinel)."
         log_warn "  A prior CI run uploaded bytes here but was cancelled before finalize"
         log_warn "  sealed the version. Scrubbing orphan bytes so this run can upload cleanly."
+
+        # Defensive recheck immediately before the destructive delete: if a
+        # sentinel appeared in the milliseconds between the initial probe and
+        # this scrub (concurrent finalize-release-sentinel write, eventual
+        # consistency, etc.), abort rather than nuke the freshly-sealed
+        # release. Pair with the --exclude '.released' below as belt-and-
+        # suspenders: the orphan case has no `.released` by definition, so
+        # the exclude is a no-op in the legitimate path but a safety net
+        # against any race we haven't enumerated.
+        if rsv_sentinel_exists "$product" "$version"; then
+            log_error "Sentinel ${product}/${version}/.released appeared during the orphan check — refusing to scrub."
+            log_error "  This race is benign for the upload caller: the version is now sealed,"
+            log_error "  so writes here would have been blocked anyway. Bump next_version past"
+            log_error "  ${version} and re-dispatch CI."
+            exit 1
+        fi
+
         aws s3 rm "s3://${RELEASES_BUCKET}/${prefix}" \
             --endpoint-url "$R2_ENDPOINT" \
-            --recursive
-        log_info "  orphan bytes removed; proceeding with upload"
+            --recursive \
+            --exclude '*.released' \
+            --exclude '.released'
+        log_info "  orphan bytes removed (sentinel files excluded); proceeding with upload"
     fi
 }
 

--- a/.ci/scripts/housekeeping/cleanup-versions.sh
+++ b/.ci/scripts/housekeeping/cleanup-versions.sh
@@ -941,6 +941,120 @@ r2_rm_recursive() {
     log_info "  Deleted s3://${R2_BUCKET}/${prefix}${label:+ ($label)}"
 }
 
+# Path to the checked-in snapshot of the most recently observed R2 sentinel
+# set. Phase 8c.5 reads this to detect disappearances; persist_sentinel_snapshot
+# writes it after Phase 8d completes successfully.
+SENTINEL_SNAPSHOT_PATH="${SCRIPT_DIR}/../../state/sentinel-snapshot.json"
+
+# Compare the live R2 sentinel set against the prior snapshot. Versions in
+# the prior snapshot but not in the live listing are "disappeared". A
+# disappearance for a version that still has a git tag is a loud failure
+# (hardcoded recovery path: the Backfill Release Sentinel workflow).
+# Disappearances paired with deleted tags are warnings only — they're the
+# expected output of a planned scrub-sentinel.sh + tag delete.
+#
+# Side effects:
+#   - Sets globals SENTINEL_LIVE_CLI / SENTINEL_LIVE_DESKTOP for later
+#     persistence. Both are space-separated v<semver> strings.
+#   - Returns non-zero if any tagged version's sentinel is missing.
+sentinel_diff_phase() {
+    log_step "  8c.5: sentinel-set diff vs prior snapshot"
+    local cli_live desktop_live cli_prev desktop_prev
+    cli_live="$(rsv_list_sentinels cli | sort -V | tr '\n' ' ' | sed 's/ *$//')"
+    desktop_live="$(rsv_list_sentinels desktop | sort -V | tr '\n' ' ' | sed 's/ *$//')"
+    SENTINEL_LIVE_CLI="$cli_live"
+    SENTINEL_LIVE_DESKTOP="$desktop_live"
+
+    if [[ ! -f "$SENTINEL_SNAPSHOT_PATH" ]]; then
+        log_warn "  8c.5: no prior snapshot at $SENTINEL_SNAPSHOT_PATH; nothing to diff (will write at end of phase)"
+        return 0
+    fi
+
+    cli_prev="$(jq -r '.cli // [] | join(" ")' "$SENTINEL_SNAPSHOT_PATH" 2>/dev/null || echo "")"
+    desktop_prev="$(jq -r '.desktop // [] | join(" ")' "$SENTINEL_SNAPSHOT_PATH" 2>/dev/null || echo "")"
+
+    local prev_run prev_commit prev_at
+    prev_run="$(jq -r '.captured_by_run // ""' "$SENTINEL_SNAPSHOT_PATH" 2>/dev/null)"
+    prev_commit="$(jq -r '.captured_by_commit // ""' "$SENTINEL_SNAPSHOT_PATH" 2>/dev/null)"
+    prev_at="$(jq -r '.captured_at // ""' "$SENTINEL_SNAPSHOT_PATH" 2>/dev/null)"
+
+    local removed_count=0 fatal=0
+    local product prev_versions live_versions v lv found
+    for product in cli desktop; do
+        if [[ "$product" == "cli" ]]; then
+            prev_versions="$cli_prev"
+            live_versions="$cli_live"
+        else
+            prev_versions="$desktop_prev"
+            live_versions="$desktop_live"
+        fi
+        for v in $prev_versions; do
+            found=0
+            for lv in $live_versions; do
+                if [[ "$v" == "$lv" ]]; then
+                    found=1
+                    break
+                fi
+            done
+            if ((!found)); then
+                removed_count=$((removed_count + 1))
+                # Loud failure when a tagged version's sentinel disappears.
+                # Probe via gh because git ls-remote is the source of truth
+                # for "tag exists on origin", not the local clone.
+                if gh api "repos/${RELEASE_REPO}/git/refs/tags/$v" --silent 2>/dev/null; then
+                    log_error "  8c.5: ${product}/${v}/.released DISAPPEARED since run ${prev_run:-<unknown>} (${prev_at:-?}, commit ${prev_commit:-?})"
+                    log_error "  8c.5: tag $v still exists on origin — recovery: dispatch Backfill Release Sentinel workflow with version=$v"
+                    echo "::error title=Sentinel disappeared::${product}/${v}/.released vanished since run ${prev_run:-?}; tag $v still exists; dispatch backfill-release-sentinel.yml"
+                    fatal=1
+                else
+                    log_warn "  8c.5: ${product}/${v}/.released disappeared and tag $v also gone (planned scrub assumed)"
+                fi
+            fi
+        done
+    done
+
+    log_info "  8c.5: snapshot age=${prev_at:-?} (run ${prev_run:-?}, commit ${prev_commit:-?})"
+    log_info "  8c.5: removed=$removed_count cli_live=$(echo "$cli_live" | wc -w) desktop_live=$(echo "$desktop_live" | wc -w)"
+
+    if ((fatal)); then
+        log_error "  8c.5: a sentinel for a still-tagged version disappeared since the last run"
+        log_error "  8c.5: NOT writing snapshot (next run will diff against the same prior to keep evidence)"
+        return 1
+    fi
+    return 0
+}
+
+# Write the live sentinel set to the snapshot file so the next housekeeping
+# run has a comparison baseline. Only call after Phase 8d completes cleanly;
+# if the diff phase flagged a fatal disappearance, leave the snapshot stale
+# so the evidence survives until manually resolved.
+persist_sentinel_snapshot() {
+    [[ -z "${SENTINEL_LIVE_CLI:-}${SENTINEL_LIVE_DESKTOP:-}" ]] && return 0
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "  [DRY-RUN] would persist sentinel snapshot at $SENTINEL_SNAPSHOT_PATH"
+        return 0
+    fi
+    local commit_sha="${GITHUB_SHA:-$(git rev-parse HEAD 2>/dev/null || echo "")}"
+    local run_id="${GITHUB_RUN_ID:-}"
+    local out_dir
+    out_dir="$(dirname "$SENTINEL_SNAPSHOT_PATH")"
+    mkdir -p "$out_dir"
+    jq -n \
+        --arg run "$run_id" \
+        --arg sha "$commit_sha" \
+        --arg at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        --arg cli "${SENTINEL_LIVE_CLI:-}" \
+        --arg desktop "${SENTINEL_LIVE_DESKTOP:-}" \
+        '{
+          captured_at: $at,
+          captured_by_run: $run,
+          captured_by_commit: $sha,
+          cli: ($cli | split(" ") | map(select(length > 0))),
+          desktop: ($desktop | split(" ") | map(select(length > 0)))
+        }' >"$SENTINEL_SNAPSHOT_PATH"
+    log_info "  8c.5: snapshot written → $SENTINEL_SNAPSHOT_PATH"
+}
+
 cleanup_r2() {
     log_step "Phase 8: Cleaning up R2 orphans"
 
@@ -1047,6 +1161,26 @@ cleanup_r2() {
             r2_rm_recursive "$dead" "legacy"
         fi
     done
+
+    # 8c.5 Sentinel-set diff vs prior run --------------------------------------
+    # The release-state validator probes R2 every push but has no memory of
+    # what it saw last time, so a sentinel that disappears between runs is
+    # silent until the *next* push trips the bijection gate. We snapshot the
+    # set into a checked-in JSON file at the end of every successful
+    # housekeeping run; on the next run we diff the live listing against the
+    # snapshot. Disappearances of versions that still have a git tag are a
+    # loud failure with full forensic context (prior run id + commit) so
+    # whoever is on call can immediately reach for the Backfill Release
+    # Sentinel workflow.
+    #
+    # Sourcing the validator is idempotent — Phase 8d already does it below,
+    # but the diff phase needs rsv_list_sentinels too and runs first.
+    # shellcheck source=../lib/release-state-validator.sh
+    source "${SCRIPT_DIR}/../lib/release-state-validator.sh"
+    if ! sentinel_diff_phase; then
+        log_error "  8c.5: sentinel diff failed; aborting Phase 8 cleanup"
+        return 1
+    fi
 
     # 8d. Sentinel-aware orphan v<semver>/ sweep + drift detection ------------
     # Source of truth: cli/v${V}/.released sentinel (see
@@ -1268,6 +1402,12 @@ cleanup_r2() {
 
     # Restore strict mode for the remaining phases.
     set -e
+
+    # Persist the sentinel snapshot now that Phase 8 finished cleanly. We
+    # only get here if 8c.5 (diff) didn't trip a fatal disappearance and
+    # 8d (orphan sweep / drift detection) completed without drift findings,
+    # so the live state is "current authoritative" by definition.
+    persist_sentinel_snapshot
 }
 
 # =============================================================================

--- a/.ci/scripts/lib/release-state-validator.sh
+++ b/.ci/scripts/lib/release-state-validator.sh
@@ -36,16 +36,21 @@ RSV_SENTINEL_KEY=".released"
 # (PR #459); every prior release was sealed by the older prefix-based guard
 # and has no `.released` marker. Override via RSV_GRANDFATHER_BEFORE if a
 # follow-up backfill seeds sentinels for old tags.
+RSV_GRANDFATHER_BEFORE="${RSV_GRANDFATHER_BEFORE-v1.0.4}"
+
+# Per-version exemptions. Newline-separated list of versions to exclude from
+# the bijection check WITHOUT widening the grandfather floor. Use this when a
+# specific post-rollout release lost its sentinel for an external reason
+# (housekeeping race, manual scrub) and you do not want to suppress drift on
+# every other release between the grandfather floor and that version.
 #
-# Bumped to v1.1.2 on 2026-05-05 because the v1.1.2 release (PR #473) ended
-# with a successful GitHub Release (40 assets) but the R2 cli/v1.1.2/.released
-# sentinel was reaped before the next release-state probe — likely a
-# housekeeping race against a subsequent failed CD attempt. The bytes are
-# released in the GitHub sense; only the R2 mirror sentinel is absent. Treat
-# v1.1.2 as grandfathered until a follow-up dispatches write-release-sentinel
-# from a workflow with R2 credentials. Tracking: revisit when v1.1.2 is no
-# longer the latest released CLI.
-RSV_GRANDFATHER_BEFORE="${RSV_GRANDFATHER_BEFORE-v1.1.2}"
+# v1.1.2: GitHub Release shipped with 40 assets; the R2 cli/v1.1.2/.released
+# sentinel was reaped before the next release-state probe (housekeeping race
+# against a subsequent failed CD attempt). The bytes are released in the
+# GitHub sense; only the R2 mirror sentinel is absent. Will be removed once
+# a workflow_dispatch is wired up that backfills the sentinel via
+# write-release-sentinel.sh with R2 credentials.
+RSV_EXEMPT_VERSIONS="${RSV_EXEMPT_VERSIONS-v1.1.2}"
 
 # =============================================================================
 # Live probes (AWS + git)
@@ -155,18 +160,27 @@ rsv_assert_bijection() {
     # `sort -V` orders strict-semver tags correctly so we can drop everything
     # at or below the baseline by comparing each candidate to the sorted list.
     local grandfather="${RSV_GRANDFATHER_BEFORE:-}"
+    # Per-version exempt set (post-rollout sentinel anomalies), built from
+    # RSV_EXEMPT_VERSIONS. Newline OR whitespace separated; matched as exact
+    # tag strings so v1.1.20 does not match v1.1.2.
+    declare -A exempt_set=()
+    local _ev
+    for _ev in ${RSV_EXEMPT_VERSIONS:-}; do
+        [[ -n "$_ev" ]] && exempt_set["$_ev"]=1
+    done
     rsv_drop_grandfathered() {
         local input="$1"
-        if [[ -z "$grandfather" ]]; then
-            printf '%s\n' "$input"
-            return 0
-        fi
-        local v
+        local v newer
         while IFS= read -r v; do
             [[ -z "$v" ]] && continue
+            # Drop exempt versions outright.
+            [[ -n "${exempt_set[$v]:-}" ]] && continue
+            if [[ -z "$grandfather" ]]; then
+                printf '%s\n' "$v"
+                continue
+            fi
             # Keep v iff (v != grandfather) AND (v sorts AFTER grandfather).
             [[ "$v" == "$grandfather" ]] && continue
-            local newer
             newer="$(printf '%s\n%s\n' "$grandfather" "$v" | sort -V | tail -1)"
             [[ "$newer" == "$v" ]] && printf '%s\n' "$v"
         done <<<"$input"

--- a/.ci/scripts/lib/release-state-validator.sh
+++ b/.ci/scripts/lib/release-state-validator.sh
@@ -38,18 +38,28 @@ RSV_SENTINEL_KEY=".released"
 # follow-up backfill seeds sentinels for old tags.
 RSV_GRANDFATHER_BEFORE="${RSV_GRANDFATHER_BEFORE-v1.0.4}"
 
-# Per-version exemptions. Newline-separated list of versions to exclude from
-# the bijection check WITHOUT widening the grandfather floor. Use this when a
-# specific post-rollout release lost its sentinel for an external reason
-# (housekeeping race, manual scrub) and you do not want to suppress drift on
-# every other release between the grandfather floor and that version.
+# Per-version exemptions. Whitespace/newline-separated list of versions to
+# exclude from the bijection check WITHOUT widening the grandfather floor.
+# Use this when a specific post-rollout release lost its sentinel for an
+# external reason (housekeeping race, manual scrub) and you do not want to
+# suppress drift on every other release between the grandfather floor and
+# that version. Match is exact-string, so v1.1.2 does not also exempt v1.1.20.
 #
-# v1.1.2: GitHub Release shipped with 40 assets; the R2 cli/v1.1.2/.released
-# sentinel was reaped before the next release-state probe (housekeeping race
-# against a subsequent failed CD attempt). The bytes are released in the
-# GitHub sense; only the R2 mirror sentinel is absent. Will be removed once
-# a workflow_dispatch is wired up that backfills the sentinel via
-# write-release-sentinel.sh with R2 credentials.
+# Recovery flow now exists end-to-end (no more hardcoded version strings
+# burning into the validator):
+#   1. Detect: housekeeping Phase 8c.5 logs every sentinel disappearance
+#      with the prior run id + commit SHA, exiting loud if any disappeared
+#      version still has a git tag.
+#   2. Dispatch: the Backfill Release Sentinel workflow
+#      (.github/workflows/backfill-release-sentinel.yml) takes a version +
+#      commit and re-runs write-release-sentinel.sh with R2 creds. It
+#      requires a real GitHub Release with rdc-* assets as a guard against
+#      sealing a never-built version.
+#   3. Once backfilled, drop the version from RSV_EXEMPT_VERSIONS.
+#
+# v1.1.2 default: temporary, unblocks CD until the backfill workflow is
+# dispatched against the merged main. Removed in the immediate follow-up
+# commit after the backfill run confirms cli/v1.1.2/.released is present.
 RSV_EXEMPT_VERSIONS="${RSV_EXEMPT_VERSIONS-v1.1.2}"
 
 # =============================================================================

--- a/.ci/scripts/lib/release-state-validator.sh
+++ b/.ci/scripts/lib/release-state-validator.sh
@@ -36,7 +36,16 @@ RSV_SENTINEL_KEY=".released"
 # (PR #459); every prior release was sealed by the older prefix-based guard
 # and has no `.released` marker. Override via RSV_GRANDFATHER_BEFORE if a
 # follow-up backfill seeds sentinels for old tags.
-RSV_GRANDFATHER_BEFORE="${RSV_GRANDFATHER_BEFORE-v1.0.4}"
+#
+# Bumped to v1.1.2 on 2026-05-05 because the v1.1.2 release (PR #473) ended
+# with a successful GitHub Release (40 assets) but the R2 cli/v1.1.2/.released
+# sentinel was reaped before the next release-state probe — likely a
+# housekeeping race against a subsequent failed CD attempt. The bytes are
+# released in the GitHub sense; only the R2 mirror sentinel is absent. Treat
+# v1.1.2 as grandfathered until a follow-up dispatches write-release-sentinel
+# from a workflow with R2 credentials. Tracking: revisit when v1.1.2 is no
+# longer the latest released CLI.
+RSV_GRANDFATHER_BEFORE="${RSV_GRANDFATHER_BEFORE-v1.1.2}"
 
 # =============================================================================
 # Live probes (AWS + git)

--- a/.ci/scripts/test/gates/test-release-state-consistency.sh
+++ b/.ci/scripts/test/gates/test-release-state-consistency.sh
@@ -186,6 +186,51 @@ test_grandfather_does_not_mask_post_rollout_drift() {
     log_pass "grandfather-does-not-mask"
 }
 
+test_exempt_versions_skip_listed_only() {
+    log_test "RSV_EXEMPT_VERSIONS skips ONLY the named versions, not a range"
+    # Drift on v1.1.2 (exempted) AND v1.1.3 (not exempted) — only v1.1.3
+    # should fire. Exempt list is whitespace separated.
+    local out rc=0
+    out="$(RSV_GRANDFATHER_BEFORE="v1.0.4" RSV_EXEMPT_VERSIONS="v1.1.2" rsv_assert_bijection \
+        "" \
+        "" \
+        "$(printf 'v1.0.5\nv1.1.2\nv1.1.3\n')" \
+        "" 2>&1)" || rc=$?
+    assert_exit_code 1 "$rc" "non-exempt drift must still fire"
+    assert_not_contains "$out" "DRIFT v1.1.2" "v1.1.2 is exempt"
+    assert_contains "$out" "DRIFT v1.1.3" "v1.1.3 is NOT exempt; drift fires"
+    assert_contains "$out" "DRIFT v1.0.5" "v1.0.5 is NOT exempt; drift fires"
+    log_pass "exempt-versions-targeted"
+}
+
+test_exempt_does_not_match_prefix() {
+    log_test "RSV_EXEMPT_VERSIONS exact match — v1.1.2 must NOT match v1.1.20"
+    local out rc=0
+    out="$(RSV_GRANDFATHER_BEFORE="v1.0.4" RSV_EXEMPT_VERSIONS="v1.1.2" rsv_assert_bijection \
+        "" \
+        "" \
+        "$(printf 'v1.1.20\n')" \
+        "" 2>&1)" || rc=$?
+    assert_exit_code 1 "$rc" "v1.1.20 must not be matched by v1.1.2 exemption"
+    assert_contains "$out" "DRIFT v1.1.20" "v1.1.20 still flagged"
+    log_pass "exempt-exact-match"
+}
+
+test_exempt_handles_multiple() {
+    log_test "RSV_EXEMPT_VERSIONS supports multiple values (whitespace separated)"
+    local out rc=0
+    out="$(RSV_GRANDFATHER_BEFORE="v1.0.4" RSV_EXEMPT_VERSIONS="v1.1.2 v1.1.5" rsv_assert_bijection \
+        "" \
+        "" \
+        "$(printf 'v1.1.2\nv1.1.5\nv1.1.7\n')" \
+        "" 2>&1)" || rc=$?
+    assert_exit_code 1 "$rc" "v1.1.7 (not exempt) still drifts"
+    assert_not_contains "$out" "DRIFT v1.1.2" "v1.1.2 is exempt"
+    assert_not_contains "$out" "DRIFT v1.1.5" "v1.1.5 is exempt"
+    assert_contains "$out" "DRIFT v1.1.7" "v1.1.7 is not exempt; drift fires"
+    log_pass "exempt-multiple"
+}
+
 test_all_committed_passes
 test_empty_state_passes
 test_orphan_prefix_not_flagged
@@ -198,5 +243,8 @@ test_in_flight_does_not_mask_other_drift
 test_prerelease_tags_ignored
 test_grandfather_excludes_old_tags
 test_grandfather_does_not_mask_post_rollout_drift
+test_exempt_versions_skip_listed_only
+test_exempt_does_not_match_prefix
+test_exempt_handles_multiple
 
 log_pass "all release-state-consistency cases"

--- a/.ci/state/sentinel-snapshot.json
+++ b/.ci/state/sentinel-snapshot.json
@@ -1,0 +1,33 @@
+{
+  "captured_at": "2026-05-05T03:24:00Z",
+  "captured_by_run": "25355300821",
+  "captured_by_commit": "1e6b2d040",
+  "_note": "Initial snapshot seeded from the Check Release State output of run 25355300821. v1.1.0 desktop sentinel has been missing for some time; v1.1.2 cli + desktop sentinels are missing post-housekeeping race. Both observations carry forward as the baseline so the next sentinel disappearance is unambiguously distinguishable from the baseline anomaly.",
+  "cli": [
+    "v1.0.5",
+    "v1.0.6",
+    "v1.0.7",
+    "v1.0.8",
+    "v1.0.9",
+    "v1.0.10",
+    "v1.0.11",
+    "v1.0.12",
+    "v1.0.13",
+    "v1.0.14",
+    "v1.1.0",
+    "v1.1.1"
+  ],
+  "desktop": [
+    "v1.0.5",
+    "v1.0.6",
+    "v1.0.7",
+    "v1.0.8",
+    "v1.0.9",
+    "v1.0.10",
+    "v1.0.11",
+    "v1.0.12",
+    "v1.0.13",
+    "v1.0.14",
+    "v1.1.1"
+  ]
+}

--- a/.github/workflows/backfill-release-sentinel.yml
+++ b/.github/workflows/backfill-release-sentinel.yml
@@ -1,0 +1,216 @@
+name: Backfill Release Sentinel
+
+# Admin-triggered recovery for a missing R2 .released sentinel. Use when the
+# Check Release State gate flags "DRIFT v<X.Y.Z>: git tag present, cli sentinel
+# missing" — the version was published (git tag + GitHub Release) but the R2
+# sentinel was lost (housekeeping race, manual scrub, etc.). This workflow
+# re-runs `.ci/scripts/deploy/write-release-sentinel.sh` for the named version
+# so the bijection check stops failing without re-running the entire CI
+# pipeline.
+#
+# The writer is idempotent (write_once_guard short-circuits if the sentinel
+# already exists), so re-running is safe.
+#
+# Guards (refuse to write unless ALL pass):
+#   1. Version matches strict semver (`v[0-9]+\.[0-9]+\.[0-9]+`).
+#   2. A GitHub Release with the version tag exists AND has at least one CLI
+#      asset attached. Prevents sealing a version that was never built.
+#   3. The git tag points at a commit reachable from `origin/main`.
+#   4. dry_run defaults to true; --execute requires the operator to set
+#      I_UNDERSTAND_THIS_WRITES_TO_R2=yes as an extra confirmation input.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to backfill (e.g. v1.1.2). Strict semver with leading v.'
+        required: true
+        type: string
+      commit_sha:
+        description: 'Commit SHA to record in the sentinel payload. Optional; defaults to the commit pointed at by the tag.'
+        required: false
+        type: string
+        default: ''
+      channel:
+        description: 'Release channel.'
+        required: true
+        type: choice
+        options:
+          - edge
+          - stable
+        default: edge
+      include_desktop:
+        description: 'Also write the desktop sentinel.'
+        required: true
+        type: boolean
+        default: true
+      dry_run:
+        description: 'Dry run — print what would be written without touching R2.'
+        required: true
+        type: boolean
+        default: true
+      confirmation:
+        description: 'Required for non-dry-run: type exactly "I_UNDERSTAND_THIS_WRITES_TO_R2=yes" to proceed.'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backfill-release-sentinel-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    name: Backfill ${{ inputs.version }}
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: ./.github/actions/app-token
+        with:
+          preset: readonly
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Install jq
+        run: command -v jq >/dev/null || sudo apt-get install -y -qq jq
+
+      - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version '$VERSION' (expected strict semver, e.g. v1.0.5)"
+            exit 1
+          fi
+          echo "✓ version format OK"
+
+      - name: Resolve commit SHA from tag
+        id: resolve
+        env:
+          VERSION: ${{ inputs.version }}
+          INPUT_SHA: ${{ inputs.commit_sha }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$INPUT_SHA" ]]; then
+            SHA="$INPUT_SHA"
+            echo "→ using operator-supplied commit_sha: $SHA"
+          else
+            SHA="$(git rev-list -n1 "$VERSION" 2>/dev/null || true)"
+            if [[ -z "$SHA" ]]; then
+              echo "::error::tag $VERSION not found in this checkout; pass commit_sha explicitly"
+              exit 1
+            fi
+            echo "→ resolved $VERSION → $SHA"
+          fi
+          # Reachability check: tag must point at something on main.
+          if ! git merge-base --is-ancestor "$SHA" origin/main 2>/dev/null; then
+            echo "::error::commit $SHA is not reachable from origin/main"
+            echo "::error::refusing to backfill a sentinel for a detached tag"
+            exit 1
+          fi
+          echo "commit_sha=$SHA" >>"$GITHUB_OUTPUT"
+          echo "✓ commit reachable from origin/main"
+
+      - name: Verify GitHub Release exists with CLI assets
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "$VERSION" --repo "${GITHUB_REPOSITORY}" --json tagName,assets >/tmp/release.json 2>/tmp/release.err; then
+            echo "::error::no GitHub Release found for $VERSION"
+            cat /tmp/release.err
+            exit 1
+          fi
+          # Count CLI assets (rdc-*). Filename pattern matches the existing
+          # release flow's artifact naming.
+          asset_count="$(jq '[.assets[] | select(.name | startswith("rdc-"))] | length' /tmp/release.json)"
+          if [[ "$asset_count" -lt 1 ]]; then
+            echo "::error::Release $VERSION has no rdc-* CLI assets"
+            echo "::error::refusing to seal a version that was never built/published"
+            jq '.assets | map(.name)' /tmp/release.json
+            exit 1
+          fi
+          echo "✓ Release $VERSION has $asset_count rdc-* CLI asset(s)"
+
+      - name: Confirm non-dry-run
+        if: ${{ inputs.dry_run == false }}
+        env:
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set -euo pipefail
+          if [[ "$CONFIRMATION" != "I_UNDERSTAND_THIS_WRITES_TO_R2=yes" ]]; then
+            echo "::error::dry_run=false requires confirmation input set to exactly:"
+            echo "::error::  I_UNDERSTAND_THIS_WRITES_TO_R2=yes"
+            echo "::error::got: '${CONFIRMATION:-<empty>}'"
+            exit 1
+          fi
+          echo "✓ confirmation OK; will write to R2"
+
+      - name: Write sentinel
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          VERSION: ${{ inputs.version }}
+          CHANNEL: ${{ inputs.channel }}
+          COMMIT_SHA: ${{ steps.resolve.outputs.commit_sha }}
+          INCLUDE_DESKTOP: ${{ inputs.include_desktop }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          # Strip leading v for the writer (it expects 1.1.2, not v1.1.2).
+          NUMERIC_VERSION="${VERSION#v}"
+          ARGS=(
+            --version "$NUMERIC_VERSION"
+            --channel "$CHANNEL"
+            --commit-sha "$COMMIT_SHA"
+          )
+          if [[ "$INCLUDE_DESKTOP" == "true" ]]; then
+            ARGS+=(--desktop)
+          fi
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "→ DRY RUN — would invoke:"
+            printf '   .ci/scripts/deploy/write-release-sentinel.sh'
+            printf ' %q' "${ARGS[@]}"
+            printf '\n'
+            echo "→ no R2 mutation performed"
+            exit 0
+          fi
+          echo "→ writing sentinel(s) for $VERSION on channel $CHANNEL (commit $COMMIT_SHA)"
+          .ci/scripts/deploy/write-release-sentinel.sh "${ARGS[@]}"
+
+      - name: Re-probe R2 sentinel state
+        if: ${{ inputs.dry_run == false }}
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          VERSION: ${{ inputs.version }}
+          INCLUDE_DESKTOP: ${{ inputs.include_desktop }}
+        run: |
+          set -euo pipefail
+          source .ci/scripts/lib/release-state-validator.sh
+          export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+          export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+          export AWS_DEFAULT_REGION=auto
+          missing=0
+          for product in cli $([[ "$INCLUDE_DESKTOP" == "true" ]] && echo desktop); do
+            if rsv_sentinel_exists "$product" "$VERSION"; then
+              echo "✓ $product/$VERSION/.released present in R2"
+            else
+              echo "::error::$product/$VERSION/.released NOT present after write"
+              missing=1
+            fi
+          done
+          [[ $missing -eq 0 ]]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1453,6 +1453,30 @@ jobs:
           # just-written sentinel always reports as "sentinel without tag".
           IN_FLIGHT_VERSION: v${{ needs.initialize.outputs.next_version }}
 
+      # Persist the sentinel snapshot updated by Phase 8c.5. The diff phase
+      # turns a silent disappearance into a loud failure on the *next* run;
+      # for that to work, the previous run must commit its observation.
+      # [skip ci] on the snapshot commit prevents the bot push from
+      # triggering its own CI cycle.
+      - name: Commit sentinel snapshot if changed
+        if: success()
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- .ci/state/sentinel-snapshot.json 2>/dev/null; then
+            echo "No sentinel snapshot change."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .ci/state/sentinel-snapshot.json
+          git commit -m "chore(housekeeping): update sentinel snapshot [skip ci]" \
+                     -m "Captured by run ${GITHUB_RUN_ID} (commit ${GITHUB_SHA})."
+          git push origin HEAD:main
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: '22'


### PR DESCRIPTION
## Summary

Replaces the hardcoded \`RSV_EXEMPT_VERSIONS=v1.1.2\` band-aid with a proper fix to the release-state system. Drift recovery is now generic, observable, and admin-triggerable.

### 1. Generic backfill workflow (new)

\`.github/workflows/backfill-release-sentinel.yml\` — workflow_dispatch admin job that takes \`(version, commit_sha, channel)\` and re-runs the existing \`write-release-sentinel.sh\` writer.

**Guards** (all must pass):
- Strict semver match \`^v[0-9]+\.[0-9]+\.[0-9]+$\`
- Tag must be reachable from \`origin/main\` (refuses detached tags)
- GitHub Release MUST exist with at least one \`rdc-*\` CLI asset (refuses to seal a never-built version)
- \`dry_run\` defaults to true; non-dry-run requires confirmation input \`I_UNDERSTAND_THIS_WRITES_TO_R2=yes\`

After writing, re-probes R2 to verify the sentinel landed. The writer is idempotent (\`write_once_guard\` upstream) so re-running is safe.

### 2. Forensic observability (housekeeping)

New Phase 8c.5 in \`.ci/scripts/housekeeping/cleanup-versions.sh\` runs before Phase 8d every housekeeping pass:

- Reads \`.ci/state/sentinel-snapshot.json\` from the prior run
- Lists current R2 sentinels
- Converts every disappearance whose version still has a git tag into a loud \`::error::\` with the prior run id + commit
- Fails the job before Phase 8d so a half-known-bad state cannot persist silently

\`ci.yml\` gets a new commit-back step that git-pushes the updated snapshot with \`[skip ci]\` so the next run has a comparison baseline. Initial seed at \`.ci/state/sentinel-snapshot.json\` carries today's observed state (12 cli + 11 desktop sentinels minus v1.1.2 and v1.1.0-desktop) so the next run starts with a clean baseline.

### 3. Defensive guard in upload-to-r2.sh

The pre-upload orphan-scrub branch was the only enumerated path that could \`aws s3 rm --recursive\` a versioned prefix without first requiring sentinel-absence confirmation. Now:

- Immediate-before-rm \`rsv_sentinel_exists\` recheck (handles eventual consistency / concurrent finalize race)
- Belt-and-suspenders \`--exclude '*.released'\` / \`--exclude '.released'\` on the rm

Legitimate orphans have no \`.released\` by definition, so the exclude is a no-op in the happy path; under any race we haven't enumerated, the exclude saves the seal.

### 4. Validator comment hardening

The \`v1.1.2\` default in \`RSV_EXEMPT_VERSIONS\` is now explicitly transitional. The block describes the full detect → dispatch → drop recovery flow so future operators don't burn hardcoded version strings into the file. Removed in an immediate follow-up commit after the admin runs the backfill workflow.

### 5. Test coverage

\`.ci/scripts/test/gates/test-release-state-consistency.sh\` adds three cases for \`RSV_EXEMPT_VERSIONS\`:
- \`exempt-versions-targeted\` — skips listed only, not a range
- \`exempt-exact-match\` — v1.1.2 must NOT exempt v1.1.20
- \`exempt-multiple\` — whitespace-separated list works

Existing 11 cases continue to pass. **Total: 14 cases, all green.** \`npm run test:quality-gates\` reports **5 of 5 quality gates passing**.

## Recovery flow (post-merge)

1. Admin dispatches \`Backfill Release Sentinel\` workflow on main with \`version=v1.1.2 dry_run=false\` plus the confirmation input.
2. Sentinel re-appears in R2.
3. Follow-up commit removes the \`v1.1.2\` default from \`RSV_EXEMPT_VERSIONS\` (keeping the env var as an overrideable knob).
4. Future drift incidents follow the same pattern: housekeeping detects → admin dispatches → drift clears.

## Files changed

| File | Change |
|---|---|
| \`.github/workflows/backfill-release-sentinel.yml\` | NEW — admin recovery workflow |
| \`.ci/scripts/housekeeping/cleanup-versions.sh\` | New Phase 8c.5 + snapshot persistence |
| \`.ci/state/sentinel-snapshot.json\` | NEW — checked-in baseline, updated by housekeeping |
| \`.ci/scripts/deploy/upload-to-r2.sh\` | Recheck + \`.released\` exclude in orphan-scrub |
| \`.ci/scripts/lib/release-state-validator.sh\` | Comment expansion + transitional v1.1.2 doc |
| \`.ci/scripts/test/gates/test-release-state-consistency.sh\` | +3 exempt-list cases |
| \`.github/workflows/ci.yml\` | Commit-back step for snapshot persistence |

## Test plan

- [x] \`bash .ci/scripts/test/gates/test-release-state-consistency.sh\` — 14 cases pass
- [x] \`npm run test:quality-gates\` — 5/5 gates pass
- [x] \`npm run check:ci-workflows\` — clean
- [x] \`shellcheck\` on modified scripts — no new warnings
- [ ] After merge: dispatch backfill workflow on v1.1.2, verify sentinel re-appears
- [ ] Follow-up commit drops the v1.1.2 default in \`RSV_EXEMPT_VERSIONS\`
- [ ] Push to main → CI \`Check Release State\` reports OK without exemption → CD pipeline runs end-to-end → all steps green (Quality / Build / Tests + Infra / Validate Install / Deploy preview)