### PR TITLE
feat(e2e): refactor machine creation tests to use per-test fixtures

### DIFF
--- a/packages/e2e/tests/03-machines/02-04-01-machine-create.test.ts
+++ b/packages/e2e/tests/03-machines/02-04-01-machine-create.test.ts
@@ -1,52 +1,26 @@
-import { Page } from '@playwright/test';
 import { test, expect } from '@/base/BaseTest';
+import { NavigationHelper } from '@/helpers/NavigationHelper';
 import { LoginPage } from '@/pages/auth/LoginPage';
-import { TestReporter } from '@/utils/report/TestReporter';
+import { ensureDrawerIsClosed } from '@/test-helpers/team-helpers';
 import { skipIfNoVm } from '@/utils/vm';
 
 test.describe('Machine Creation Tests - Authenticated', () => {
   test.describe.configure({ mode: 'serial' });
 
-  // Skip all tests in this file if VM infrastructure is not available
-  test.beforeEach(() => {
+  test.beforeEach(async ({ page }) => {
     skipIfNoVm();
-  });
 
-  let page: Page;
-  let loginPage: LoginPage;
-
-  test.beforeAll(async ({ browser }) => {
-    // Create a single page to be shared across all tests
-    page = await browser.newPage();
-    loginPage = new LoginPage(page);
-
-    // Initial navigation
+    const loginPage = new LoginPage(page);
     await loginPage.navigate();
+    await loginPage.performQuickLogin();
+
+    const nav = new NavigationHelper(page);
+    await nav.goToMachines();
+
+    await ensureDrawerIsClosed(page);
   });
 
-  test.afterAll(async () => {
-    await page.close();
-  });
-
-  test.beforeEach(async () => {
-    // Check if based on localstorage/session we are logged in
-    // logic: If we are on the login page or have the login button, perform login.
-    // Otherwise, assume session is active (or restore if possible, but user said no file).
-    // User requested: "login işlemeleri için tarayıcının localstorage'ını kullan" -> implied: check state
-
-    const isLoginPage = page.url().includes('/login');
-    const loginButtonVisible = await page
-      .locator('[data-testid="login-submit-button"]')
-      .isVisible()
-      .catch(() => false);
-
-    if (isLoginPage || loginButtonVisible) {
-      await loginPage.performQuickLogin();
-    }
-  });
-
-  test.afterEach(async () => {
-    // Cleanup: Close modal if left open to ensure next test starts clean
+  test.afterEach(async ({ page }) => {
     const modal = page.getByTestId('resource-modal-form');
     if (await modal.isVisible()) {
       const cancelButton = page.getByTestId('resource-modal-cancel-button');
@@ -57,19 +31,11 @@ test.describe('Machine Creation Tests - Authenticated', () => {
     }
   });
 
-  test('should open machine creation dialog @resources @smoke', async ({
-    testDataManager: _testDataManager,
-  }, testInfo) => {
-    // Manually instantiate reporter with shared page
-    const testReporter = new TestReporter(page, testInfo);
-
-    testReporter.startStep('Navigate to machines section');
+  test('should open machine creation dialog @resources @smoke', async ({ page, testReporter }) => {
+    testReporter.startStep('Open machine creation dialog');
 
     const createMachineButton = page.getByTestId('machines-create-machine-button');
     await expect(createMachineButton).toBeVisible({ timeout: 10000 });
-
-    testReporter.startStep('Open machine creation dialog');
-
     await createMachineButton.click();
 
     const createMachineDialog = page.getByTestId('resource-modal-form');
@@ -91,35 +57,34 @@ test.describe('Machine Creation Tests - Authenticated', () => {
   });
 
   test('should create a new machine @resources @regression', async ({
+    page,
+    testReporter,
     testDataManager,
-  }, testInfo) => {
-    const testReporter = new TestReporter(page, testInfo);
+  }) => {
+    test.setTimeout(120000);
 
-    // Step 1: Open machine creation dialog
     testReporter.startStep('Open machine creation dialog');
 
     const createMachineButton = page.getByTestId('machines-create-machine-button');
     await expect(createMachineButton).toBeVisible({ timeout: 10000 });
+    await expect(createMachineButton).toBeEnabled();
     await createMachineButton.click();
 
-    // Use form locator to avoid strict mode issues with the modal container
     const createMachineDialog = page.getByTestId('resource-modal-form');
     await expect(createMachineDialog).toBeVisible();
 
     testReporter.completeStep('Open machine creation dialog', 'passed');
 
-    // Step 2: Fill machine details with unique name
     testReporter.startStep('Fill machine details');
 
-    const testMachine = testDataManager.getMachine();
+    const testMachine = testDataManager.createTemporaryMachine();
 
-    // Fill basic info
     await page.getByTestId('resource-modal-field-machineName-input').fill(testMachine.name);
     await page.getByTestId('vault-editor-field-ip').fill(testMachine.ip);
 
-    // Fill Vault info
     const userField = page.getByTestId('vault-editor-field-user');
     const passwordField = page.getByTestId('vault-editor-field-ssh_password');
+
     if (await userField.isVisible()) {
       await userField.fill(testMachine.user);
     }
@@ -127,26 +92,33 @@ test.describe('Machine Creation Tests - Authenticated', () => {
       await passwordField.fill(testMachine.password);
     }
 
-    // Test Connection
+    testReporter.startStep('Test Connection');
     await page.getByTestId('vault-editor-test-connection').click();
+
     const vaultSection = page.getByTestId('resource-modal-vault-editor-section');
     const connectionAlert = vaultSection.getByRole('alert');
-    await expect(connectionAlert).toBeVisible({ timeout: 50000 });
+
+    await expect(connectionAlert).toBeVisible({ timeout: 60000 });
     await expect(connectionAlert.locator('.ant-alert-title .ant-space-item').nth(1)).toContainText(
-      'Compatible'
+      'Compatible',
+      { timeout: 30000 }
     );
+    testReporter.completeStep('Test Connection', 'passed');
+
+    testReporter.completeStep('Fill machine details', 'passed');
 
     testReporter.startStep('Submit machine creation');
 
     const submitButton = page.getByTestId('resource-modal-ok-button');
+    await expect(submitButton).toBeEnabled();
     await submitButton.click();
 
-    // Verify success state in the queue trace modal (Wait up to 30s)
     const queueOverview = page.getByTestId('queue-trace-simple-overview');
-    await expect(queueOverview).toBeVisible({ timeout: 5000 });
+    await expect(queueOverview).toBeVisible({ timeout: 10000 });
+
     await expect(
       queueOverview.locator('.queue-trace-status-icon .anticon-check-circle')
-    ).toBeVisible({ timeout: 30000 });
+    ).toBeVisible({ timeout: 45000 });
 
     const closeQueueButton = page.getByTestId('queue-trace-close-button');
     await expect(closeQueueButton).toBeVisible();
@@ -156,23 +128,25 @@ test.describe('Machine Creation Tests - Authenticated', () => {
 
     testReporter.startStep('Verify machine created');
 
-    // Check if machine appears in the list
-    const machineList = page.getByTestId('machines-machines-table');
-    const newMachineRow = machineList.locator(`text=${testMachine.name}`);
+    await expect
+      .poll(
+        async () => {
+          const machineTable = page.getByTestId('machines-machines-table');
+          return await machineTable.getByText(testMachine.name).isVisible();
+        },
+        {
+          timeout: 15000,
+          intervals: [1000, 2000, 5000],
+        }
+      )
+      .toBe(true);
 
-    try {
-      await expect(newMachineRow).toBeVisible({ timeout: 10000 });
-      testReporter.completeStep('Verify machine created', 'passed');
-    } catch {
-      testReporter.completeStep('Verify machine created', 'failed', 'Machine not found in list');
-    }
+    testReporter.completeStep('Verify machine created', 'passed');
 
     await testReporter.finalizeTest();
   });
 
-  test('should validate required fields @resources', async ({ testDataManager: _dm }, testInfo) => {
-    const testReporter = new TestReporter(page, testInfo);
-
+  test('should validate required fields @resources', async ({ page, testReporter }) => {
     testReporter.startStep('Open machine creation dialog');
 
     const createMachineButton = page.getByTestId('machines-create-machine-button');
@@ -184,36 +158,21 @@ test.describe('Machine Creation Tests - Authenticated', () => {
 
     testReporter.completeStep('Open machine creation dialog', 'passed');
 
-    testReporter.startStep('Test validation without filling fields');
+    testReporter.startStep('Test validation');
 
     const submitButton = page.getByTestId('resource-modal-ok-button');
+    await expect(submitButton).toBeDisabled();
 
-    // Verify that submit button is disabled when required fields are empty
-    const isDisabled = await submitButton.isDisabled();
-
-    if (isDisabled) {
-      console.warn('Submit button is disabled - validation working correctly');
-      testReporter.completeStep('Test validation without filling fields', 'passed');
-    } else {
-      console.warn('Submit button is NOT disabled - validation may not be working');
-      testReporter.completeStep(
-        'Test validation without filling fields',
-        'failed',
-        'Submit button should be disabled when fields are empty'
-      );
-    }
+    testReporter.completeStep('Test validation', 'passed');
 
     await testReporter.finalizeTest();
   });
 
-  test('should cancel machine creation @resources', async ({ testDataManager: _dm }, testInfo) => {
-    const testReporter = new TestReporter(page, testInfo);
-
+  test('should cancel machine creation @resources', async ({ page, testReporter }) => {
     testReporter.startStep('Open machine creation dialog');
 
     const createMachineButton = page.getByTestId('machines-create-machine-button');
     await expect(createMachineButton).toBeVisible({ timeout: 10000 });
-
     await createMachineButton.click();
 
     const createMachineDialog = page.getByTestId('resource-modal-form');


### PR DESCRIPTION
## Summary

- Replace shared `page` object (anti-pattern) with proper Playwright fixtures (`page`, `testReporter`, `testDataManager`) so each test runs in isolation
- Each test now navigates to the machines page independently via `NavigationHelper.goToMachines()` and logs in fresh via `LoginPage.performQuickLogin()`, eliminating state leakage
- Validation test now uses `expect(submitButton).toBeDisabled()` instead of a manual `isDisabled()` check
- Machine creation test uses `createTemporaryMachine()` for unique test data and `expect.poll()` for stable list verification
- `ensureDrawerIsClosed()` added to `afterEach` setup to prevent pointer-event interception on mobile/tablet viewports

## Test plan

- [ ] VM infrastructure available: all 4 tests pass end-to-end
- [ ] No VM: all tests skip cleanly via `skipIfNoVm()`
- [ ] CI Quality checks pass (format, TypeScript, lint)

?? Generated with [Claude Code](https://claude.com/claude-code)