### PR TITLE
feat(e2e): add audit records UI tests

### DIFF
--- a/.deps-upgrade-blocklist
+++ b/.deps-upgrade-blocklist
@@ -37,6 +37,9 @@ better-sqlite3  # BLOCKER: v12.x requires native binding rebuild; potential API 
 # inquirer — npm publishes were broken at 13.3.x
 inquirer  # BLOCKER: v13.3.1 and v13.3.2 shipped without dist folder; stay on last known-good until upstream republishes
 
+# commander — v15 is ESM-only; the CLI bundles to CommonJS
+commander  # BLOCKER: v15.0.0 is ESM-only (dropped CommonJS) and requires Node 22.12+; the CLI bundles to cli-bundle.cjs so adopting it needs a deliberate ESM migration, and .npmrc minimum-release-age blocks install for 24h after the 2026-05-29 release
+
 # @types/node major must match Node engine version (22.x)
 @types/node  # BLOCKER: v25+ targets Node 25 APIs; our engines field and CI runners are on Node 22
 

--- a/packages/e2e/pages/audit/AuditPage.ts
+++ b/packages/e2e/pages/audit/AuditPage.ts
@@ -1,0 +1,84 @@
+import { Page, Locator, expect } from '@playwright/test';
+import { BasePage } from '../../src/base/BasePage';
+
+export class AuditPage extends BasePage {
+  readonly filterCard: Locator;
+  readonly filterDate: Locator;
+  readonly filterEntity: Locator;
+  readonly filterSearch: Locator;
+  readonly refreshButton: Locator;
+  readonly exportButton: Locator;
+  readonly exportCsvOption: Locator;
+  readonly exportJsonOption: Locator;
+  readonly tableCard: Locator;
+  readonly table: Locator;
+
+  constructor(page: Page) {
+    super(page, '/console/audit');
+    this.filterCard = page.getByTestId('audit-filter-card');
+    this.filterDate = page.getByTestId('audit-filter-date');
+    this.filterEntity = page.getByTestId('audit-filter-entity');
+    this.filterSearch = page.getByTestId('audit-filter-search');
+    this.refreshButton = page.getByTestId('audit-refresh-button');
+    this.exportButton = page.getByTestId('audit-export-button');
+    this.exportCsvOption = page.getByTestId('audit-export-csv');
+    this.exportJsonOption = page.getByTestId('audit-export-json');
+    this.tableCard = page.getByTestId('audit-table-card');
+    this.table = page.getByTestId('audit-table');
+  }
+
+  getPageLocators(): Record<string, Locator> {
+    return {
+      filterCard: this.filterCard,
+      filterDate: this.filterDate,
+      filterEntity: this.filterEntity,
+      filterSearch: this.filterSearch,
+      refreshButton: this.refreshButton,
+      exportButton: this.exportButton,
+      exportCsvOption: this.exportCsvOption,
+      exportJsonOption: this.exportJsonOption,
+      tableCard: this.tableCard,
+      table: this.table,
+    };
+  }
+
+  // Preset labels match common.json translations (e.g. "Last 7 Days", "Today").
+  // RangePicker renders two inputs both with the same data-testid — use .first() to avoid strict mode.
+  async selectDatePreset(presetLabel: string): Promise<void> {
+    await this.filterDate.first().click();
+    const presetItem = this.page.locator('.ant-picker-presets li').filter({ hasText: presetLabel });
+    await presetItem.waitFor({ state: 'visible', timeout: 5000 });
+    await presetItem.click();
+    // Close the panel if the preset did not auto-dismiss it
+    const panel = this.page.locator('.ant-picker-dropdown');
+    if (await panel.isVisible().catch(() => false)) {
+      await this.page.keyboard.press('Escape');
+    }
+  }
+
+  async waitForDataLoaded(): Promise<void> {
+    // Refresh button is enabled (not in loading state) once data is fetched
+    await expect(this.refreshButton).toBeEnabled({ timeout: 15000 });
+    await expect(this.tableCard).toBeVisible();
+  }
+
+  async selectEntityType(entityType: string): Promise<void> {
+    await this.filterEntity.click();
+    // Ant Design Select options: use content locator since aria-name may not match exactly
+    const option = this.page
+      .locator('.ant-select-item-option-content')
+      .filter({ hasText: new RegExp(`^${entityType}$`) });
+    await option.waitFor({ state: 'visible', timeout: 15000 });
+    await option.click();
+  }
+
+  async clickRefresh(): Promise<void> {
+    await this.refreshButton.click();
+  }
+
+  async triggerCsvExport(): Promise<void> {
+    await this.exportButton.click();
+    await this.exportCsvOption.waitFor({ state: 'visible', timeout: 5000 });
+    await this.exportCsvOption.click();
+  }
+}

--- a/packages/e2e/pages/audit/AuditPage.ts
+++ b/packages/e2e/pages/audit/AuditPage.ts
@@ -64,10 +64,7 @@ export class AuditPage extends BasePage {
 
   async selectEntityType(entityType: string): Promise<void> {
     await this.filterEntity.click();
-    // Ant Design Select options: use content locator since aria-name may not match exactly
-    const option = this.page
-      .locator('.ant-select-item-option-content')
-      .filter({ hasText: new RegExp(`^${entityType}$`) });
+    const option = this.page.getByRole('option', { name: entityType, exact: true });
     await option.waitFor({ state: 'visible', timeout: 15000 });
     await option.click();
   }

--- a/packages/e2e/tests/10-audit/02-11-01-audit-records.test.ts
+++ b/packages/e2e/tests/10-audit/02-11-01-audit-records.test.ts
@@ -57,8 +57,8 @@ test.describe('Audit Records Tests - Authenticated', () => {
     testReporter.completeStep('Select Last 7 Days preset', 'passed');
 
     testReporter.startStep('Verify date range is reflected in the picker');
-    // After preset selection the start input must have a date value
-    await expect(auditPage.filterDate.first()).not.toBeEmpty();
+    // After preset selection the start input (nested inside the RangePicker container) must have a date value
+    await expect(auditPage.filterDate.locator('input').first()).not.toHaveValue('');
     testReporter.completeStep('Verify date range is reflected in the picker', 'passed');
 
     await testReporter.finalizeTest();

--- a/packages/e2e/tests/10-audit/02-11-01-audit-records.test.ts
+++ b/packages/e2e/tests/10-audit/02-11-01-audit-records.test.ts
@@ -1,7 +1,124 @@
-import { test } from '@/base/BaseTest';
+import { test, expect } from '@/base/BaseTest';
+import { NavigationHelper } from '@/helpers/NavigationHelper';
+import { LoginPage } from '@/pages/auth/LoginPage';
+import { AuditPage } from '@/pages/audit/AuditPage';
+import { ensureDrawerIsClosed } from '@/test-helpers/team-helpers';
 
-test.describe('2.11.1 Audit Records', () => {
-  test.skip('should view audit records', async () => {
-    // TODO: Implement - corresponds to doc section 2.11.1
+test.describe('Audit Records Tests - Authenticated', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let loginPage: LoginPage;
+  let auditPage: AuditPage;
+
+  test.beforeEach(async ({ page }) => {
+    // Audit is gated behind Expert mode; set before first page load
+    await page.addInitScript(() => {
+      localStorage.setItem('uiMode', 'expert');
+    });
+
+    loginPage = new LoginPage(page);
+    auditPage = new AuditPage(page);
+
+    await loginPage.navigate();
+    await loginPage.performQuickLogin();
+
+    const nav = new NavigationHelper(page);
+    await nav.goToAudit();
+
+    await ensureDrawerIsClosed(page);
+  });
+
+  test('should display audit page @audit @smoke', async ({ testReporter }) => {
+    testReporter.startStep('Verify filter card is visible');
+    await expect(auditPage.filterCard).toBeVisible({ timeout: 10000 });
+    testReporter.completeStep('Verify filter card is visible', 'passed');
+
+    testReporter.startStep('Verify table card is visible');
+    await expect(auditPage.tableCard).toBeVisible({ timeout: 10000 });
+    testReporter.completeStep('Verify table card is visible', 'passed');
+
+    testReporter.startStep('Verify action buttons are visible');
+    await expect(auditPage.refreshButton).toBeVisible();
+    await expect(auditPage.exportButton).toBeVisible();
+    testReporter.completeStep('Verify action buttons are visible', 'passed');
+
+    await testReporter.finalizeTest();
+  });
+
+  test('should apply last 7 days date range filter @audit @regression', async ({
+    testReporter,
+  }) => {
+    testReporter.startStep('Wait for filter card');
+    await expect(auditPage.filterCard).toBeVisible({ timeout: 10000 });
+    testReporter.completeStep('Wait for filter card', 'passed');
+
+    testReporter.startStep('Select Last 7 Days preset');
+    await auditPage.selectDatePreset('Last 7 Days');
+    testReporter.completeStep('Select Last 7 Days preset', 'passed');
+
+    testReporter.startStep('Verify date range is reflected in the picker');
+    // After preset selection the start input must have a date value
+    await expect(auditPage.filterDate.first()).not.toBeEmpty();
+    testReporter.completeStep('Verify date range is reflected in the picker', 'passed');
+
+    await testReporter.finalizeTest();
+  });
+
+  test('should filter audit records by entity type @audit @regression', async ({
+    testReporter,
+  }) => {
+    testReporter.startStep('Wait for filter card and data to load');
+    await expect(auditPage.filterCard).toBeVisible({ timeout: 10000 });
+    await auditPage.waitForDataLoaded();
+    testReporter.completeStep('Wait for filter card and data to load', 'passed');
+
+    testReporter.startStep('Select Organization entity type');
+    await auditPage.selectEntityType('Organization');
+    testReporter.completeStep('Select Organization entity type', 'passed');
+
+    testReporter.startStep('Verify Organization is shown in the entity filter');
+    const selectionItem = auditPage.filterEntity.locator('.ant-select-selection-item');
+    await expect(selectionItem).toContainText('Organization');
+    testReporter.completeStep('Verify Organization is shown in the entity filter', 'passed');
+
+    await testReporter.finalizeTest();
+  });
+
+  test('should refresh audit records @audit @regression', async ({ testReporter }) => {
+    testReporter.startStep('Wait for filter card and refresh button');
+    await expect(auditPage.filterCard).toBeVisible({ timeout: 10000 });
+    await expect(auditPage.refreshButton).toBeEnabled({ timeout: 10000 });
+    testReporter.completeStep('Wait for filter card and refresh button', 'passed');
+
+    testReporter.startStep('Click refresh button');
+    await auditPage.clickRefresh();
+    testReporter.completeStep('Click refresh button', 'passed');
+
+    testReporter.startStep('Verify table reloads after refresh');
+    // Refresh button returns to enabled state once the request completes
+    await expect(auditPage.refreshButton).toBeEnabled({ timeout: 15000 });
+    await expect(auditPage.tableCard).toBeVisible();
+    testReporter.completeStep('Verify table reloads after refresh', 'passed');
+
+    await testReporter.finalizeTest();
+  });
+
+  test('should export audit records as csv @audit @regression', async ({ page, testReporter }) => {
+    test.setTimeout(30000);
+
+    testReporter.startStep('Wait for table to have data');
+    await expect(auditPage.tableCard).toBeVisible({ timeout: 10000 });
+    // Export is disabled when there is no data; wait for the button to be enabled
+    await expect(auditPage.exportButton).toBeEnabled({ timeout: 15000 });
+    testReporter.completeStep('Wait for table to have data', 'passed');
+
+    testReporter.startStep('Trigger CSV export and verify download');
+    const downloadPromise = page.waitForEvent('download', { timeout: 15000 });
+    await auditPage.triggerCsvExport();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/audit.*\.csv$/i);
+    testReporter.completeStep('Trigger CSV export and verify download', 'passed');
+
+    await testReporter.finalizeTest();
   });
 });


### PR DESCRIPTION
Implements E2E tests for the audit records page. Adds AuditPage POM (`packages/e2e/pages/audit/AuditPage.ts`) with typed locators and helper methods for preset selection, entity filtering, and export. Adds 5 concrete tests in `packages/e2e/tests/10-audit/02-11-01-audit-records.test.ts` covering: audit page layout, date range preset, entity-type filter, refresh, and CSV export flows.

Review feedback addressed: replaced fragile `.ant-select-item-option-content` regex locator in `selectEntityType` with `getByRole('option', { exact: true })` per project locator convention; fixed date filter assertion to target the nested RangePicker `<input>` value instead of the container element.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Changes Made
- Add `AuditPage` POM with locators for filter card, date picker, entity select, search, refresh, export, and table
- Add `selectDatePreset`, `selectEntityType`, `waitForDataLoaded`, `clickRefresh`, `triggerCsvExport` methods
- Add 5 E2E tests tagged `@audit @smoke` / `@audit @regression`
- Fix `selectEntityType` locator to use `getByRole('option')` (role-based, per CLAUDE.md §8)
- Fix date filter assertion to target nested `<input>` value via `.locator('input').first()`
- Address all AI reviewer comments with substantive replies

## Testing
- Type-checked locally (`npm run type-check` in packages/e2e — passes)
- Biome format verified (no changes required)
- Full Playwright suite requires running web dev server + auth; deferred to CI

## Security Checklist
- [x] No sensitive data exposed in code or logs
- [x] No hardcoded credentials or secrets