### PR TITLE
fix(cli): stop ConfigFileStorage's tempPath colliding under CI-runner load

### DIFF
--- a/packages/cli/src/adapters/config-file-storage.ts
+++ b/packages/cli/src/adapters/config-file-storage.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import { basename, join } from 'node:path';
 import {
@@ -258,7 +259,14 @@ export class ConfigFileStorage {
     const versioned: RdcConfig = bumpVersion ? { ...config, version: config.version + 1 } : config;
     const encrypted = await this.encryptConfig(versioned);
 
-    const tempPath = `${configPath}.tmp.${process.pid}.${Date.now()}`;
+    // `pid.Date.now()` alone can collide: two saveUnlocked calls for the SAME
+    // name that land in the same millisecond compute the identical tempPath.
+    // Whichever renames second then hits ENOENT, because the first already
+    // moved that path away (observed live: run 30512465488, storage.test.ts's
+    // "should not corrupt file under concurrent writes", a lock-window race
+    // under CI-runner load that did not reproduce under local stress testing).
+    // The random suffix makes every tempPath unique regardless of timing.
+    const tempPath = `${configPath}.tmp.${process.pid}.${Date.now()}.${randomUUID()}`;
     const content = stringifyConfig(encrypted);
 
     await fs.writeFile(tempPath, content, { mode: 0o600 });


### PR DESCRIPTION
## What

`main` has been red for real (not the old cancelled-laundering bug) 3 nights
running: 2026-07-28, 2026-07-29, 2026-07-30 (runs `30327872124`,
`30421536380`, `30512465488`), all on head `b549047790` (#541). Two
independent, unrelated failures on that head; this PR fixes one of them.

**`Quality / Packages`** failed identically all three nights on:

```
FAIL src/adapters/__tests__/storage.test.ts > ConfigFileStorage > stress tests
     > should not corrupt file under concurrent writes
Error: ENOENT: no such file or directory, rename
  '/tmp/cli-storage-test-.../test.json.tmp.<pid>.<ms>' -> '.../test.json'
```

`tempPath` was `${configPath}.tmp.${process.pid}.${Date.now()}`. Two
`saveUnlocked` calls for the same config name that land in the same
millisecond compute the identical `tempPath`; whichever renames second hits
`ENOENT`, because the first already moved that exact path away. A CI runner
under load is exactly the condition that narrows the timing window enough
for two locked, sequential saves to land in the same millisecond -- this did
not reproduce locally under 15 sequential runs, 6 parallel processes, or 3
runs under synthetic 20-core CPU load, consistent with a runner-load-
dependent race rather than a logic bug in the locking itself.

Fix: append a `randomUUID()` to `tempPath` so it is unique regardless of
timing (matches the existing pattern already used elsewhere in this package
-- `repo-delta.ts`, `repo-create-delete.ts`). Grepped for siblings: this is
the only `.tmp.${process.pid}` atomic-save site in the tree.

## Not in scope

**`Quality / Content`** (tutorial caption-sync, `check:ci-tutorial-caption-sync`)
failed the same 3 nights on 15 tutorial x language combos with flat/estimated
word timing. That's a separate, pre-existing ownership area (TTS/audio
regeneration), tracked separately, and deliberately not touched here.

## Testing

- `npx tsc --noEmit --project packages/cli/tsconfig.json` clean
- `npx biome check packages/cli/src/adapters/config-file-storage.ts` clean
- `npm run test:unit --workspace=@rediacc/cli`: 159/159 files, 2132/2132 tests
- Repro attempts documented in the commit message (all passed locally, as
  expected for a runner-load-dependent race)