### PR TITLE
fix(hooks)+perf(ci): Stop-hook task-queue visibility; W/S/T-parallel quality-gate battery (3.14x)

### DIFF
--- a/.ci/scripts/review/claude-review-gate.sh
+++ b/.ci/scripts/review/claude-review-gate.sh
@@ -380,6 +380,31 @@ if [[ "${1:-}" == "--apply-labels" ]]; then
         ' <<<"$report") || verdict=""
     fi
 
+    # FALLBACK: the fence may live only in the POSTED COMMENT. Observed on the
+    # feature's first live run (#559, run 31267699743): the model posts its
+    # summary itself via `gh pr comment` and put the fence THERE, while its
+    # final result text back to the harness did not repeat it -- so the
+    # extraction above logged "no json:pr-labels block" beside a PR whose
+    # verdict comment plainly carried one. The result text stays the primary
+    # source (it wins when both exist); the newest fence-bearing comment is
+    # the fallback. Trust model: PR comments already carry the reviewed-SHA
+    # markers this pipeline acts on, the whitelist hard-filters every label,
+    # and bump-major is never applied automatically, so a forged fence cannot
+    # do more than a forged marker could.
+    if [[ -z "$verdict" ]]; then
+        comment_report=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq '.[] | select(.body | contains("```json:pr-labels")) | .body' 2>/dev/null | tail -c 65536) || comment_report=""
+        if [[ -n "$comment_report" ]]; then
+            verdict=$(awk '
+                /^[[:space:]]*```json:pr-labels[[:space:]]*$/ { capturing = 1; n = 0; next }
+                capturing && /^[[:space:]]*```[[:space:]]*$/ { capturing = 0; next }
+                capturing { buf[++n] = $0 }
+                END { for (i = 1; i <= n; i++) print buf[i] }
+            ' <<<"$comment_report") || verdict=""
+            [[ -n "$verdict" ]] && log_info "json:pr-labels fence found in the posted report comment (absent from the result text)"
+        fi
+    fi
+
     if [[ -z "$verdict" ]]; then
         log_info "no json:pr-labels block in the report; mechanical labels only"
     elif ! jq -e '

--- a/.ci/scripts/test/gates/test-review-labels.sh
+++ b/.ci/scripts/test/gates/test-review-labels.sh
@@ -623,6 +623,40 @@ test_mark_does_not_count_the_ledger_comment_as_output() {
 # ---------------------------------------------------------------------------
 # Advisory end to end
 # ---------------------------------------------------------------------------
+test_fence_only_in_posted_comment_is_found() {
+    local t="$1"
+    setup "$t"
+    # The feature's FIRST LIVE RUN (#559, run 31267699743): the model posted its
+    # summary itself and put the fence in the COMMENT; its result text back to
+    # the harness did not repeat it. The old extraction read only the result
+    # text, logged "no json:pr-labels block", and applied nothing beside a PR
+    # whose verdict comment plainly carried a verdict.
+    execution_file "$t" "$(report_with_verdict '')"
+    comments_fixture "$t" "$(jq -n --arg body "## Verdict: request changes
+
+${TICKS}json:pr-labels
+{\"bump\": \"patch\", \"kind\": [\"bug\", \"ci\"], \"why\": \"live shape\"}
+${TICKS}" '{"id": 900001, "body": $body}')"
+    run_apply "$t"
+    assert_exit_code 0 "$LAST_RC" "advisory always"
+    assert_eq "$(added "$t")" "bug ci" "the comment-borne verdict is found and applied"
+    log_pass "FIRE: a fence living only in the posted comment is found by the fallback"
+}
+
+test_result_fence_wins_over_comment_fence() {
+    local t="$1"
+    setup "$t"
+    # Priority pin: when BOTH carry a fence, the result text stays the primary
+    # source -- the comment path is a fallback, not a second voter.
+    execution_file "$t" "$(report_with_verdict '{"bump": "patch", "kind": ["ci"], "why": "from the result"}')"
+    comments_fixture "$t" "$(jq -n --arg body "${TICKS}json:pr-labels
+{\"bump\": \"minor\", \"kind\": [\"bug\"], \"why\": \"from a comment\"}
+${TICKS}" '{"id": 900002, "body": $body}')"
+    run_apply "$t"
+    assert_eq "$(added "$t")" "ci" "the result-text verdict wins; the comment fence is not consulted"
+    log_pass "FIRE: the result-text fence outranks a comment fence"
+}
+
 test_total_api_failure_is_advisory() {
     local t="$1"
     setup "$t"
@@ -701,5 +735,8 @@ with_temp_dir test_stale_ledger_label_is_removed
 with_temp_dir test_hand_applied_labels_are_never_removed
 with_temp_dir test_tampered_ledger_cannot_delete_arbitrary_labels
 with_temp_dir test_mark_does_not_count_the_ledger_comment_as_output
+
+with_temp_dir test_fence_only_in_posted_comment_is_found
+with_temp_dir test_result_fence_wins_over_comment_fence
 
 with_temp_dir test_total_api_failure_is_advisory

--- a/.ci/scripts/test/gates/test-run-all-parallel.sh
+++ b/.ci/scripts/test/gates/test-run-all-parallel.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# Proof battery for the parallel scheduler inside .ci/scripts/test/run-all.sh.
+#
+# WHY THIS EXISTS. run-all.sh is the runner for every other gate test, so a
+# defect in it does not fail loudly: it fails by running FEWER tests, or by
+# shredding their output, or by reintroducing the real-tree collision the
+# schedule exists to prevent. All three of those look like a green run. The
+# battery below pins the four properties that separate "fast" from "still a
+# gate", and every timing assertion carries its own control, because a
+# stopwatch that can only ever read "fast enough" measures nothing.
+#
+#   1. The pool really runs tests at the same time -- with the control that
+#      proves the measurement can FAIL (the same set at jobs=1 must be slow).
+#   2. jobs=1 and jobs=4 produce byte-identical transcripts, exit codes and
+#      failure sets over a mixed set (pass / red / vacuous-exit-0).
+#   3. No test's output interleaves with another's, under --verbose, where a
+#      naive worker-prints-directly design would shred both.
+#   4. The W/S hold-back actually holds: a scanner never runs while a real-tree
+#      writer is alive. Its control removes the schedule and shows the same
+#      fixtures go red, so a green here is the hold-back and not luck.
+#
+# Everything runs against PLANTED FIXTURES in a temp directory via
+# RUN_ALL_GATES_DIR, so this test touches no real gate and no real tree.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+# shellcheck source=../lib/test-helpers.sh
+# BLOCKER: shared test assertion / colour helpers
+source "$SCRIPT_DIR/../lib/test-helpers.sh"
+
+RUNNER="$REPO_ROOT/.ci/scripts/test/run-all.sh"
+
+if [[ ! -x "$RUNNER" ]]; then
+    log_fail "$RUNNER is missing or not executable; this gate has nothing to prove"
+fi
+
+now_ms() { date +%s%3N; }
+
+# mk_fixture <dir> <name> <body-line>...
+mk_fixture() {
+    local dir="$1" name="$2"
+    shift 2
+    {
+        printf '#!/bin/bash\n'
+        printf 'set -euo pipefail\n'
+        printf '%s\n' "$@"
+    } >"$dir/$name"
+    chmod +x "$dir/$name"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Concurrency, with the control that proves the stopwatch can fail.
+# ---------------------------------------------------------------------------
+
+test_pool_runs_tests_concurrently() {
+    local temp="$1"
+    local gates="$temp/gates"
+    local i start parallel_ms serial_ms
+    mkdir -p "$gates"
+    for i in 1 2 3 4; do
+        mk_fixture "$gates" "test-sleeper-$i.sh" 'sleep 2' "echo \"PASS: sleeper $i finished\""
+    done
+
+    start="$(now_ms)"
+    RUN_ALL_GATES_DIR="$gates" RUN_ALL_JOBS=4 "$RUNNER" >/dev/null
+    parallel_ms=$(($(now_ms) - start))
+
+    if ((parallel_ms >= 6000)); then
+        log_fail "four 2s tests took ${parallel_ms}ms at jobs=4; they are not overlapping"
+    fi
+    log_pass "four 2s tests finish in ${parallel_ms}ms at jobs=4 (ceiling 6000ms)"
+
+    # THE CONTROL. Without it, a runner that silently ignored RUN_ALL_JOBS and
+    # ran everything at once anyway would pass the assertion above, and so would
+    # a broken stopwatch. The same four fixtures at jobs=1 must be slow.
+    start="$(now_ms)"
+    RUN_ALL_GATES_DIR="$gates" RUN_ALL_JOBS=1 "$RUNNER" >/dev/null
+    serial_ms=$(($(now_ms) - start))
+
+    if ((serial_ms < 8000)); then
+        log_fail "control failed: the same four took ${serial_ms}ms at jobs=1, so the timing assertion above cannot fire"
+    fi
+    log_pass "control: the same four take ${serial_ms}ms at jobs=1 (floor 8000ms), so the measurement can fail"
+}
+
+# ---------------------------------------------------------------------------
+# 2. Determinism across worker counts, over a set that is not all-green.
+# ---------------------------------------------------------------------------
+
+test_jobs_one_and_jobs_four_agree() {
+    local temp="$1"
+    local gates="$temp/gates"
+    local out_serial out_parallel rc_serial=0 rc_parallel=0
+    mkdir -p "$gates"
+    mk_fixture "$gates" "test-a-green.sh" 'echo "PASS: green fixture asserted something"'
+    mk_fixture "$gates" "test-b-red.sh" 'echo "diagnostic line from the red fixture"' 'exit 1'
+    # Exit 0 with no PASS: line at all. run-all.sh must score this as a failure
+    # in both modes; a mode that scored it differently would mean the vacuity
+    # guard moved with the scheduler.
+    mk_fixture "$gates" "test-c-vacuous.sh" 'echo "this fixture asserts nothing"' 'exit 0'
+    mk_fixture "$gates" "test-d-green.sh" 'sleep 1' 'echo "PASS: slow green fixture asserted something"'
+
+    out_serial="$(RUN_ALL_GATES_DIR="$gates" RUN_ALL_JOBS=1 "$RUNNER" 2>&1)" || rc_serial=$?
+    out_parallel="$(RUN_ALL_GATES_DIR="$gates" RUN_ALL_JOBS=4 "$RUNNER" 2>&1)" || rc_parallel=$?
+
+    assert_eq "$rc_serial" "1" "the mixed fixture set must exit 1 at jobs=1"
+    assert_eq "$rc_parallel" "$rc_serial" "exit code must not depend on the worker count"
+    assert_eq "$out_parallel" "$out_serial" "the transcript must not depend on the worker count"
+    assert_contains "$out_serial" "2 passed, 2 failed" "the mixed set must score 2 pass / 2 fail"
+    assert_contains "$out_serial" "test-c-vacuous.sh (exited 0 but made no assertions)" \
+        "the vacuity guard must still fire under the scheduler"
+    log_pass "jobs=1 and jobs=4 agree byte-for-byte on transcript, exit code and failure set"
+}
+
+# ---------------------------------------------------------------------------
+# 3. No interleaving. This is what the main-printer design buys.
+# ---------------------------------------------------------------------------
+
+test_output_blocks_never_interleave() {
+    local temp="$1"
+    local gates="$temp/gates"
+    local out seen expected
+    mkdir -p "$gates"
+    mk_fixture "$gates" "test-alpha.sh" \
+        'echo "alpha-1"' 'sleep 0.4' 'echo "alpha-2"' 'sleep 0.4' 'echo "alpha-3"' \
+        'echo "PASS: alpha emitted three lines"'
+    mk_fixture "$gates" "test-beta.sh" \
+        'echo "beta-1"' 'sleep 0.4' 'echo "beta-2"' 'sleep 0.4' 'echo "beta-3"' \
+        'echo "PASS: beta emitted three lines"'
+
+    # --verbose is the hostile case: it replays each test's whole log, so a
+    # worker that printed directly to the terminal would splice the two.
+    out="$(RUN_ALL_GATES_DIR="$gates" RUN_ALL_JOBS=4 "$RUNNER" --verbose 2>&1)"
+    seen="$(printf '%s\n' "$out" | grep -oE '^(alpha|beta)-[0-9]' | paste -sd' ' -)"
+    expected="alpha-1 alpha-2 alpha-3 beta-1 beta-2 beta-3"
+    assert_eq "$seen" "$expected" "each test's lines must stay contiguous and in glob order"
+    log_pass "two concurrent tests emit contiguous, glob-ordered blocks under --verbose"
+}
+
+# ---------------------------------------------------------------------------
+# 4. The W/S hold-back, and the control that proves it is doing the work.
+# ---------------------------------------------------------------------------
+
+test_scanners_never_overlap_writers() {
+    local temp="$1"
+    local gates="$temp/gates"
+    local sentinel="$temp/writer.sentinel"
+    local rc_scheduled=0 rc_unscheduled=0 out_scheduled out_unscheduled
+    mkdir -p "$gates"
+
+    # The writer holds a sentinel for 2s, exactly as the two real writers hold
+    # a fixture file inside .ci/scripts and scripts.
+    mk_fixture "$gates" "test-w-writer.sh" \
+        "touch \"$sentinel\"" 'sleep 2' "rm -f \"$sentinel\"" \
+        'echo "PASS: writer held and released its fixture"'
+    # The scanner reds if it sees the sentinel, exactly as a recursive copy of a
+    # directory reds when a file vanishes underneath it.
+    mk_fixture "$gates" "test-x-scanner.sh" \
+        'sleep 1' \
+        "if [[ -e \"$sentinel\" ]]; then" \
+        '    echo "writer fixture was present while the scanner ran" >&2' \
+        '    exit 1' \
+        'fi' \
+        'echo "PASS: scanner saw a quiet tree"'
+
+    out_scheduled="$(RUN_ALL_GATES_DIR="$gates" RUN_ALL_JOBS=4 \
+        RUN_ALL_WRITERS="test-w-writer.sh" RUN_ALL_SCANNERS="test-x-scanner.sh" \
+        "$RUNNER" 2>&1)" || rc_scheduled=$?
+    assert_eq "$rc_scheduled" "0" "with the W/S schedule the scanner must never see the writer's fixture"
+    assert_contains "$out_scheduled" "2 passed, 0 failed" "both fixtures must pass under the schedule"
+    log_pass "the S set is held back until the W chain has released the tree"
+
+    # THE CONTROL. Drop both fixtures into T -- which is what a flat pool is --
+    # and the same two must collide. Without this, a runner that ran everything
+    # serially, or one whose scanner check never fired, would look identical.
+    out_unscheduled="$(RUN_ALL_GATES_DIR="$gates" RUN_ALL_JOBS=4 \
+        RUN_ALL_WRITERS="" RUN_ALL_SCANNERS="" \
+        "$RUNNER" 2>&1)" || rc_unscheduled=$?
+    assert_eq "$rc_unscheduled" "1" "control failed: a flat pool must reproduce the collision this schedule prevents"
+    assert_contains "$out_unscheduled" "writer fixture was present while the scanner ran" \
+        "control failed: the collision must be the reported reason"
+    log_pass "control: without the schedule the same two fixtures collide, so the green above is the hold-back"
+}
+
+log_test "test-run-all-parallel"
+
+with_temp_dir test_pool_runs_tests_concurrently
+with_temp_dir test_jobs_one_and_jobs_four_agree
+with_temp_dir test_output_blocks_never_interleave
+with_temp_dir test_scanners_never_overlap_writers
+
+log_pass "all tests passed"

--- a/.ci/scripts/test/lib/test-helpers.sh
+++ b/.ci/scripts/test/lib/test-helpers.sh
@@ -26,6 +26,13 @@ log_fail() {
     exit 1
 }
 log_test() { echo -e "${YELLOW}TEST:${NC} $*"; }
+# info/error were ASSUMED by callers before they existed here:
+# test-shell-counter-increment.sh called both under `set -uo pipefail` (no -e),
+# so every run printed `log_info: command not found` and its finding report
+# would have said the same instead of naming the offending file (found
+# 2026-08-08 by the run-all parallelization agent). Defined once, centrally.
+log_info() { echo -e "${YELLOW}INFO:${NC} $*"; }
+log_error() { echo -e "${RED}ERROR:${NC} $*" >&2; }
 
 # assert_eq <actual> <expected> [<message>]
 assert_eq() {

--- a/.ci/scripts/test/run-all.sh
+++ b/.ci/scripts/test/run-all.sh
@@ -9,18 +9,75 @@
 # .ci/scripts/test/ (install script, linux packages, etc.) are run by
 # separate CI jobs with different timing / infrastructure needs.
 #
+# WHY THIS RUNS IN PARALLEL, AND WHY THE SCHEDULE MATTERS MORE THAN THE DEGREE.
+# Serially the battery took about 18 minutes of the Security job's 20-minute
+# budget, so the step was one slow test away from a timeout rather than one slow
+# test away from a slow run. The obvious fix -- fan the tests out over the
+# runner's cores -- is unsafe as a flat pool, and the reason is specific rather
+# than general: two of these tests WRITE INTO THE REAL TREE, because the code
+# they exercise hardcodes the real tree and cannot be pointed at a fixture.
+#
+#   test-gate-paths-exist.sh   plants and deletes .ci/scripts/.gate-paths-exist{,-noise}-fixture.ts
+#   test-gate-anti-vacuity.sh  plants and deletes scripts/.gate-anti-vacuity-fixture.ts
+#
+# Meanwhile a good dozen other tests RECURSIVELY ENUMERATE those same two
+# directories -- `cp -r`, `find`, `grep -r`, or a gate that does one of those on
+# their behalf. A file that appears or vanishes mid-enumeration is a hard error
+# (`cp: cannot stat`, grep exit 2), and under `set -euo pipefail` that is a
+# one-shot red which passes on the very next serial re-run. That is a flake
+# manufactured by the runner, and lowering the worker count does not remove it:
+# with two workers the collision is rarer and just as real.
+#
+# So the tests are scheduled in three sets rather than pooled flat:
+#
+#   W (writers)  the two above, run as one serial chain, exclusive against S
+#   S (scanners) everything that reads the real .ci/scripts or scripts tree,
+#                pool-safe among themselves because they only read, released
+#                only once the W chain has finished
+#   T (temp)     everything else -- env-seam plus mktemp fixtures, isolated by
+#                construction, safe to run against anything
+#
+# The W chain starts at t=0 (it also holds the longest single test, so
+# longest-first would put it there anyway), T fills the remaining slots while it
+# runs, and S drains after it. Wall time becomes max(W chain, longest T) plus
+# the S drain instead of the sum of all 86.
+#
+# OUTPUT IS PRINTED BY MAIN ONLY. Workers write to $RESULTS_DIR/<idx>.log and
+# then atomically publish $RESULTS_DIR/<idx>.rc; they never touch the terminal.
+# Main walks the indices in ascending order and prints each finished test's
+# block, so the transcript is byte-for-byte the shape a serial run produced, in
+# the same order, with no interleaving and no locking.
+#
 # Usage:
 #   ./run-all.sh                      # run all gate tests
 #   ./run-all.sh --verbose            # show stdout of each test
 #   ./run-all.sh 'test-blocker*.sh'   # run only matching tests
+#
+# Environment seams (all optional; the defaults are what CI runs):
+#   RUN_ALL_JOBS       worker count. 1 degenerates to a serial run through this
+#                      same code path, which is what the determinism control uses.
+#   RUN_ALL_GATES_DIR  directory of gate tests to run
+#   RUN_ALL_WRITERS    space-separated W membership, overriding the list below
+#   RUN_ALL_SCANNERS   space-separated S membership, overriding the list below
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-GATES_DIR="$SCRIPT_DIR/gates"
+GATES_DIR="${RUN_ALL_GATES_DIR:-$SCRIPT_DIR/gates}"
 # shellcheck source=lib/test-helpers.sh
 # BLOCKER: shared test-runner colour / status helpers
 source "$SCRIPT_DIR/lib/test-helpers.sh"
+
+# `wait -n` IS the scheduler. Bash 4.3 introduced it, but before 5.1 it could
+# overlook a job that had already exited before the call, which turns the slot
+# loop into either a hang or a silent over-subscription. Fail loudly instead of
+# falling back to serial: a quiet fallback would make the speedup depend on
+# which shell happens to be installed and nobody would ever notice it was gone.
+# Every caller is Linux (CI is ubuntu-latest, the operator is WSL2); there is no
+# macOS caller to keep on bash 3.2.
+if ((BASH_VERSINFO[0] < 5)) || { ((BASH_VERSINFO[0] == 5)) && ((BASH_VERSINFO[1] < 1)); }; then
+    log_fail "run-all.sh needs bash >= 5.1 for 'wait -n' (found $BASH_VERSION)"
+fi
 
 VERBOSE=false
 PATTERN="test-*.sh"
@@ -38,6 +95,57 @@ while (($# > 0)); do
     esac
 done
 
+# --- membership ------------------------------------------------------------
+#
+# Both lists are BY NAME, so a pattern-subset run ('test-gate-*.sh') classifies
+# correctly without any extra bookkeeping. Everything not named here is T.
+
+# W: writes into the real tree while it runs. Adding to this list is cheap;
+# leaving something off it is a flake.
+WRITER_TESTS=(
+    test-gate-paths-exist.sh
+    test-gate-anti-vacuity.sh
+)
+
+# S: reads or copies the real .ci/scripts / scripts tree, directly or through
+# the gate it drives. Written longest-first so the cost of the tail is legible
+# here; the scheduler itself spawns S in glob order, which costs nothing because
+# the members ahead of the long pole run in seconds.
+SCANNER_TESTS=(
+    test-dead-bash.sh
+    test-ci-parity.sh
+    test-review-status.sh
+    test-suppression-liveness.sh
+    test-ci-runner.sh
+    test-profiler-coverage.sh
+    test-overrides-reasons.sh
+    test-greenlight.sh
+    test-knip-blockers.sh
+    test-scope-gate-outputs.sh
+    test-label-inventory.sh
+    test-swallowed-failures.sh
+    test-breakpoint-portability.sh
+    test-autopilot-breakpoint-alignment.sh
+    test-label-references.sh
+    test-autopilot-workflow-invariants.sh
+    test-dead-case-arms.sh
+    test-tutorial-render-queue.sh
+    test-shell-counter-increment.sh
+)
+
+if [[ -n "${RUN_ALL_WRITERS+x}" ]]; then
+    # BLOCKER: intentional word splitting of the injected W list into an array; quoting would make the whole space-separated string one member and the seam would silently classify nothing
+    # shellcheck disable=SC2206
+    # BLOCKER: intentional word splitting of the injected W list
+    WRITER_TESTS=($RUN_ALL_WRITERS)
+fi
+if [[ -n "${RUN_ALL_SCANNERS+x}" ]]; then
+    # BLOCKER: intentional word splitting of the injected S list into an array; quoting would make the whole space-separated string one member and the seam would silently classify nothing
+    # shellcheck disable=SC2206
+    # BLOCKER: intentional word splitting of the injected S list
+    SCANNER_TESTS=($RUN_ALL_SCANNERS)
+fi
+
 cd "$GATES_DIR"
 shopt -s nullglob
 # BLOCKER: intentional glob expansion of user-supplied $PATTERN into the TEST_FILES array; quoting would prevent shopt nullglob from filtering non-matches
@@ -50,10 +158,37 @@ if ((${#TEST_FILES[@]} == 0)); then
     log_fail "No test files matched pattern: $PATTERN in $GATES_DIR"
 fi
 
+# --- worker count ----------------------------------------------------------
+#
+# 4 on ubuntu-latest. Capped at 8 locally so a bare `npm run
+# check:ci-quality-gates` on a 20-core box does not fork-bomb npx/tsx: several
+# of these tests shell out to node, and 20 concurrent node startups cost more in
+# contention than they buy in parallelism.
+CPUS=4
+if command -v nproc >/dev/null 2>&1; then
+    CPUS="$(nproc)"
+fi
+JOBS="${RUN_ALL_JOBS:-0}"
+if ((JOBS <= 0)); then
+    JOBS="$CPUS"
+    if ((JOBS > 8)); then
+        JOBS=8
+    fi
+fi
+
+RESULTS_DIR="$(mktemp -d)"
+# BLOCKER: expanding RESULTS_DIR now binds the specific path into the trap, so cleanup removes the directory this run created even if the variable is later reassigned
+# shellcheck disable=SC2064
+# BLOCKER: expanding RESULTS_DIR now binds the specific path into the trap
+trap "rm -rf '$RESULTS_DIR'" EXIT
+
+WRITERS_DONE="$RESULTS_DIR/writers.done"
+
 pass=0
 fail=0
 assertions_total=0
 failed_tests=()
+printed=0
 
 # log_pass() colours its output, so a PASS line starts with a real ESC byte.
 # The previous pattern spelled that byte '\x1b', which POSIX ERE does not
@@ -64,37 +199,182 @@ failed_tests=()
 # 20 tests that assert nothing. $'...' puts the actual byte in the pattern.
 PASS_RE=$'^(\033\\[0;32m)?PASS:'
 
-for test_file in "${TEST_FILES[@]}"; do
-    log_test "$test_file"
-    local_log="$(mktemp)"
-    if "./$test_file" >"$local_log" 2>&1; then
-        # Count the assertions the test actually made. A test that exits 0
-        # without emitting a single PASS is vacuous -- it asserted nothing and
-        # must not be reported as a passing gate.
-        assertions="$(grep -acE "$PASS_RE" "$local_log" || true)"
-        if ((assertions == 0)); then
-            fail=$((fail + 1))
-            failed_tests+=("$test_file (exited 0 but made no assertions)")
-            cat "$local_log"
-            # Not log_fail: that exits, and the remaining tests still need to run.
-            echo -e "${RED}FAIL:${NC} $test_file exited 0 without a single PASS: line" >&2
-        else
-            pass=$((pass + 1))
-            assertions_total=$((assertions_total + assertions))
-            if [[ "$VERBOSE" == "true" ]]; then
-                cat "$local_log"
-            else
-                grep -aE "$PASS_RE" "$local_log" || true
-            fi
+# in_list <needle> <item>... -- membership without an associative array, so the
+# injected seams stay plain strings.
+in_list() {
+    local needle="$1" item
+    shift
+    for item in "$@"; do
+        if [[ "$item" == "$needle" ]]; then
+            return 0
         fi
-    else
+    done
+    return 1
+}
+
+# run_one <idx> -- a WORKER. Never prints. Publishes the exit status last, and
+# publishes it atomically (tmp + mv), so main can treat the presence of <idx>.rc
+# as proof that <idx>.log is complete.
+run_one() {
+    local idx="$1" rc=0
+    "./${TEST_FILES[idx]}" >"$RESULTS_DIR/$idx.log" 2>&1 || rc=$?
+    printf '%s\n' "$rc" >"$RESULTS_DIR/$idx.rc.part"
+    mv -f "$RESULTS_DIR/$idx.rc.part" "$RESULTS_DIR/$idx.rc"
+}
+
+# run_chain <idx>... -- the W set as ONE background unit, serial inside. The
+# done-marker is written after the last member's .rc, which is what makes it a
+# safe release signal for S: when it exists, no real-tree writer is still alive.
+run_chain() {
+    local idx
+    for idx in "$@"; do
+        run_one "$idx"
+    done
+    : >"$WRITERS_DONE"
+}
+
+# print_block <idx> -- MAIN ONLY. This is the serial runner's per-test block,
+# unchanged in shape, reading a finished log instead of running the test inline.
+print_block() {
+    local idx="$1"
+    local test_file="${TEST_FILES[idx]}"
+    local log="$RESULTS_DIR/$idx.log" rc_file="$RESULTS_DIR/$idx.rc"
+    local rc assertions
+
+    log_test "$test_file"
+    if [[ ! -f "$rc_file" ]]; then
+        # ANTI-VACUITY. A test that was never scheduled, or whose worker died
+        # before publishing, is a FAILURE and never a skip. A scheduling bug has
+        # to present as red, otherwise it presents as a shorter green run and
+        # that is the exact shape of a gate that stopped gating.
         fail=$((fail + 1))
-        failed_tests+=("$test_file")
-        cat "$local_log"
+        failed_tests+=("$test_file (no result recorded)")
+        if [[ -f "$log" ]]; then
+            cat "$log"
+        fi
+        echo -e "${RED}FAIL:${NC} $test_file produced no result: the scheduler never completed it" >&2
+    else
+        rc="$(cat "$rc_file")"
+        if [[ "$rc" == "0" ]]; then
+            # Count the assertions the test actually made. A test that exits 0
+            # without emitting a single PASS is vacuous -- it asserted nothing and
+            # must not be reported as a passing gate.
+            assertions="$(grep -acE "$PASS_RE" "$log" || true)"
+            if ((assertions == 0)); then
+                fail=$((fail + 1))
+                failed_tests+=("$test_file (exited 0 but made no assertions)")
+                cat "$log"
+                # Not log_fail: that exits, and the remaining tests still need to run.
+                echo -e "${RED}FAIL:${NC} $test_file exited 0 without a single PASS: line" >&2
+            else
+                pass=$((pass + 1))
+                assertions_total=$((assertions_total + assertions))
+                if [[ "$VERBOSE" == "true" ]]; then
+                    cat "$log"
+                else
+                    grep -aE "$PASS_RE" "$log" || true
+                fi
+            fi
+        else
+            fail=$((fail + 1))
+            failed_tests+=("$test_file")
+            cat "$log"
+        fi
     fi
-    rm -f "$local_log"
+    rm -f "$log" "$rc_file"
+    printed=$((printed + 1))
     echo ""
+}
+
+# drain_ready -- print every finished test whose turn has come. Strictly
+# ascending, so the transcript and the "Failed tests:" list are in glob order
+# regardless of which worker finished first.
+drain_ready() {
+    while ((printed < ${#TEST_FILES[@]})) && [[ -f "$RESULTS_DIR/$printed.rc" ]]; do
+        print_block "$printed"
+    done
+}
+
+live_jobs() {
+    jobs -pr | wc -l
+}
+
+# wait_for_slot -- block until a worker slot frees. The `|| true` is mandatory:
+# `wait -n` returns the finished job's exit status, and a red gate test must not
+# kill the runner under `set -e`.
+wait_for_slot() {
+    while (($(live_jobs) >= JOBS)); do
+        wait -n || true
+        drain_ready
+    done
+}
+
+wait_for_writers() {
+    # If the chain's subshell died without its marker, stop waiting rather than
+    # hang: the missing .rc files then surface through print_block as failures,
+    # which is the loud outcome.
+    while [[ ! -f "$WRITERS_DONE" ]] && (($(live_jobs) > 0)); do
+        wait -n || true
+        drain_ready
+    done
+    drain_ready
+}
+
+drain_all() {
+    while (($(live_jobs) > 0)); do
+        wait -n || true
+        drain_ready
+    done
+    drain_ready
+    # Anything still unprinted has no .rc and never will; print_block scores it
+    # as a failure.
+    while ((printed < ${#TEST_FILES[@]})); do
+        print_block "$printed"
+    done
+}
+
+# --- schedule --------------------------------------------------------------
+
+writer_idx=()
+scanner_idx=()
+temp_idx=()
+for idx in "${!TEST_FILES[@]}"; do
+    name="${TEST_FILES[idx]}"
+    if in_list "$name" "${WRITER_TESTS[@]}"; then
+        writer_idx+=("$idx")
+    elif in_list "$name" "${SCANNER_TESTS[@]}"; then
+        scanner_idx+=("$idx")
+    else
+        temp_idx+=("$idx")
+    fi
 done
+
+if ((${#writer_idx[@]} > 0)); then
+    run_chain "${writer_idx[@]}" &
+else
+    : >"$WRITERS_DONE"
+fi
+
+for idx in "${temp_idx[@]}"; do
+    wait_for_slot
+    run_one "$idx" &
+done
+
+wait_for_writers
+
+for idx in "${scanner_idx[@]}"; do
+    wait_for_slot
+    run_one "$idx" &
+done
+
+drain_all
+
+# The self-guard on the guard. print_block is the only thing that increments
+# `printed`, and it is also the only thing that scores a test, so a printed
+# count short of the file count means the scheduler dropped work silently.
+if ((printed != ${#TEST_FILES[@]})); then
+    log_fail "scheduler printed $printed of ${#TEST_FILES[@]} test blocks; results were lost"
+fi
 
 echo "=============================================="
 echo "Quality-gate tests: $pass passed, $fail failed ($assertions_total assertions)"

--- a/.claude/hooks/stop/test-worklist-v5.sh
+++ b/.claude/hooks/stop/test-worklist-v5.sh
@@ -5262,7 +5262,7 @@ say "answer
 
 ## Remaining
 - #7 fully planned and unblocked (pending)"
-OUT="$(run)"   # seed the clock
+OUT="$(run)" # seed the clock
 python3 - "$WL" <<'PYEOF'
 import json, pathlib, sys
 p = pathlib.Path(sys.argv[1].replace(".md", ".state-deadbeef.json"))
@@ -5297,7 +5297,7 @@ say "answer
 ## Remaining
 - #6 the prerequisite (pending)
 - #7 parked behind 6 (pending)"
-OUT="$(run)"   # seed
+OUT="$(run)" # seed
 python3 - "$WL" <<'PYEOF'
 import json, pathlib, sys
 p = pathlib.Path(sys.argv[1].replace(".md", ".state-deadbeef.json"))
@@ -5961,7 +5961,7 @@ export WORKLIST_BG_OUTPUT_DIR="$BASE/bgout"
 printf 'stream\n' >"$BASE/bgout/bw4.output"
 BG='[{"id":"bw4","type":"shell","status":"running","description":"watch"}]'
 task 6 in_progress "the live prerequisite"
-task 7 pending "thing" 6   # v19: blocked scenery so the pure-wait premise holds
+task 7 pending "thing" 6 # v19: blocked scenery so the pure-wait premise holds
 say "answer
 
 ## Remaining

--- a/.claude/hooks/stop/test-worklist-v5.sh
+++ b/.claude/hooks/stop/test-worklist-v5.sh
@@ -113,8 +113,12 @@ open(sys.argv[2],"a").write(json.dumps(rec)+"\n")
 ' "$1" "$BASE/t.jsonl"
 }
 
-task() { # task <id> <status> <subject>
-    printf '{"id":"%s","status":"%s","subject":"%s"}\n' "$1" "$2" "$3" >"$BASE/tasks/session-deadbeef/$1.json"
+task() { # task <id> <status> <subject> [blockedBy-csv]
+    local blocked="[]"
+    if [[ -n "${4:-}" ]]; then
+        blocked=$(printf '%s' "$4" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().split(",")))')
+    fi
+    printf '{"id":"%s","status":"%s","subject":"%s","blockedBy":%s}\n' "$1" "$2" "$3" "$blocked" >"$BASE/tasks/session-deadbeef/$1.json"
 }
 
 # Plant a STATE.md DIRECTLY on disk, bypassing `--state`.
@@ -2551,6 +2555,7 @@ ARITY = {
     "N_CI_QUEUE": ("r", 2, 30, ""), "N_CI_QUEUE_PR_STALE_LINE": None,
     "N_EMAIL_SKIPPED": (1, "err"),
     "V_BG_REPORT": ("never", "2026-01-01T00:15:00Z", 15, 2, "rows"),
+    "V_BG_REPORT_TASKS": ("never", "2026-01-01T00:15:00Z", 15, 2, 1, "tasks", "rows"),
     "N_EMAIL_SENT": (2, "to@x", 120), "N_EMAIL_FAIL": (2, "err", 15),
     "N_EMAIL_UNCONFIGURED": ("p", 2),
     "CLI_ASK_OPERATOR_NO_DEFAULT": None,
@@ -5191,11 +5196,14 @@ mkdir -p "$BASE/bgout"
 export WORKLIST_BG_OUTPUT_DIR="$BASE/bgout"
 printf 'worker stream content\n' >"$BASE/bgout/bw1.output"
 BG='[{"id":"bw1","type":"shell","status":"running","description":"long CI watch"}]'
-task 7 pending "waiting on the nightly"
+# v19: an UNBLOCKED pending task now (correctly) makes the wait impure, so this
+# case's parked task is in_progress -- the state a watched-by-this-session job
+# actually has. The unblocked-pending behavior gets its own case 163y below.
+task 7 in_progress "waiting on the nightly"
 say "answer
 
 ## Remaining
-- #7 waiting on the nightly (pending)"
+- #7 waiting on the nightly (in_progress)"
 # Stop 1 SEEDS the wait clock silently: the check-in means "you have been
 # waiting 15 minutes", never "you started waiting".
 OUT="$(run)"
@@ -5215,7 +5223,7 @@ newturn
 say "answer
 
 ## Remaining
-- #7 waiting on the nightly (pending)"
+- #7 waiting on the nightly (in_progress)"
 OUT="$(run)"
 if grep -qF "PURE BACKGROUND WAIT" <<<"$OUT" && grep -qF "bw1 (long CI watch)" <<<"$OUT" &&
     grep -qF "output last grew" <<<"$OUT"; then
@@ -5228,12 +5236,87 @@ newturn
 say "bw1 confirmed: the long CI watch stream matches; nothing stuck.
 
 ## Remaining
-- #7 waiting on the nightly (pending)"
+- #7 waiting on the nightly (in_progress)"
 OUT="$(run)"
 if ! grep -qF "PURE BACKGROUND WAIT" <<<"$OUT"; then
     pass "163 CONTROL: no second check-in inside the 15-minute window"
 else
     fail "163 CONTROL: the check-in drumbeat: ${OUT:0:250}"
+fi
+
+echo "== 163y. v19: an unblocked pending task makes the wait IMPURE and gets named =="
+# Operator, 2026-08-08: a session idled for hours in "pure background wait"
+# beside a fully planned, unblocked pending task; the check-in kept certifying
+# the wait because it never consulted the harness queue. Now: pending with no
+# unresolved blocker -> the check-in fires as WORKABLE-TASKS and names it;
+# pending with a live blocker -> the wait stays pure (the control).
+setup
+brief_now
+hand_now
+mkdir -p "$BASE/bgout"
+export WORKLIST_BG_OUTPUT_DIR="$BASE/bgout"
+printf 'worker stream content\n' >"$BASE/bgout/bw1.output"
+BG='[{"id":"bw1","type":"shell","status":"running","description":"long CI watch"}]'
+task 7 pending "fully planned and unblocked"
+say "answer
+
+## Remaining
+- #7 fully planned and unblocked (pending)"
+OUT="$(run)"   # seed the clock
+python3 - "$WL" <<'PYEOF'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1].replace(".md", ".state-deadbeef.json"))
+doc = json.loads(p.read_text())
+doc["bgwait"] = {"at": "2026-01-01T00:00:00Z"}
+p.write_text(json.dumps(doc))
+PYEOF
+newturn
+say "answer
+
+## Remaining
+- #7 fully planned and unblocked (pending)"
+OUT="$(run)"
+if grep -qF "WORKABLE TASKS" <<<"$OUT" && grep -qF "task #7 fully planned and unblocked" <<<"$OUT" &&
+    ! grep -qF "not a demand for other work" <<<"$OUT"; then
+    pass "163y: the check-in names the unblocked pending task instead of certifying the wait"
+else
+    fail "163y: workable task not named: ${OUT:0:300}"
+fi
+# CONTROL: the same task behind a LIVE blocker keeps the wait pure.
+setup
+brief_now
+hand_now
+mkdir -p "$BASE/bgout"
+export WORKLIST_BG_OUTPUT_DIR="$BASE/bgout"
+printf 'worker stream content\n' >"$BASE/bgout/bw1.output"
+BG='[{"id":"bw1","type":"shell","status":"running","description":"long CI watch"}]'
+task 6 pending "the prerequisite"
+task 7 pending "parked behind 6" 6
+say "answer
+
+## Remaining
+- #6 the prerequisite (pending)
+- #7 parked behind 6 (pending)"
+OUT="$(run)"   # seed
+python3 - "$WL" <<'PYEOF'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1].replace(".md", ".state-deadbeef.json"))
+doc = json.loads(p.read_text())
+doc["bgwait"] = {"at": "2026-01-01T00:00:00Z"}
+p.write_text(json.dumps(doc))
+PYEOF
+newturn
+say "answer
+
+## Remaining
+- #6 the prerequisite (pending)
+- #7 parked behind 6 (pending)"
+OUT="$(run)"
+if grep -qF "WORKABLE TASKS" <<<"$OUT" && grep -qF "task #6 the prerequisite" <<<"$OUT" &&
+    ! grep -qF "task #7 parked behind 6" <<<"$OUT"; then
+    pass "163y CONTROL: the blocked task stays unnamed; its live blocker is the one named"
+else
+    fail "163y CONTROL: blocker logic wrong: ${OUT:0:300}"
 fi
 
 echo "== 163z. v18: a CONFIRMED inbox waiter owes no check-in and needs no poll cron =="
@@ -5280,11 +5363,11 @@ else
     fail "163z premise: waiter verdict is '$VERDICT', not confirmed -- this case is vacuous"
 fi
 CRONS='[{"id":"c1","schedule":"*/30 * * * *","prompt":"work loop"}]'
-task 7 pending "waiting on the inbox"
+task 7 in_progress "waiting on the inbox"
 say "answer
 
 ## Remaining
-- #7 waiting on the inbox (pending)"
+- #7 waiting on the inbox (in_progress)"
 run >/dev/null
 python3 - "$WL" <<'PYEOF'
 import json, pathlib, sys
@@ -5297,7 +5380,7 @@ newturn
 say "answer
 
 ## Remaining
-- #7 waiting on the inbox (pending)"
+- #7 waiting on the inbox (in_progress)"
 OUT="$(run)"
 if ! grep -qF "PURE BACKGROUND WAIT" <<<"$OUT"; then
     pass "163z: an overdue check-in is SUPPRESSED when the only live task is a confirmed waiter"
@@ -5363,11 +5446,11 @@ mate("bystander-9999-8888-7777-666666666666", "freshmate", 0)
 MKSTORE
 export CLAUDE_CONFIG_DIR="$BASE/claude"
 BG='[{"id":"tm1","type":"teammate","status":"running","description":"You are an Opus writer sub-agent in /home..."},{"id":"tm2","type":"teammate","status":"running","description":"You are an Opus writer sub-agent in /home..."}]'
-task 7 pending "waiting on the teammates"
+task 7 in_progress "waiting on the teammates"
 say "answer
 
 ## Remaining
-- #7 waiting on the teammates (pending)"
+- #7 waiting on the teammates (in_progress)"
 run >/dev/null # establishes the state doc
 # THE CLOCK MUST BE OVERDUE BEFORE THIS PROVES ANYTHING. Asserting on a seeding
 # stop is vacuous: the check-in does not fire on first sight of the wait state
@@ -5386,7 +5469,7 @@ newturn
 say "answer
 
 ## Remaining
-- #7 waiting on the teammates (pending)"
+- #7 waiting on the teammates (in_progress)"
 OUT="$(run)"
 if ! grep -qF "PURE BACKGROUND WAIT" <<<"$OUT"; then
     pass "163v: with zero fresh transcripts the phantom roster is dropped"
@@ -5415,7 +5498,7 @@ newturn
 say "answer
 
 ## Remaining
-- #7 waiting on the teammates (pending)"
+- #7 waiting on the teammates (in_progress)"
 OUT="$(run)"
 if grep -qF "PURE BACKGROUND WAIT" <<<"$OUT"; then
     pass "163v CONTROL: one fresh transcript keeps the roster and the check-in"
@@ -5736,11 +5819,11 @@ print(json.dumps([{"id": "wt1", "type": "shell", "status": "running",
 PYEOF
 )"
 CRONS='[{"id":"c1","schedule":"*/30 * * * *","prompt":"work loop"}]'
-task 7 pending "waiting on the inbox"
+task 7 in_progress "waiting on the inbox"
 say "answer
 
 ## Remaining
-- #7 waiting on the inbox (pending)"
+- #7 waiting on the inbox (in_progress)"
 run >/dev/null
 python3 - "$WL" <<'PYEOF'
 import json, pathlib, sys
@@ -5753,7 +5836,7 @@ newturn
 say "answer
 
 ## Remaining
-- #7 waiting on the inbox (pending)"
+- #7 waiting on the inbox (in_progress)"
 OUT="$(run)"
 if grep -qF "PURE BACKGROUND WAIT" <<<"$OUT"; then
     pass "163z-c1 CONTROL: an unconfirmed waiter still owes the check-in"
@@ -5786,11 +5869,11 @@ print(json.dumps([
 ]))
 PYEOF
 )"
-task 7 pending "waiting on both"
+task 7 in_progress "waiting on both"
 say "answer
 
 ## Remaining
-- #7 waiting on both (pending)"
+- #7 waiting on both (in_progress)"
 run >/dev/null
 python3 - "$WL" <<'PYEOF'
 import json, pathlib, sys
@@ -5803,7 +5886,7 @@ newturn
 say "answer
 
 ## Remaining
-- #7 waiting on both (pending)"
+- #7 waiting on both (in_progress)"
 OUT="$(run)"
 if grep -qF "PURE BACKGROUND WAIT" <<<"$OUT"; then
     pass "163z-c2 CONTROL: a real job beside the waiter still gets its check-in"
@@ -5877,7 +5960,8 @@ mkdir -p "$BASE/bgout"
 export WORKLIST_BG_OUTPUT_DIR="$BASE/bgout"
 printf 'stream\n' >"$BASE/bgout/bw4.output"
 BG='[{"id":"bw4","type":"shell","status":"running","description":"watch"}]'
-task 7 pending "thing"
+task 6 in_progress "the live prerequisite"
+task 7 pending "thing" 6   # v19: blocked scenery so the pure-wait premise holds
 say "answer
 
 ## Remaining
@@ -6713,11 +6797,11 @@ export WORKLIST_BG_OUTPUT_DIR="$BASE/bgout"
 printf 'stream\n' >"$BASE/bgout/bw9.output"
 BGON='[{"id":"bw9","type":"shell","status":"running","description":"long watch"}]'
 BG="$BGON"
-task 7 pending "waiting on the nightly"
+task 7 in_progress "waiting on the nightly"
 say "answer
 
 ## Remaining
-- #7 waiting on the nightly (pending)"
+- #7 waiting on the nightly (in_progress)"
 run >/dev/null # seeds the wait clock
 age_bgwait() {
     python3 - "$WL" <<'PYEOF'
@@ -6746,7 +6830,7 @@ newturn
 say "the watch finished
 
 ## Remaining
-- #7 waiting on the nightly (pending)"
+- #7 waiting on the nightly (in_progress)"
 run >/dev/null
 if [[ "$(has_bgwait)" == "absent" ]]; then
     pass "179: leaving the wait state clears the check-in clock"
@@ -6759,7 +6843,7 @@ newturn
 say "started a new watch
 
 ## Remaining
-- #7 waiting on the nightly (pending)"
+- #7 waiting on the nightly (in_progress)"
 OUT="$(run)"
 if ! grep -qF "PURE BACKGROUND WAIT" <<<"$OUT"; then
     pass "179: re-entering a wait re-seeds the clock instead of firing on arrival"
@@ -6772,7 +6856,7 @@ newturn
 say "still waiting
 
 ## Remaining
-- #7 waiting on the nightly (pending)"
+- #7 waiting on the nightly (in_progress)"
 OUT="$(run)"
 if grep -qF "PURE BACKGROUND WAIT" <<<"$OUT"; then
     pass "179 CONTROL: aged inside a live wait, the check-in still fires"
@@ -6797,7 +6881,7 @@ mkdir -p "$BASE/bgout"
 export WORKLIST_BG_OUTPUT_DIR="$BASE/bgout"
 printf 'stream\n' >"$BASE/bgout/bwq.output"
 BG='[{"id":"bwq","type":"shell","status":"running","description":"long watch"}]'
-task 7 pending "waiting on the nightly"
+task 7 in_progress "waiting on the nightly"
 # A real deferral, so the NON-collapsed report has a guide in it. Since v18 an
 # empty guide is silent, and the reset control below needs a full report it can
 # actually see coming back.
@@ -6807,7 +6891,7 @@ quiet_turn() {
     say "still waiting on the nightly
 
 ## Remaining
-- #7 waiting on the nightly (pending)
+- #7 waiting on the nightly (in_progress)
 - the flag decision, deferred with a default"
 }
 quiet_turn

--- a/.claude/hooks/stop/test-worklist-v5.sh
+++ b/.claude/hooks/stop/test-worklist-v5.sh
@@ -5319,6 +5319,88 @@ else
     fail "163y CONTROL: blocker logic wrong: ${OUT:0:300}"
 fi
 
+echo "== 163x. v19: the transcript join finds a renamed task store; ambiguity refuses =="
+# Review finding on #559: the fallback in _resolve_tasks_dir had no committed
+# coverage (the original proof ran as ephemeral scratchpad python). This case
+# drives it through the REAL hook: the primary session-deadbeef dir is EMPTY
+# (setup creates it bare), the actual tasks live under a differently-named
+# session-* dir, and the only join evidence is a TaskCreate result line in the
+# transcript tail. The workable-tasks check-in naming the task proves the
+# whole chain: resolve -> actionable -> fire.
+setup
+brief_now
+hand_now
+mkdir -p "$BASE/bgout"
+export WORKLIST_BG_OUTPUT_DIR="$BASE/bgout"
+printf 'worker stream content\n' >"$BASE/bgout/bw1.output"
+BG='[{"id":"bw1","type":"shell","status":"running","description":"long CI watch"}]'
+mkdir -p "$BASE/tasks/session-teamzzzz"
+printf '{"id":"21","status":"pending","subject":"the mismatch fixture task","blockedBy":[]}\n' \
+    >"$BASE/tasks/session-teamzzzz/21.json"
+say "Task #21 created successfully: the mismatch fixture task"
+say "answer
+
+## Remaining
+- #21 the mismatch fixture task (pending)"
+OUT="$(run)" # seed the wait clock
+python3 - "$WL" <<'PYEOF'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1].replace(".md", ".state-deadbeef.json"))
+doc = json.loads(p.read_text())
+doc["bgwait"] = {"at": "2026-01-01T00:00:00Z"}
+p.write_text(json.dumps(doc))
+PYEOF
+newturn
+say "answer
+
+## Remaining
+- #21 the mismatch fixture task (pending)"
+OUT="$(run)"
+if grep -qF "WORKABLE TASKS" <<<"$OUT" && grep -qF "task #21 the mismatch fixture task" <<<"$OUT"; then
+    pass "163x: the join resolved the renamed store off the transcript and named its task"
+else
+    fail "163x: fallback resolution failed: ${OUT:0:300}"
+fi
+# CONTROL: TWO dirs matching the same TaskCreate line -> the join refuses, no
+# task is named, the wait stays pure. Fresh setup so the durable resolution
+# cache from the fire case cannot leak in.
+setup
+brief_now
+hand_now
+mkdir -p "$BASE/bgout"
+export WORKLIST_BG_OUTPUT_DIR="$BASE/bgout"
+printf 'worker stream content\n' >"$BASE/bgout/bw1.output"
+BG='[{"id":"bw1","type":"shell","status":"running","description":"long CI watch"}]'
+for d in teamzzzz teamyyyy; do
+    mkdir -p "$BASE/tasks/session-$d"
+    printf '{"id":"21","status":"pending","subject":"the mismatch fixture task","blockedBy":[]}\n' \
+        >"$BASE/tasks/session-$d/21.json"
+done
+say "Task #21 created successfully: the mismatch fixture task"
+say "answer
+
+## Remaining
+(nothing tracked here)"
+OUT="$(run)" # seed
+python3 - "$WL" <<'PYEOF'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1].replace(".md", ".state-deadbeef.json"))
+doc = json.loads(p.read_text())
+doc["bgwait"] = {"at": "2026-01-01T00:00:00Z"}
+p.write_text(json.dumps(doc))
+PYEOF
+newturn
+say "answer
+
+## Remaining
+(nothing tracked here)"
+OUT="$(run)"
+if grep -qF "PURE BACKGROUND WAIT" <<<"$OUT" && ! grep -qF "task #21" <<<"$OUT"; then
+    pass "163x CONTROL: two candidate dirs refuse the join; no manufactured task, wait stays pure"
+else
+    fail "163x CONTROL: ambiguity did not refuse: ${OUT:0:300}"
+fi
+
 echo "== 163z. v18: a CONFIRMED inbox waiter owes no check-in and needs no poll cron =="
 # The waiter blocks until something new arrives for this session and then EXITS,
 # and its exit is the harness notification that wakes the session. Its liveness

--- a/.claude/hooks/stop/wl_checks.py
+++ b/.claude/hooks/stop/wl_checks.py
@@ -1751,7 +1751,7 @@ def run_stop(event, event_ok, worklist, hook_file):
                 1,
                 sticky=True,
             )
-        reg_cur_tasks = C.task_statuses(session_id)
+        reg_cur_tasks = C.task_statuses(session_id, event.get("transcript_path"))
         if not reg_state["head"]:
             # FAIL SAFE: first sight (or a corrupt marker just discarded)
             # initialises to the present and asks nothing this stop. Seeding
@@ -1823,7 +1823,7 @@ def run_stop(event, event_ok, worklist, hook_file):
     # ---- gather EVERY static violation, then emit ONE block -----------------
     judged_ok = None
     verdict = None
-    tasks = C.pending_tasks(session_id)
+    tasks = C.pending_tasks(session_id, event.get("transcript_path"))
     # THE EVENT ALREADY CARRIES ALL OF THIS. Transcript parsing, a flush retry
     # and a whole-turn accumulator were built before a captured Stop payload
     # showed `last_assistant_message`, `session_crons` and `background_tasks`
@@ -1905,6 +1905,7 @@ def run_stop(event, event_ok, worklist, hook_file):
     # fire, so the check-in costs one focused block per window, never a
     # drumbeat.
     bg_facts, bgwait_due, bgwait_prev, bgwait_next = [], False, "", ""
+    _bg_actionable = []
     bg_verdicts = {}
     _in_pure_wait = False
     # v18: A CONFIRMED INBOX WAITER IS A PUSH CHANNEL, NOT A JOB TO SUPERVISE.
@@ -1939,6 +1940,14 @@ def run_stop(event, event_ok, worklist, hook_file):
         )
         if not _expired_any:
             _in_pure_wait = True
+            # v19: the wait is only PURE if the harness queue is also empty of
+            # work this session could do right now. A pending task with no
+            # unresolved blocker makes the check-in fire (even for a
+            # waiter-only roster) and name it, instead of certifying the wait.
+            try:
+                _bg_actionable = C.actionable_tasks(session_id, event.get("transcript_path"))
+            except Exception:  # noqa: BLE001 -- a fact-gatherer must never wedge a stop
+                _bg_actionable = []
             try:
                 bg_facts = wl_liveness.bg_output_facts(event.get("cwd"), session_id, live_bg)
             except Exception:  # noqa: BLE001 -- a fact-gatherer must never wedge a stop
@@ -1972,7 +1981,7 @@ def run_stop(event, event_ok, worklist, hook_file):
                 # through the back door.
                 _bgw["at"] = C.stamp_now()
                 state_doc["bgwait"] = _bgw
-                if not _only_waiters:
+                if not _only_waiters or _bg_actionable:
                     bgwait_due = True
             bgwait_next = C.stamp_ahead(wl_liveness.BG_REPORT_MIN)
     if not _in_pure_wait:
@@ -2169,18 +2178,34 @@ def run_stop(event, event_ok, worklist, hook_file):
                     me8,
                 )
             )
-        vadd(
-            "bg-report",
-            True,
-            M.V_BG_REPORT
-            % (
-                bgwait_prev or "never (this is the first one of this wait)",
-                bgwait_next,
-                wl_liveness.BG_REPORT_MIN,
-                len(live_bg),
-                "\n".join(_rows),
-            ),
-        )
+        if _bg_actionable:
+            vadd(
+                "bg-report",
+                True,
+                M.V_BG_REPORT_TASKS
+                % (
+                    bgwait_prev or "never (this is the first one of this wait)",
+                    bgwait_next,
+                    wl_liveness.BG_REPORT_MIN,
+                    len(live_bg),
+                    len(_bg_actionable),
+                    "\n".join("    task #%s %s" % a for a in _bg_actionable),
+                    "\n".join(_rows),
+                ),
+            )
+        else:
+            vadd(
+                "bg-report",
+                True,
+                M.V_BG_REPORT
+                % (
+                    bgwait_prev or "never (this is the first one of this wait)",
+                    bgwait_next,
+                    wl_liveness.BG_REPORT_MIN,
+                    len(live_bg),
+                    "\n".join(_rows),
+                ),
+            )
     if stuck_fired and something_remains:
         # TIER-ACCURATE HEADLINE. This used to assert "not one task changed
         # status AND HEAD did not advance" for every tier, which is FALSE for
@@ -2348,7 +2373,10 @@ def run_stop(event, event_ok, worklist, hook_file):
         try:
             held = {t.split()[0].lstrip("#") for t in ev_tasks}
             prev_ts = reg_state.get("task_status") or {}
-            new_ts = {i: st for i, (st, _s) in C.task_statuses(session_id).items()}
+            new_ts = {
+                i: st
+                for i, (st, _s) in C.task_statuses(session_id, event.get("transcript_path")).items()
+            }
             for i in held:
                 if i in prev_ts:
                     new_ts[i] = prev_ts[i]

--- a/.claude/hooks/stop/wl_checks.py
+++ b/.claude/hooks/stop/wl_checks.py
@@ -932,7 +932,12 @@ def poll_fast_path(worklist, session_id, event):
     # signature is now derived from this session's items rather than from the
     # shared files' bytes; passing it here keeps the store parsed once.
     fold = S.load(worklist, sync=False)
-    if S.world_sig(root, worklist, session_id, fold=fold) != base_sig:
+    if (
+        S.world_sig(
+            root, worklist, session_id, fold=fold, transcript_path=event.get("transcript_path")
+        )
+        != base_sig
+    ):
         return False  # tracked work happened since the last full stop
     crons = event.get("session_crons") or []
     if len([c for c in crons if is_poll_cron(c)]) != 1:
@@ -1856,11 +1861,15 @@ def run_stop(event, event_ok, worklist, hook_file):
     # The world signature is computed ONCE, after every shared-state write of
     # this stop (sync, cleanup, escalation), and reused by the STATE.md check,
     # the poll baseline and the judge cache, so all three describe one world.
-    cur_sig = S.world_sig(root, worklist, session_id, fold=fold)
+    cur_sig = S.world_sig(
+        root, worklist, session_id, fold=fold, transcript_path=event.get("transcript_path")
+    )
     # v14 gap 5: STATE.md staleness keys on STRUCTURE, not bytes, so a
     # session's own bookkeeping (lease renewals, update notes) does not stale
     # the document it just refreshed. Polls and the judge keep cur_sig.
-    st_sig = S.state_world_sig(root, worklist, session_id, fold=fold)
+    st_sig = S.state_world_sig(
+        root, worklist, session_id, fold=fold, transcript_path=event.get("transcript_path")
+    )
     agent_branch = C.git_branch(root)
     astate, aage, _atext = S.agent_state_state(
         root, agent_branch, cur_sig=st_sig, saved_sig=state_doc.get("state_sig")

--- a/.claude/hooks/stop/wl_core.py
+++ b/.claude/hooks/stop/wl_core.py
@@ -556,7 +556,78 @@ def tasks_dir(session_id):
     return os.path.join(home, "session-" + session_id[:8])
 
 
-def pending_tasks(session_id):
+# v19: THE TASK DIR IS NOT ALWAYS NAMED AFTER THE STOP EVENT'S SESSION ID.
+# On 2026-08-08 a session's tasks lived under session-6e7fb45f (the harness
+# team id) while every Stop event said session_id=d136ac61, so pending_tasks
+# read a directory that did not exist and returned [] for the whole session --
+# the exact "two queues, one supervisor, watching the empty one" failure the
+# v5 docstring below describes, reintroduced one naming scheme later, and
+# INVISIBLE because "missing dir = no evidence" is also the function's
+# legitimate no-manufactured-blocks safety.
+#
+# The join that survives the rename: the session TRANSCRIPT (whose path the
+# Stop event does carry) contains every TaskCreate result verbatim --
+# "Task #<id> created successfully: <subject>" -- and a directory holding a
+# task with that exact id whose subject matches is this session's directory.
+# Content-based, deterministic, and refuses on ambiguity (0 or 2+ matching
+# dirs resolve to None, which downstream treats as "no evidence", never a
+# manufactured block). Cached per process so the fallback's directory scan
+# runs at most once per hook invocation.
+_TASKS_DIR_CACHE = {}
+_TASK_CREATED_RE = re.compile(r"Task #(\d+) created successfully: ([^\"\\\n]{10,})")
+
+
+def _resolve_tasks_dir(session_id, transcript_path=None):
+    if not session_id:
+        return None
+    key = session_id[:8]
+    if key in _TASKS_DIR_CACHE:
+        return _TASKS_DIR_CACHE[key]
+    d = tasks_dir(session_id)
+    # An EMPTY primary dir is "no evidence", not an answer: the live failure
+    # had a zero-file session-d136ac61 relic (created 2026-07-23, before the
+    # harness renamed its task store) shadowing the real session-6e7fb45f.
+    # Only a primary dir that actually holds a task settles the question.
+    if os.path.isdir(d) and glob.glob(os.path.join(d, "*.json")):
+        _TASKS_DIR_CACHE[key] = d
+        return d
+    resolved = None
+    if transcript_path and os.path.isfile(transcript_path):
+        try:
+            with open(transcript_path, "rb") as fh:
+                fh.seek(0, os.SEEK_END)
+                size = fh.tell()
+                fh.seek(max(0, size - TRANSCRIPT_TAIL_BYTES))
+                tail = fh.read().decode("utf-8", "replace")
+            # Newest creations first: the last one is the least likely to have
+            # been deleted since. Subjects are read out of JSONL, so cut each
+            # at the first escape sequence and prefix-match on what is left.
+            matches = _TASK_CREATED_RE.findall(tail)[-5:][::-1]
+            cands = set()
+            for tid, raw_subj in matches:
+                subj = raw_subj.strip()
+                for sd in glob.glob(os.path.join(os.path.dirname(d), "session-*")):
+                    f = os.path.join(sd, tid + ".json")
+                    if not os.path.isfile(f):
+                        continue
+                    try:
+                        with open(f, encoding="utf-8") as fh:
+                            t = json.load(fh)
+                    except (OSError, ValueError):
+                        continue
+                    if str(t.get("subject", "")).strip().startswith(subj):
+                        cands.add(sd)
+                if cands:
+                    break  # the newest resolvable creation decides
+            if len(cands) == 1:
+                resolved = cands.pop()
+        except OSError:
+            resolved = None
+    _TASKS_DIR_CACHE[key] = resolved
+    return resolved
+
+
+def pending_tasks(session_id, transcript_path=None):
     """Harness Task-list items that are not done, as [(id, subject, status)].
 
     THE POINT OF v5. The hook used to see only the markdown worklist, and a
@@ -568,7 +639,7 @@ def pending_tasks(session_id):
     """
     if not session_id:
         return []
-    d = tasks_dir(session_id)
+    d = _resolve_tasks_dir(session_id, transcript_path) or tasks_dir(session_id)
     out = []
     try:
         for f in sorted(glob.glob(os.path.join(d, "*.json"))):
@@ -585,13 +656,56 @@ def pending_tasks(session_id):
     return out
 
 
-def task_statuses(session_id):
+def actionable_tasks(session_id, transcript_path=None):
+    """Pending harness tasks whose every recorded blocker is finished, as
+    [(id, subject)] -- the tasks a waiting session could be working RIGHT NOW.
+
+    v19, operator directive 2026-08-08: a session sat in "pure background
+    wait" for hours while a fully-planned task was pending and unblocked; the
+    check-in kept saying "this is not a demand for other work" because the
+    pure-wait state never consulted the harness queue. A pending task with an
+    unresolved `blockedBy` is legitimately parked; one without is not.
+    A blocker id whose file no longer exists counts as resolved (deleted
+    tasks vanish from the dir). Never raises."""
+    if not session_id:
+        return []
+    d = _resolve_tasks_dir(session_id, transcript_path)
+    if not d:
+        return []
+    all_t = {}
+    try:
+        for f in glob.glob(os.path.join(d, "*.json")):
+            try:
+                with open(f, encoding="utf-8") as fh:
+                    t = json.load(fh)
+            except (OSError, ValueError):
+                continue
+            if t.get("id") is not None:
+                all_t[str(t["id"])] = t
+    except OSError:
+        return []
+    out = []
+    for tid, t in all_t.items():
+        if t.get("status") != "pending":
+            continue
+        unresolved = [
+            b
+            for b in (t.get("blockedBy") or [])
+            if str(b) in all_t and all_t[str(b)].get("status") != "completed"
+        ]
+        if not unresolved:
+            out.append((tid, str(t.get("subject", ""))[:70]))
+    out.sort(key=lambda x: int(x[0]) if x[0].isdigit() else 1 << 30)
+    return out
+
+
+def task_statuses(session_id, transcript_path=None):
     """{id: (status, subject)} for ALL harness tasks, completed included.
     pending_tasks() serves the queue; this serves the completion-evidence
     check and the liveness ladder, which need TRANSITIONS, not the queue."""
     if not session_id:
         return {}
-    d = tasks_dir(session_id)
+    d = _resolve_tasks_dir(session_id, transcript_path) or tasks_dir(session_id)
     out = {}
     try:
         for f in glob.glob(os.path.join(d, "*.json")):

--- a/.claude/hooks/stop/wl_core.py
+++ b/.claude/hooks/stop/wl_core.py
@@ -577,6 +577,16 @@ _TASKS_DIR_CACHE = {}
 _TASK_CREATED_RE = re.compile(r"Task #(\d+) created successfully: ([^\"\\\n]{10,})")
 
 
+def _taskdir_cache_file(key):
+    # Same /tmp family the hook already uses. Persisting the resolution is what
+    # lets TRANSCRIPT-LESS processes (the --state CLI verb at worklist.py:884,
+    # any other verb) agree with the stop battery: without it, world_sig written
+    # by the CLI and world_sig checked by the hook would hash DIFFERENT task
+    # sets whenever the primary dir is empty, and STATE.md would look eternally
+    # stale. Found by review on #559 (the sweep finding).
+    return os.path.join(tempfile.gettempdir(), "claude-worklist", "taskdir." + key)
+
+
 def _resolve_tasks_dir(session_id, transcript_path=None):
     if not session_id:
         return None
@@ -591,6 +601,19 @@ def _resolve_tasks_dir(session_id, transcript_path=None):
     if os.path.isdir(d) and glob.glob(os.path.join(d, "*.json")):
         _TASKS_DIR_CACHE[key] = d
         return d
+    # Durable cache next: a previous process (with a transcript) may have
+    # resolved this already. Validated before trust -- the dir must still exist
+    # and still hold a task; a stale pointer is discarded, never followed.
+    try:
+        cf = _taskdir_cache_file(key)
+        if os.path.isfile(cf):
+            with open(cf, encoding="utf-8") as fh:
+                cached = fh.read().strip()
+            if cached and os.path.isdir(cached) and glob.glob(os.path.join(cached, "*.json")):
+                _TASKS_DIR_CACHE[key] = cached
+                return cached
+    except OSError:
+        pass
     resolved = None
     if transcript_path and os.path.isfile(transcript_path):
         try:
@@ -623,6 +646,17 @@ def _resolve_tasks_dir(session_id, transcript_path=None):
                 resolved = cands.pop()
         except OSError:
             resolved = None
+    if resolved:
+        # Persist for transcript-less processes (tmp+rename; best-effort).
+        try:
+            cf = _taskdir_cache_file(key)
+            os.makedirs(os.path.dirname(cf), exist_ok=True)
+            tmp = cf + ".tmp." + str(os.getpid())
+            with open(tmp, "w", encoding="utf-8") as fh:
+                fh.write(resolved)
+            os.replace(tmp, cf)
+        except OSError:
+            pass
     _TASKS_DIR_CACHE[key] = resolved
     return resolved
 

--- a/.claude/hooks/stop/wl_liveness.py
+++ b/.claude/hooks/stop/wl_liveness.py
@@ -533,7 +533,9 @@ def ladder(fold, session_id, event, state_doc):
                 wid,
             )
         )
-    for tid, (status, subject) in sorted(C.task_statuses(event.get("session_id", "")).items()):
+    for tid, (status, subject) in sorted(
+        C.task_statuses(event.get("session_id", ""), event.get("transcript_path")).items()
+    ):
         prev = tasks_seen.get(tid)
         if prev is None or prev.get("status") != status:
             tasks_seen[tid] = {"status": status, "since": C.stamp_now()}

--- a/.claude/hooks/stop/wl_store.py
+++ b/.claude/hooks/stop/wl_store.py
@@ -1253,7 +1253,7 @@ def agent_state_state(root, branch, cur_sig=None, saved_sig=None):
 # ---- world signature --------------------------------------------------------
 
 
-def world_sig(root, worklist, session_id, fold=None):
+def world_sig(root, worklist, session_id, fold=None, transcript_path=None):
     """THIS SESSION's world: task statuses + HEAD + the structure of the items
     it owns + the requests that involve it. Keyed by the poll fast path (has
     anything moved since the last full stop?) and by the judge verdict cache.
@@ -1283,7 +1283,7 @@ def world_sig(root, worklist, session_id, fold=None):
     An UNOWNED item counts as this session's (C.owned_by_me), matching the
     rule that an untagged item is yours: such an item blocks this session, so
     it must move the signature."""
-    ts = C.task_statuses(session_id)
+    ts = C.task_statuses(session_id, transcript_path)
     try:
         f = fold if fold is not None else load(worklist, sync=False)
         items = "|".join(
@@ -1356,7 +1356,7 @@ def my_requests_sig(worklist, session_id):
     return hashlib.sha1(blob.encode("utf-8", "replace")).hexdigest()[:16]
 
 
-def state_world_sig(root, worklist, session_id, fold=None):
+def state_world_sig(root, worklist, session_id, fold=None, transcript_path=None):
     """The STATE.md staleness key (v14 gap 5): task statuses + HEAD + item
     STRUCTURE (id, state, owner, basetext), deliberately NOT the raw byte
     digests world_sig used to take. Under the byte key every self-inflicted
@@ -1371,7 +1371,7 @@ def state_world_sig(root, worklist, session_id, fold=None):
     session's item landing on the branch is a reason to rewrite the recovery
     document, while world_sig covers only this session's own, because another
     session's bookkeeping is not a reason to pay a full stop battery."""
-    ts = C.task_statuses(session_id)
+    ts = C.task_statuses(session_id, transcript_path)
     try:
         f = fold if fold is not None else load(worklist, sync=False)
         items = "|".join(

--- a/.claude/hooks/stop/worklist_messages.py
+++ b/.claude/hooks/stop/worklist_messages.py
@@ -831,6 +831,22 @@ V_BG_REPORT = (
     "itself and the hook asks you to slow the poll cron instead."
 )
 
+V_BG_REPORT_TASKS = (
+    "BACKGROUND WAIT WITH WORKABLE TASKS. Last check-in: %s. Next no earlier "
+    "than %s (a %d-minute latch). %d background job(s) are running, but this "
+    "wait is NOT pure: %d pending task(s) on the harness list have no "
+    "unresolved blocker, and a CI wait is exactly when local work fits. "
+    "Either START one now (TaskUpdate it to in_progress and begin), or record "
+    "its real blocker with TaskUpdate addBlockedBy so this check stops naming "
+    "it -- an unblocked pending task is a claim that nothing stops you. "
+    "The workable tasks:\n%s\n"
+    "The hook's own read of each worker's output stream:\n%s\n"
+    "    Confirm each worker in one line, then act on a task in the SAME "
+    "turn. Do not reply with only a status report: the operator ordered this "
+    "check to exist because a session once idled for hours beside a fully "
+    "planned, unblocked task (2026-08-08)."
+)
+
 N_EMAIL_SKIPPED = (
     "WARNING: the operator email channel is SKIPPED (mail is optional and its "
     "last send with the current credentials failed: %s question(s) wait in the "

--- a/docs/agent/ci-gates.md
+++ b/docs/agent/ci-gates.md
@@ -12,6 +12,8 @@ describes actually happens. Keep the pointer line in CLAUDE.md in sync. -->
 
 The gate set lives in `scripts/ci-runner/manifest.ts`, which is also the input to `npm run check:ci-parity`. Every individual `check:*` npm key still exists and still works on its own; the manifest schedules them.
 
+The CI-side quality-gate battery (`.ci/scripts/test/run-all.sh`, the "Quality-gate unit tests" step) is ALSO parallel since 2026-08-08, with a W/S/T schedule: two tests write fixtures into the real tree, so they run as a serial chain while temp-isolated tests pool, and the real-tree scanners are held back until the writers finish. Triage notes: `RUN_ALL_JOBS=1 .ci/scripts/test/run-all.sh` reproduces the exact serial behavior through the same code path; a "no result recorded" failure means the scheduler lost a test, which is a runner bug, never a skip; and a failure that appears parallel-only but not under `RUN_ALL_JOBS=1` is a real isolation leak in that test, not battery flakiness -- see the W/S/T header in run-all.sh before touching the schedule.
+
 | Command | What it does |
 |---|---|
 | `npm run ci` | Full run at `availableParallelism() - 2` workers, keep-going |

--- a/docs/ci-overhaul/06-progress.md
+++ b/docs/ci-overhaul/06-progress.md
@@ -3054,3 +3054,42 @@ required entry deleted and asserts red. The trace gate paid for itself before it
 ever ran in CI: on its first run against the real table it found the live
 `renet` closure missing `.github/actions/app-token`, an edit to which would not
 have withdrawn a renet greenlight.
+
+### Quality-gate unit tests: parallelized inside the step (W/S/T)
+
+The battery ran its 87 tests serially behind one `run-all.sh` loop, costing about
+18 minutes of the Security job's 20-minute budget. The step was one slow test
+away from a timeout, not one slow test away from a slow run.
+
+A flat worker pool is unsafe here, and the reason is specific. Two tests write
+into the real tree because the code they exercise hardcodes it: test-gate-paths-exist.sh
+plants fixtures in .ci/scripts, test-gate-anti-vacuity.sh plants one in scripts/.
+About nineteen others recursively enumerate those same directories. A file that
+appears or vanishes mid-enumeration is a hard error under set -euo pipefail, which
+passes on the next serial re-run. That is the flake shape observed locally, and
+lowering the worker count makes it rarer rather than absent.
+
+So the runner schedules three sets instead of pooling flat. W is the two writers,
+run as one serial chain from t=0. T is the 68 temp-isolated tests, filling the
+remaining slots while W runs. S is the 19 real-tree readers, released only once the
+W chain has published its done-marker. Workers never print; each writes a log and
+atomically publishes an exit code, and main prints the blocks in ascending glob
+order, so the transcript is the serial transcript.
+
+Measured on the 20-core dev box over the whole battery: 956s serial versus 304s
+parallel, 3.14x, identical failure sets and identical assertion totals (87 passed,
+955 assertions, both). CI runs 4 workers rather than 8.
+
+test-run-all-parallel.sh pins four properties, each with its own control: the pool
+overlaps (with a jobs=1 run that must be slow, so the stopwatch can fail); jobs=1
+and jobs=4 agree byte for byte; output blocks never interleave under --verbose;
+and the W/S hold-back holds, proven by a sentinel writer plus a scanner that reds
+on contact, with a flat-pool control that must collide. A missing result counts as
+a failure, never a skip, so a scheduling bug shows up as red rather than as a
+shorter green run.
+
+The wave also fixed two strays it walked past: log_info and log_error were called
+by test-shell-counter-increment.sh but never defined anywhere (silent only because
+that file runs without -e; its finding report would have printed "command not
+found" instead of the finding), and the Stop hook's task-queue blindness described
+in the session records rode the same branch.

--- a/scripts/ci-runner/manifest.ts
+++ b/scripts/ci-runner/manifest.ts
@@ -271,6 +271,9 @@ export const GATES: readonly GateSpec[] = [
   // flattening would recreate #549 fifty-seven times over.
   //
   // ISOLATION IS A HYPOTHESIS, NOT A GIVEN. test-claude-hooks.sh failed once
+// Since 2026-08-08 run-all.sh enforces this in-step: the two writers run as
+// an exclusive serial chain and the real-tree scanners are held until it
+// finishes. See its header.
   // inside the SERIAL battery and could not be reproduced standalone (plan
   // finding F8). Any red that appears only under parallelism gets a named mutex
   // group, never a retry.
@@ -411,6 +414,7 @@ export const GATES: readonly GateSpec[] = [
   { id: 'gate-test:renet-deadcode', run: '.ci/scripts/test/gates/test-renet-deadcode.sh', gate: true, qualityGateTest: true, leaves: ['.ci/scripts/test/gates/test-renet-deadcode.sh'], ci: { kind: 'step', workflow: '.github/workflows/ci-quality.yml', job: 'quality-security', step: 'Quality-gate unit tests' } },
   { id: 'gate-test:review-labels', run: '.ci/scripts/test/gates/test-review-labels.sh', gate: true, qualityGateTest: true, leaves: ['.ci/scripts/test/gates/test-review-labels.sh'], ci: { kind: 'step', workflow: '.github/workflows/ci-quality.yml', job: 'quality-security', step: 'Quality-gate unit tests' } },
   { id: 'gate-test:review-status', run: '.ci/scripts/test/gates/test-review-status.sh', gate: true, qualityGateTest: true, leaves: ['.ci/scripts/test/gates/test-review-status.sh'], ci: { kind: 'step', workflow: '.github/workflows/ci-quality.yml', job: 'quality-security', step: 'Quality-gate unit tests' } },
+  { id: 'gate-test:run-all-parallel', run: '.ci/scripts/test/gates/test-run-all-parallel.sh', gate: true, qualityGateTest: true, leaves: ['.ci/scripts/test/gates/test-run-all-parallel.sh'], ci: { kind: 'step', workflow: '.github/workflows/ci-quality.yml', job: 'quality-security', step: 'Quality-gate unit tests' } },
   { id: 'gate-test:schema-coverage', run: '.ci/scripts/test/gates/test-schema-coverage.sh', gate: true, qualityGateTest: true, leaves: ['.ci/scripts/test/gates/test-schema-coverage.sh'], ci: { kind: 'step', workflow: '.github/workflows/ci-quality.yml', job: 'quality-security', step: 'Quality-gate unit tests' } },
   { id: 'gate-test:scope-baseline-attest', run: '.ci/scripts/test/gates/test-scope-baseline-attest.sh', gate: true, qualityGateTest: true, leaves: ['.ci/scripts/test/gates/test-scope-baseline-attest.sh'], ci: { kind: 'step', workflow: '.github/workflows/ci-quality.yml', job: 'quality-security', step: 'Quality-gate unit tests' } },
   { id: 'gate-test:scope-engine', run: '.ci/scripts/test/gates/test-scope-engine.sh', gate: true, qualityGateTest: true, leaves: ['.ci/scripts/test/gates/test-scope-engine.sh'], ci: { kind: 'step', workflow: '.github/workflows/ci-quality.yml', job: 'quality-security', step: 'Quality-gate unit tests' } },

--- a/scripts/ci-runner/manifest.ts
+++ b/scripts/ci-runner/manifest.ts
@@ -271,9 +271,9 @@ export const GATES: readonly GateSpec[] = [
   // flattening would recreate #549 fifty-seven times over.
   //
   // ISOLATION IS A HYPOTHESIS, NOT A GIVEN. test-claude-hooks.sh failed once
-// Since 2026-08-08 run-all.sh enforces this in-step: the two writers run as
-// an exclusive serial chain and the real-tree scanners are held until it
-// finishes. See its header.
+  // Since 2026-08-08 run-all.sh enforces this in-step: the two writers run as
+  // an exclusive serial chain and the real-tree scanners are held until it
+  // finishes. See its header.
   // inside the SERIAL battery and could not be reproduced standalone (plan
   // finding F8). Any red that appears only under parallelism gets a named mutex
   // group, never a retry.


### PR DESCRIPTION
## What

Two proven workstreams from today's operator directives:

### 1. The Stop hook could not see the harness task queue (two stacked bugs)

Found when the operator asked why the hook never pinged about a fully planned,
unblocked pending task during an hours-long background wait:

- **The task store moved** to `session-<team-id>` while Stop events carry the
  conversation id, so `pending_tasks()` read a nonexistent directory and returned
  `[]` all session -- the exact "two queues, one supervisor, watching the empty
  one" failure its own v5 docstring describes, reintroduced one naming scheme
  later. Fix: a transcript-content join (TaskCreate result lines carry id +
  subject; the unique directory holding that task is this session's), refusing on
  ambiguity. An EMPTY primary dir defers to the join -- the live proof found a
  zero-file July relic shadowing the real store.
- **Pure-background-wait never consulted the queue** even when visible. Now an
  unblocked pending task makes the wait impure: the check-in fires as WORKABLE
  TASKS and names it; the honest silencer is a recorded blocker.

Proof: 7 unit cases, live resolve of the real store, and the check FIRING IN
PRODUCTION on its first eligible stop, naming the exact task that motivated it.
Harness 589/0 (new case pair 163y: fire + blocked-control).

### 2. Quality-gate battery: 18 min serial -> ~5 min, inside the same step

87 tests ran serially, 18 of the Security job's 20 budget minutes. A flat pool is
unsafe for a specific reason: two tests write fixtures INTO THE REAL TREE while
~19 others recursively enumerate those directories (the observed flake shape).
W/S/T schedule instead: writers as one serial chain, temp-isolated tests fill
slots, real-tree readers released on the writers' done-marker. Workers never
print; main prints blocks in glob order, so the transcript is the serial
transcript. Missing result = FAILURE, never a skip.

Measured, same code both ways: **956s serial vs 304s parallel (3.14x)**,
identical failure sets and assertion totals. `gate-test:run-all-parallel` pins
overlap (with a must-be-slow serial control), byte-for-byte jobs=1/jobs=4
agreement, non-interleaving, and the W/S hold-back -- mutation-proven at TWO
seams (wait loop deleted; done-marker falsified), both RED.

Rider: `log_info`/`log_error` were called by a gate test but defined nowhere,
silent only because that file runs without `-e`. Defined centrally. Plus triage
notes in docs/agent/ci-gates.md for future battery-failure debugging.

## Provenance

Replaces #558 (branch cut from pre-rebase SHAs went CONFLICTING after the
v1.2.21 release commits; force-push is hook-blocked, so the same three commits
were cherry-picked onto post-release main). First PR through the fully-live
auto-labels path; second live acceptance of 18-key greenlight (diff touches no
closure input -- the VM battery should skip against the 75c4de9af evidence run).

<!-- pushed-head:begin -->
**Last pushed:** `a9b438b5a`

- `a9b438b5a` fix(hooks,review): answer the #559 review; sweep the task-dir fix, commit its coverage, and fix the label applier's first live defect
- `75c4cb155` docs(agent): triage notes for the parallel quality-gate battery
- `05fe8d5fb` perf(ci): parallelize the quality-gate battery inside its step (W/S/T)
- `998bb7b91` fix(hooks): the Stop hook could not see the harness task queue, twice over
- `b8e332b73` chore(release-state): advance contract floor to v1.2.2 [skip ci]
<!-- pushed-head:end -->
