### PR TITLE
fix(review): the deadlock guard could not fire, so a capped PR went unmergeable

### DIFF
--- a/.ci/scripts/lib/common.sh
+++ b/.ci/scripts/lib/common.sh
@@ -545,6 +545,34 @@ review_report_count() {
                   | .id" 2>/dev/null | wc -l || true
 }
 
+# review_spent_attempt_count <pr> <attempt-prefix> -> passes that produced no report.
+#
+# review_spend_total <pr> <attempt-prefix> -> what the CAP is actually measured against.
+#
+# THESE LIVE HERE FOR THE REASON STATED ABOVE, AND IT WAS LEARNED THE HARD WAY.
+# Moving review_cap_for() here fixed the DENOMINATOR drift and left the NUMERATOR
+# split: claude-review-gate.sh counted `reports_posted + attempts_spent` while
+# review-status.sh counted posted reports alone. On PR #553 (2026-08-07) that read
+# as 3/3 in the gate and 0/3 in review-status simultaneously. The gate refused to
+# review because the cap was reached; review-status could not see the cap as
+# reached, so its DEADLOCK GUARD -- written precisely so a capped PR never becomes
+# unmergeable -- did not fire, and posted a required FAILURE instead. The PR was
+# green, ready and thread-clean, and permanently unmergeable through no fault of
+# its author: exactly the outcome that guard exists to prevent.
+#
+# One numerator, one denominator, one file. Both callers use review_spend_total.
+review_spent_attempt_count() {
+    gh api "repos/${GITHUB_REPOSITORY}/issues/${1}/comments" --paginate \
+        --jq ".[] | select(.body | startswith(\"${2}\")) | .id" 2>/dev/null | wc -l || true
+}
+
+review_spend_total() {
+    local posted spent
+    posted="$(review_report_count "$1")"
+    spent="$(review_spent_attempt_count "$1" "$2")"
+    echo $((${posted//[[:space:]]/} + ${spent//[[:space:]]/}))
+}
+
 # pr_diff_loc <pr> -> additions + deletions, or 0 when it cannot be read.
 # Failing to 0 puts an unreadable PR in the SMALLEST bucket, which is the
 # conservative direction: it spends fewer review passes, never more.

--- a/.ci/scripts/lib/common.sh
+++ b/.ci/scripts/lib/common.sh
@@ -566,10 +566,16 @@ review_spent_attempt_count() {
         --jq ".[] | select(.body | startswith(\"${2}\")) | .id" 2>/dev/null | wc -l || true
 }
 
+# review_spend_total <pr> <attempt-prefix> [posted] [spent]
+#
+# Optional pre-fetched counts, because claude-review-gate.sh needs the two numbers
+# SEPARATELY for its log line and would otherwise pay for four paginated gh calls
+# per invocation instead of two. Passing them keeps the single definition of "what
+# the cap counts" here -- which is the whole point -- without the round trips.
 review_spend_total() {
-    local posted spent
-    posted="$(review_report_count "$1")"
-    spent="$(review_spent_attempt_count "$1" "$2")"
+    local posted="${3:-}" spent="${4:-}"
+    [[ -n "$posted" ]] || posted="$(review_report_count "$1")"
+    [[ -n "$spent" ]] || spent="$(review_spent_attempt_count "$1" "$2")"
     echo $((${posted//[[:space:]]/} + ${spent//[[:space:]]/}))
 }
 

--- a/.ci/scripts/review/claude-review-gate.sh
+++ b/.ci/scripts/review/claude-review-gate.sh
@@ -69,13 +69,10 @@ ATTEMPT_PREFIX='<!-- claude-review-attempt:'
 # the reason stated there: this file counts the numerator and review-status.sh
 # reports the fraction, and two copies of the numerator drifted once already.
 
-# Spent review passes that produced no report. Counted against the same cap as
-# posted reports, because the cost is identical; see the --mark spent-attempt
-# path for why they exist at all.
-spent_attempt_count() {
-    gh api "repos/${GITHUB_REPOSITORY}/issues/${1}/comments" --paginate \
-        --jq ".[] | select(.body | startswith(\"$ATTEMPT_PREFIX\")) | .id" 2>/dev/null | wc -l || true
-}
+# Spent review passes are counted by review_spent_attempt_count() in
+# ../lib/common.sh, beside review_report_count() and review_cap_for(). The local
+# copy that used to live here is gone deliberately: review-status.sh could not
+# see it, summed a smaller numerator, and its deadlock guard stopped firing.
 
 last_marker_sha() {
     gh api "repos/${GITHUB_REPOSITORY}/issues/${1}/comments" --paginate \
@@ -273,7 +270,7 @@ if [[ "${1:-}" == "--mark" ]]; then
     # An attempt marker is deliberately NOT a reviewed marker. It carries its own
     # prefix so `last_marker_sha` still cannot see it -- a spent attempt must
     # never suppress a later genuine review of the same SHA by pretending the
-    # code was read -- but `spent_attempt_count` does, so it consumes budget.
+    # code was read -- but `review_spent_attempt_count` does, so it consumes budget.
     # It records WHY, because "we stopped reviewing this PR" is only a
     # defensible message if it says what was spent on.
     if [[ "${REVIEW_OUTCOME:-}" != "success" ]]; then
@@ -425,11 +422,16 @@ case "${EVENT_NAME:-}" in
 esac
 
 reports_posted=$(review_report_count "$pr")
-attempts_spent=$(spent_attempt_count "$pr")
+attempts_spent=$(review_spent_attempt_count "$pr" "$ATTEMPT_PREFIX")
 # Budget is what was SPENT, not what was delivered. A pass that burned its turns
 # and posted nothing cost the same as one that posted a full report, and
 # charging only for successes is what let a failing SHA be re-reviewed forever.
-review_count=$((${reports_posted:-0} + ${attempts_spent:-0}))
+#
+# Via the SHARED helper, not a local sum: review-status.sh caps on the same total,
+# and when it summed differently (posted only) it read 0/3 while this script read
+# 3/3 on PR #553 -- so its deadlock guard could not fire and the PR went
+# permanently unmergeable. One numerator, in ../lib/common.sh.
+review_count=$(review_spend_total "$pr" "$ATTEMPT_PREFIX")
 pr_loc=$(pr_diff_loc "$pr")
 MAX_REVIEWS_PER_PR=$(review_cap_for "$pr_loc")
 if [[ "${review_count:-0}" -ge "$MAX_REVIEWS_PER_PR" ]]; then

--- a/.ci/scripts/review/claude-review-gate.sh
+++ b/.ci/scripts/review/claude-review-gate.sh
@@ -431,7 +431,7 @@ attempts_spent=$(review_spent_attempt_count "$pr" "$ATTEMPT_PREFIX")
 # and when it summed differently (posted only) it read 0/3 while this script read
 # 3/3 on PR #553 -- so its deadlock guard could not fire and the PR went
 # permanently unmergeable. One numerator, in ../lib/common.sh.
-review_count=$(review_spend_total "$pr" "$ATTEMPT_PREFIX")
+review_count=$(review_spend_total "$pr" "$ATTEMPT_PREFIX" "$reports_posted" "$attempts_spent")
 pr_loc=$(pr_diff_loc "$pr")
 MAX_REVIEWS_PER_PR=$(review_cap_for "$pr_loc")
 if [[ "${review_count:-0}" -ge "$MAX_REVIEWS_PER_PR" ]]; then

--- a/.ci/scripts/review/review-status.sh
+++ b/.ci/scripts/review/review-status.sh
@@ -83,6 +83,11 @@ fi
 
 MARKER_PREFIX="$(sed -n "s/^MARKER_PREFIX='\(.*\)'[[:space:]]*$/\1/p" "$GATE_SCRIPT")"
 MARKER_PREFIX="${MARKER_PREFIX%%$'\n'*}"
+# The cap is measured against posted reports PLUS spent attempts, so this script
+# needs the attempt prefix too. Parsed from the gate exactly like MARKER_PREFIX:
+# a second hard-coded copy is the drift this file exists to prevent.
+ATTEMPT_PREFIX="$(sed -n "s/^ATTEMPT_PREFIX='\(.*\)'[[:space:]]*$/\1/p" "$GATE_SCRIPT")"
+ATTEMPT_PREFIX="${ATTEMPT_PREFIX%%$'\n'*}"
 # The cap is no longer a constant in the gate script: it is sized to the diff by
 # review_cap_for() in ../lib/common.sh, which BOTH scripts source. That is the
 # whole point -- sed-parsing a number out of the other file was always one edit
@@ -90,6 +95,18 @@ MARKER_PREFIX="${MARKER_PREFIX%%$'\n'*}"
 if [[ -z "$MARKER_PREFIX" ]]; then
     log_error "could not parse MARKER_PREFIX out of $GATE_SCRIPT"
     log_error "  Fix: keep it as a plain top-level assignment there, or update this parser."
+    exit 1
+fi
+if [[ -z "$ATTEMPT_PREFIX" ]]; then
+    log_error "could not parse ATTEMPT_PREFIX out of $GATE_SCRIPT"
+    log_error "  Fix: keep it as a plain top-level assignment there, or update this parser."
+    log_error "  Without it the cap reads LOWER here than in the gate, and the deadlock"
+    log_error "  guard below cannot fire on a capped PR -- the #553 failure mode."
+    exit 1
+fi
+if ! declare -F review_spend_total >/dev/null; then
+    log_error "review_spend_total() is missing from ../lib/common.sh"
+    log_error "  Fix: restore it there; the gate and this script must share ONE numerator."
     exit 1
 fi
 if ! declare -F review_cap_for >/dev/null; then
@@ -293,7 +310,10 @@ else
     fi
 fi
 
-review_count="$(review_report_count "$pr")"
+# Posted reports PLUS spent attempts -- the same total the gate caps on. Counting
+# posted reports alone made this script read 0/3 while the gate read 3/3 on the
+# SAME PR, which is why the deadlock guard below never fired. See common.sh.
+review_count="$(review_spend_total "$pr" "$ATTEMPT_PREFIX")"
 review_count="${review_count//[[:space:]]/}"
 # Y in "X/Y" is sized to THIS PR's diff, via the shared table in ../lib/common.sh.
 pr_loc="$(pr_diff_loc "$pr")"

--- a/.ci/scripts/review/review-status.sh
+++ b/.ci/scripts/review/review-status.sh
@@ -319,7 +319,10 @@ review_count="${review_count//[[:space:]]/}"
 pr_loc="$(pr_diff_loc "$pr")"
 MAX_REVIEWS_PER_PR="$(review_cap_for "$pr_loc")"
 notes+=("Currency: ${currency_detail}.")
-notes+=("Review reports posted: ${review_count:-0}/${MAX_REVIEWS_PER_PR} (cap ${MAX_REVIEWS_PER_PR} for a ${pr_loc}-line diff).")
+# "spent", not "posted": this number is reports PLUS attempts that burned their
+# budget and posted nothing. Saying "3/3 posted" when zero were posted is the
+# exact #553 confusion this file now fixes the logic for.
+notes+=("Review passes spent: ${review_count:-0}/${MAX_REVIEWS_PER_PR} (posted reports + spent attempts; cap ${MAX_REVIEWS_PER_PR} for a ${pr_loc}-line diff).")
 
 if [[ "$currency_ok" == true ]]; then
     log_info "CURRENCY ok: $currency_detail"

--- a/.ci/scripts/test/gates/test-review-status.sh
+++ b/.ci/scripts/test/gates/test-review-status.sh
@@ -182,6 +182,18 @@ report_comments() {
     echo "$out"
 }
 
+# Spent review passes: budget burned, NOTHING posted. Counted against the same cap
+# as a posted report, because the cost is identical.
+attempt_comments() {
+    local n="$1" i out="[]"
+    for ((i = 1; i <= n; i++)); do
+        out="$(jq --argjson id "$((200 + i))" \
+            '. + [{id: $id, user: {login: "github-actions[bot]"},
+                   body: "<!-- claude-review-attempt: deadbeef -->\nburned its turns"}]' <<<"$out")"
+    done
+    echo "$out"
+}
+
 # setup <TEMP> -- default world: open non-draft PR #42, head NEW_SHA, marker on
 # NEW_SHA, no reports, all hygiene green.
 setup() {
@@ -466,7 +478,13 @@ test_cap_reached_warns_instead_of_deadlocking() {
     jq -s 'add' "$t/comments-marker.json" "$t/comments-reports.json" >"$t/fixtures/comments.json"
     echo '{"files": [{"filename": "packages/cli/src/commands/repo.ts"}]}' \
         >"$t/fixtures/compare.json"
-    printf '%s\n' "MARKER_PREFIX='<!-- claude-reviewed:'" >"$t/gate-cap3.sh"
+    # BOTH prefixes: review-status.sh parses ATTEMPT_PREFIX as well now, because the
+    # cap counts posted reports PLUS spent attempts. It REFUSES TO RUN without it,
+    # deliberately -- a missing prefix reads the cap LOW and silently recreates the
+    # deadlock this very test asserts against. A stub carrying only MARKER_PREFIX
+    # therefore exits before posting, which is exactly what this fixture used to do.
+    printf '%s\n' "MARKER_PREFIX='<!-- claude-reviewed:'" \
+        "ATTEMPT_PREFIX='<!-- claude-review-attempt:'" >"$t/gate-cap3.sh"
     pr_size "$t" 900 100 # 1,000 lines -> smallest tier, cap 3
 
     run_status "$t" EVENT_NAME=pull_request_review PR_NUMBER=42 \
@@ -476,6 +494,34 @@ test_cap_reached_warns_instead_of_deadlocking() {
     assert_contains "$(posted "$t" '.output.summary')" "REVIEW CAP REACHED" \
         "the pass is loud, not silent"
     log_pass "cap reached + stale marker => success WITH A WARNING (no permanent block)"
+}
+
+# THE SHAPE THAT ACTUALLY HAPPENED, and that the case above cannot see. PR #553 hit
+# its cap with ZERO posted reports and THREE spent attempts -- three reviews that
+# burned their turn budget and posted nothing. review-status.sh counted posted
+# reports alone, read 0/3, concluded the cap was NOT reached, and posted a REQUIRED
+# failure, leaving a green, ready, thread-clean PR permanently unmergeable: exactly
+# what the guard above exists to prevent. The sibling case passes under EITHER
+# numerator, because 3 posted reports look identical to both.
+test_cap_reached_by_spent_attempts_alone() {
+    local t="$1"
+    setup "$t"
+    marker_comment "$OLD_SHA" | jq -s '.' >"$t/comments-marker.json"
+    attempt_comments 3 >"$t/comments-attempts.json"
+    jq -s 'add' "$t/comments-marker.json" "$t/comments-attempts.json" >"$t/fixtures/comments.json"
+    echo '{"files": [{"filename": "packages/cli/src/commands/repo.ts"}]}' \
+        >"$t/fixtures/compare.json"
+    printf '%s\n' "MARKER_PREFIX='<!-- claude-reviewed:'" \
+        "ATTEMPT_PREFIX='<!-- claude-review-attempt:'" >"$t/gate-cap3.sh"
+    pr_size "$t" 900 100 # 1,000 lines -> smallest tier, cap 3
+
+    run_status "$t" EVENT_NAME=pull_request_review PR_NUMBER=42 \
+        REVIEW_STATUS_GATE_SCRIPT="$t/gate-cap3.sh"
+    assert_eq "$(posted "$t" '.conclusion')" success \
+        "cap reached by SPENT attempts alone must stay mergeable (the #553 deadlock)"
+    assert_contains "$(posted "$t" '.output.summary')" "REVIEW CAP REACHED" \
+        "the pass is loud here too"
+    log_pass "0 posted + 3 spent => cap reached => success WITH A WARNING"
 }
 
 test_below_cap_the_same_state_fails() {
@@ -488,7 +534,13 @@ test_below_cap_the_same_state_fails() {
         >"$t/fixtures/compare.json"
     # Identical world, cap raised: the warning must become a failure. If it does
     # not, the cap value is not actually being read.
-    printf '%s\n' "MARKER_PREFIX='<!-- claude-reviewed:'" >"$t/gate-cap9.sh"
+    # BOTH prefixes: review-status.sh parses ATTEMPT_PREFIX as well now, because the
+    # cap counts posted reports PLUS spent attempts. It REFUSES TO RUN without it,
+    # deliberately -- a missing prefix reads the cap LOW and silently recreates the
+    # deadlock this very test asserts against. A stub carrying only MARKER_PREFIX
+    # therefore exits before posting, which is exactly what this fixture used to do.
+    printf '%s\n' "MARKER_PREFIX='<!-- claude-reviewed:'" \
+        "ATTEMPT_PREFIX='<!-- claude-review-attempt:'" >"$t/gate-cap9.sh"
     # THE POINT OF THE TIERS: identical review count, different verdict, purely
     # because the diff is large enough to earn a bigger budget.
     pr_size "$t" 60000 10000 # 70,000 lines -> top tier, cap 7
@@ -1270,6 +1322,7 @@ with_temp_dir test_missing_hygiene_dir_hard_fails
 with_temp_dir test_unparseable_constants_hard_fail
 
 with_temp_dir test_cap_reached_warns_instead_of_deadlocking
+with_temp_dir test_cap_reached_by_spent_attempts_alone
 with_temp_dir test_below_cap_the_same_state_fails
 
 with_temp_dir test_anchors_to_current_head_not_event_sha

--- a/docs/ci-overhaul/06-progress.md
+++ b/docs/ci-overhaul/06-progress.md
@@ -2659,3 +2659,90 @@ checks out submodules. Measured before the fix:
 Both follow the same pattern as the older gates here: a committed baseline, a
 `--refresh` that carries the only network access, a vacuity floor, and controls
 that fire in both directions before any real read.
+
+## A required check that could not pass, and a guard that could not fire (2026-08-07)
+
+Two defects of the same shape, found hours apart, both in the machinery that
+decides whether a PR may merge. Neither was a missed bug: both were checks
+producing confident WRONG answers, which is more expensive, because the work they
+create looks legitimate.
+
+### 1. The review deadlock: two numerators, one cap
+
+PR #553 reached green CI, ready, zero unresolved threads -- and became
+PERMANENTLY UNMERGEABLE. Its required `Review Complete` was red and no action
+could clear it.
+
+`review-status.sh` has an explicit DEADLOCK GUARD for exactly that state: once
+the review cap is reached the reviewed-SHA marker can never advance, so failing
+would strand the PR "through no fault of its author". It passes loudly instead.
+
+It never fired, because the two scripts measured different numerators against the
+same denominator:
+
+| script | numerator | #553 |
+|---|---|---|
+| `claude-review-gate.sh:449` | posted reports + spent attempts | **3/3** -> refuses to review |
+| `review-status.sh:296` | posted reports only | **0/3** -> guard mute |
+
+The gate stopped reviewing because the budget was gone; review-status could not
+see the cap as reached and demanded a review that could never happen.
+
+`.ci/scripts/lib/common.sh` exists precisely to stop this drift, and it
+half-worked: it shared `review_cap_for()` (the DENOMINATOR) while the NUMERATOR
+stayed split across two files, one of which did not know spent attempts existed.
+**Sharing a file is not sharing the computation.** Both callers now use
+`review_spend_total()` from that file; the gate's local counter is deleted rather
+than left as a second copy.
+
+**This fix could not be validated on the PR that made it.** `review-status.yml`
+checks out `.ci/scripts` from the DEFAULT BRANCH -- deliberately, so a PR cannot
+edit the logic judging it -- so the fix is inert until it is on `main`. Breaking
+the circularity needed a separate tiny branch (0807-3, PR #554). Any future
+session touching review-cap logic must expect the same: **your fix will not act
+on your own PR.**
+
+### 2. The turn budget, and why a green retry proves nothing
+
+The same PR starved its entire review budget first: three passes, all
+`error_max_turns`, zero findings posted. Sonnet twice, then opus-5 -- the model
+was never the constraint.
+
+Measured, same day, same reviewer, both in the old 50-turn tier:
+
+| PR | diff | outcome |
+|---|---|---|
+| #552 | 2270 lines / 39 files | completed, full report (22.0 turns/KLOC) |
+| #553 | 2802 lines / 36 files | starved, nothing posted (17.8 turns/KLOC) |
+
+File count does not discriminate (39 passed where 36 failed); lines do. The
+50-turn tier stretched to 5000 lines, so a 4999-line diff got 10 turns/KLOC.
+
+The first fix -- moving the rung from 5000 to 2000 -- was WRONG, and the new
+`check-review-turn-capacity.sh` gate caught it immediately: it left a
+2000..29999 tier whose top edge got 2.6 turns/KLOC, the same hole fifteen times
+wider. **Rungs starve at their top by construction.** The budget is now
+continuous (25 turns/KLOC, floor 50, ceiling 140).
+
+### The generalisable trap
+
+A starved review is the EXPENSIVE outcome, not the cheap one: it burns its whole
+budget, posts nothing, and still spends an attempt against a finite per-PR cap.
+Three attempts at a budget that cannot finish leaves a PR unreviewable forever.
+`REVIEW_CAP_TIERS` and the turn budget are still tuned independently -- nothing
+forbids granting N attempts at a budget guaranteed to starve. That coupling is
+the next thing worth gating.
+
+### New gates
+
+- `check:ci-review-turn-capacity` -- monotonic, total, density-where-achievable,
+  ceiling-beyond, plus the measured regression point. Control collapses
+  turns-per-KLOC and requires the assertions to fail.
+- `check:ci-review-cap-coherence` -- both scripts take the numerator from
+  `review_spend_total()` and the denominator from `review_cap_for()`, neither
+  redefines them locally, and -- the behavioural half -- with numerator == cap the
+  deadlock guard is the branch that actually runs.
+- `check:ci-gate-reachability-coverage` -- guards the Stop hook's own probe,
+  which returned False for ALL 191 registered gates because it walked `npm run`
+  edges from `ci`, and `ci` is `tsx scripts/ci-runner/run.ts` with zero such
+  edges. It had been telling sessions their wired gates were unwired.

--- a/docs/ci-overhaul/06-progress.md
+++ b/docs/ci-overhaul/06-progress.md
@@ -2733,16 +2733,25 @@ Three attempts at a budget that cannot finish leaves a PR unreviewable forever.
 forbids granting N attempts at a budget guaranteed to starve. That coupling is
 the next thing worth gating.
 
-### New gates
+### The gates that close this, and where they live
 
-- `check:ci-review-turn-capacity` -- monotonic, total, density-where-achievable,
-  ceiling-beyond, plus the measured regression point. Control collapses
-  turns-per-KLOC and requires the assertions to fail.
-- `check:ci-review-cap-coherence` -- both scripts take the numerator from
-  `review_spend_total()` and the denominator from `review_cap_for()`, neither
-  redefines them locally, and -- the behavioural half -- with numerator == cap the
-  deadlock guard is the branch that actually runs.
-- `check:ci-gate-reachability-coverage` -- guards the Stop hook's own probe,
-  which returned False for ALL 191 registered gates because it walked `npm run`
-  edges from `ci`, and `ci` is `tsx scripts/ci-runner/run.ts` with zero such
-  edges. It had been telling sessions their wired gates were unwired.
+**NOT on this branch.** `check:ci-review-turn-capacity`,
+`check:ci-review-cap-coherence` and `check:ci-gate-reachability-coverage` were
+built on `0807-2` and land with it. Naming them here as shipped would be exactly
+the drift this directory exists to prevent -- a reader grepping for them on this
+branch finds nothing.
+
+What THIS branch carries is the numerator fix alone, plus the gate-test case that
+reproduces the #553 shape,
+`test-review-status.sh::test_cap_reached_by_spent_attempts_alone`. That case is
+mutation-proven against the scripts as they exist on main, where it reports the
+live incident verbatim: `expected 'success', got 'failure'`. Its sibling case --
+which reaches the cap with three POSTED reports -- passes under either numerator,
+which is why 46 existing assertions never caught this.
+
+When 0807-2 lands, those three gates cover the turn budget (monotonic, total,
+density-where-achievable, ceiling-beyond), the cap coherence (one numerator, one
+denominator, and the deadlock guard reachable AT the cap), and the Stop hook's own
+reachability probe -- which returned False for all 191 registered gates because it
+walked `npm run` edges from `ci`, and `ci` is `tsx scripts/ci-runner/run.ts` with
+zero such edges.


### PR DESCRIPTION
## The bug

`review-status.sh` carries an explicit **deadlock guard**: when the review cap is reached the marker can never advance, so failing there "would make the PR permanently unmergeable through no fault of its author." It passes loudly instead.

It could not fire, because the two scripts counted **different numerators against the same cap**:

| script | numerator | PR #553 read |
|---|---|---|
| `claude-review-gate.sh:449` | posted + spent attempts | **3/3** -> refuses to review |
| `review-status.sh:296` | posted reports only | **0/3** -> guard stays mute |

So the gate stopped reviewing because the budget was spent, while review-status could not see the cap as reached and posted a **required** failure. PR #553 is green, ready, thread-clean -- and permanently unmergeable. Exactly the outcome the guard exists to prevent, produced by the guard's own input.

## The fix

This is the drift `.ci/scripts/lib/common.sh` was created to stop, and it half-worked: moving `review_cap_for()` there fixed the **denominator** and left the **numerator** split across two files, one of which did not know spent attempts existed. **Sharing a file is not sharing the computation.**

Both callers now use `review_spend_total()` from that same file; the gate's local counter is deleted rather than left as a second copy; and `review-status.sh` parses `ATTEMPT_PREFIX` from the gate the way it already parses `MARKER_PREFIX`, refusing to run if it cannot -- because a missing prefix silently reads the cap **low** and reproduces this bug exactly.

## Proof

Measured against live data, not reasoned:

```
posted=0  spent=3  TOTAL=3  cap=3 (3024 lines)  => guard fires
```

Under the old numerator the same PR read `0/3` and the guard stayed silent.

## Why this is its own tiny PR

`review-status.yml` checks out `.ci/scripts` from the **default branch**, so this fix is inert until it is on `main` -- it cannot rescue the PR it was written on. Splitting it out is what breaks the circularity, and a diff this small reviews comfortably inside the turn budget that starved #553.

Gates: `check:ci-shell-lint`, `check:ci-shell-format`, `check:ci-dead-bash`, `check:ci-silent-failures` all green.

<!-- pushed-head:begin -->
**Last pushed:** `eb80a3e0c`

- `eb80a3e0c` fix(review): address all three review findings on #554
- `528b8736b` test(review): pin the cap reached by SPENT attempts, not posted reports
- `451596829` docs(ci-overhaul): the deadlock guard, the turn budget, and why a retry lies
- `0af433de8` fix(review): the deadlock guard could not fire, so a capped PR went unmergeable
- `e4cd1fd2d` chore(submodules): bump renet to its merged main commit
<!-- pushed-head:end -->
