### PR TITLE
fix(ci): skip Electron binary download in non-desktop ops workflows

### DIFF
--- a/.github/workflows/cd-deploy-account.yml
+++ b/.github/workflows/cd-deploy-account.yml
@@ -63,6 +63,10 @@ on:
       TURNSTILE_SECRET_KEY:
         required: true
 
+# Nothing here runs Electron; skip the flaky binary download in install:natives.
+env:
+  ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+
 jobs:
   # Read regions.json to build the deployment matrix
   read-regions:

--- a/.github/workflows/cd-deploy-worker.yml
+++ b/.github/workflows/cd-deploy-worker.yml
@@ -54,6 +54,10 @@ on:
       TURNSTILE_SECRET_KEY:
         required: true
 
+# Nothing here runs Electron; skip the flaky binary download in install:natives.
+env:
+  ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+
 jobs:
   deploy:
     name: Deploy ${{ inputs.target }} Worker

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -9,6 +9,10 @@ permissions:
   actions: read
   deployments: write
 
+# Nothing here runs Electron; skip the flaky binary download in install:natives.
+env:
+  ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+
 jobs:
   cleanup:
     name: Cleanup Preview

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -30,6 +30,11 @@ concurrency:
   group: housekeeping
   cancel-in-progress: false
 
+# Nothing here runs Electron; the binary download was the recurring 504
+# failure source in the stripe-cleanup install step.
+env:
+  ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+
 jobs:
   cleanup:
     name: Cleanup versions


### PR DESCRIPTION
## Problem

The nightly Housekeeping workflow failed twice in two weeks (runs [26676858933](https://github.com/rediacc/console/actions/runs/26676858933) on May 30 and [27124689484](https://github.com/rediacc/console/actions/runs/27124689484) on June 8), both times at the identical step: `Stripe sandbox cleanup` → "Install dependencies" (`npm ci && npm run install:natives`). The June 8 log shows the cause — the `electron` postinstall binary download hit `HTTPError: Response code 504 (Gateway Time-out)`.

That job never runs Electron. It only needs `tsx` scripts and the shared-package build (esbuild); the Electron binary is downloaded purely as a side effect of the root `install:natives` rebuild. Three other ops workflows share the same pattern and exposure: `cleanup-preview.yml`, `cd-deploy-worker.yml`, `cd-deploy-account.yml`.

## Fix

Set `ELECTRON_SKIP_BINARY_DOWNLOAD: '1'` at workflow level in all four files. Electron's `install.js` exits early when it is set (checked in both the root `electron@39.8.10` and nested `packages/desktop` `electron@39.8.6` copies); the npm package still installs and esbuild/ssh2/node-pty/cpu-features keep rebuilding as before.

CI/desktop-build workflows (`ci.yml`, `ci-quality.yml`, `ct-tests.yml`, `ci-build-desktop.yml`, `ci-build-docker.yml`) are intentionally untouched — some of their jobs need the real binary.

## Verification

- `ELECTRON_SKIP_BINARY_DOWNLOAD=1 npm run install:natives` locally: both electron postinstalls exit immediately with no download, all other natives rebuild, `npm run build:packages` green.
- `actionlint` on the four edited files: only pre-existing findings in untouched sections; nothing for the new `env:` blocks.
- Post-merge: the next nightly Housekeeping run (03:00 UTC cron) should show no electron download in the install step.