### PR TITLE
feat(ci): wire the profiler fleet-wide; nightly channel guard, fixture race, autopilot fixes

### DIFF
--- a/.ci/scripts/quality/check-profiler-coverage.sh
+++ b/.ci/scripts/quality/check-profiler-coverage.sh
@@ -29,12 +29,21 @@
 # reason, because the alternative is a silent hole shaped exactly like the ones
 # this repo keeps finding.
 #
-# COVERAGE IS DIRECT, DELIBERATELY. A job is covered when its own steps use the
-# action. Whether a JavaScript action's `post:` hook still fires when the action
-# is nested inside a composite is the open question profiler-probe.yml exists to
-# answer; until it answers yes, counting a wrapping composite as coverage would
-# be a fail-open. When it does answer yes, add the wrapping composite to
-# COVERING_ACTIONS below (one line) and the whole rollout collapses to one edit.
+# COVERAGE IS DIRECT OR THROUGH A VERIFIED WRAPPER. A job is covered when its
+# own steps use the action, or when they use a composite that carries it.
+# Whether a JavaScript action's `post:` hook still fires when the action is
+# nested inside a composite was the open question profiler-probe.yml existed to
+# answer, and on 2026-08-08 it answered YES on real runners (run 31252148469:
+# the panel appeared on ubuntu-slim and on ubuntu-latest through a composite
+# wrapper). So ./.github/actions/setup-workspace is a wrapper from here on, and
+# the ~26 jobs that already call it are covered without an edit each.
+#
+# A WRAPPER IS VERIFIED, NOT TRUSTED. Coverage for those jobs now hangs on one
+# `uses:` line inside somebody else's file, and deleting that line would leave
+# 26 jobs reporting as profiled while profiling nothing -- a fail-open of
+# exactly the shape this gate exists to prevent. So each wrapper's own
+# action.yml must be shown to reference the profiler before it counts, and a
+# wrapper that stops doing so REFUSES rather than quietly covering nothing.
 #
 # ANTI-VACUITY. Every extractor self-tests against a planted sample before the
 # sweep, and the sweep refuses on zero workflows, zero jobs, zero declared
@@ -46,6 +55,8 @@
 #   PROFILER_COVERAGE_WORKFLOW_DIR   directory of workflow YAML to scan
 #   PROFILER_COVERAGE_ALLOWLIST      allowlist path
 #   PROFILER_COVERAGE_ACTION_DIR     directory holding the profiler action.yml
+#   PROFILER_COVERAGE_WRAPPER_DIRS   composite dirs that carry the profiler
+#                                    (each is verified; empty means none)
 #   PROFILER_COVERAGE_COVERING_ACTIONS  extra `uses:` refs that count as coverage
 #   PROFILER_COVERAGE_MIN_WORKFLOWS  floor on workflow files parsed
 #   PROFILER_COVERAGE_MIN_JOBS       floor on jobs parsed
@@ -71,14 +82,20 @@ WORKFLOW_DIR="${PROFILER_COVERAGE_WORKFLOW_DIR:-.github/workflows}"
 ALLOWLIST="${PROFILER_COVERAGE_ALLOWLIST:-.profiler-coverage-allowlist}"
 ACTION_DIR="${PROFILER_COVERAGE_ACTION_DIR:-.github/actions/profiler}"
 
-# Extra `uses:` strings that count as coverage beyond the profiler itself.
-# EMPTY, and it stays empty until profiler-probe.yml proves a nested `post:`
-# hook fires: counting a wrapper before then would be a fail-open. When it does,
-# change the default below to the wrapping composite (e.g.
-# ./.github/actions/setup-workspace) and every job that already calls it becomes
-# covered in one line. Space-separated; the env name is also the test seam that
-# proves this path works rather than leaving it dead until the day it is needed.
-read -r -a COVERING_ACTIONS <<<"${PROFILER_COVERAGE_COVERING_ACTIONS:-}"
+# Composite actions that carry the profiler on behalf of every job calling them.
+# Space-separated DIRECTORIES (not `uses:` refs): each one's action.yml is read
+# below and must be shown to reference the profiler before the wrapper counts,
+# which is what keeps this from being a one-line fail-open for ~26 jobs.
+# `${VAR-default}` rather than `${VAR:-default}` on purpose: a test that sets it
+# to the empty string means "no wrappers at all", which is the control for the
+# wrapper path.
+read -r -a WRAPPER_DIRS <<<"${PROFILER_COVERAGE_WRAPPER_DIRS-.github/actions/setup-workspace}"
+
+# Extra `uses:` strings that count as coverage, taken on trust and NOT verified.
+# Empty by default. This is the extension seam for a wrapper that lives outside
+# this repo's action tree, and it is also what test-profiler-coverage.sh drives
+# to prove the wrapper path is live code rather than a comment.
+read -r -a EXTRA_COVERING_ACTIONS <<<"${PROFILER_COVERAGE_COVERING_ACTIONS:-}"
 
 # Floors. The tree carries 28 workflows / 121 jobs / 97 Linux jobs; anything
 # far under these numbers means the parse found a layout it does not
@@ -358,6 +375,31 @@ if [ "$DECLARED_COUNT" -lt 1 ]; then
     log_error "parsed ZERO inputs from $ACTION_YML; the action declares some, so the parser is broken"
     exit 1
 fi
+
+# ---------------------------------------------------------------------------
+# The wrapper contract. A composite counts as coverage only once it is SHOWN to
+# reference the profiler, using the same matcher the job sweep uses, so the day
+# somebody edits that line out this gate goes red instead of certifying ~26 jobs
+# as profiled.
+# ---------------------------------------------------------------------------
+COVERING_ACTIONS=()
+for wdir in ${WRAPPER_DIRS[@]+"${WRAPPER_DIRS[@]}"}; do
+    [ -n "$wdir" ] || continue
+    wdir="${wdir#./}"
+    wyml="$wdir/action.yml"
+    if [ ! -f "$wyml" ]; then
+        log_error "covering wrapper '$wdir' has no action.yml at $wyml"
+        log_error "Every job counted as covered through this wrapper would be counted off a file that does not exist. Fix the path, do not drop the check."
+        exit 1
+    fi
+    if [ "$(covering_uses "$wyml" "$ACTION_REF")" -lt 1 ]; then
+        log_error "covering wrapper '$wdir' does not use $ACTION_REF"
+        log_error "It is treated as coverage for every job that calls it, so without that step those jobs are unprofiled while reporting as profiled -- the exact fail-open this gate exists to prevent."
+        exit 1
+    fi
+    COVERING_ACTIONS+=("./$wdir")
+done
+COVERING_ACTIONS+=(${EXTRA_COVERING_ACTIONS[@]+"${EXTRA_COVERING_ACTIONS[@]}"})
 
 # ---------------------------------------------------------------------------
 # The allowlist

--- a/.ci/scripts/test/gates/test-gate-paths-exist.sh
+++ b/.ci/scripts/test/gates/test-gate-paths-exist.sh
@@ -70,6 +70,34 @@ source "$SCRIPT_DIR/../lib/test-helpers.sh"
 # excludes on purpose.
 FIXTURE_DIR="$REPO_ROOT/.ci/scripts"
 
+# The fixture filenames carry THIS PROCESS's pid, and that is a correctness fix
+# rather than tidiness. They used to be fixed names, so two concurrent
+# invocations -- two sessions each running the battery, which nothing prevents
+# -- planted the same two paths and each `trap rm -f` deleted the OTHER run's
+# fixture. On 2026-08-05 that surfaced as a false "detector broken": the
+# control's collect_dead_paths came back empty because its fixture had already
+# been removed by a neighbour. run-all.sh's W chain serialises this test WITHIN
+# one battery and cannot serialise across independent processes.
+#
+# The dotfile prefix is load-bearing (it is what keeps eslint, biome and knip
+# off these files) and the `.ts` suffix is what scan_targets() globs for, so the
+# pid goes between them. FIXTURE_NAME_PREFIX is the shape both fixtures share
+# ACROSS pids: a concurrent run's fixtures are still visible to this one's scan,
+# so the assertions below scope themselves with it rather than assuming they are
+# alone in the tree.
+FIXTURE_PID_SUFFIX="$$"
+FIXTURE_NAME_PREFIX='.gate-paths-exist-'
+
+# Belt to the per-test RETURN traps' braces. A RETURN trap does not fire when
+# the shell is killed or interrupted, and this test runs for ~3 minutes, which
+# is long enough for a Ctrl-C or a `pkill` to be routine. With fixed filenames
+# an orphan was invisible (the next run overwrote it); pid-named ones ACCUMULATE
+# in a tracked directory instead, so they get cleaned here too. Scoped to this
+# pid: a concurrent run's fixtures are not ours to delete, which is the whole
+# point of the suffix.
+# BLOCKER: pid-scoped so a concurrent invocation's fixtures survive; a wildcard here would recreate the cross-process deletion this suffix exists to fix
+trap 'rm -f "$FIXTURE_DIR/${FIXTURE_NAME_PREFIX}fixture.$FIXTURE_PID_SUFFIX.ts" "$FIXTURE_DIR/${FIXTURE_NAME_PREFIX}noise-fixture.$FIXTURE_PID_SUFFIX.ts"' EXIT INT TERM
+
 # Directory prefixes that are generated, vendored, or gitignored. A literal
 # whose path traverses one of these is skipped in Tier B.
 EPHEMERAL_SEGMENTS='/(dist|build|bin|out|coverage|node_modules|\.astro|\.backups|\.cache)(/|$)'
@@ -215,8 +243,16 @@ assert_scan_is_whole() {
 
 test_no_dead_path_constants() {
     assert_scan_is_whole
-    local dead
-    dead="$(collect_dead_paths)"
+    local all dead
+    # Two steps, not a pipeline: collect_dead_paths keeps its own failure under
+    # set -e, which a trailing `|| true` on the same pipeline would swallow.
+    #
+    # A CONCURRENT invocation of this same test plants its own control fixture,
+    # which is a deliberate dead path and would read here as a real finding.
+    # Filtering by the fixture filename shape is precise: nothing but this test
+    # writes a `.gate-paths-exist-*` file into the scanned tree.
+    all="$(collect_dead_paths)"
+    dead="$(printf '%s\n' "$all" | grep -vF -- "$FIXTURE_NAME_PREFIX" || true)"
     if [[ -n "$dead" ]]; then
         echo "$dead" >&2
         log_fail "dead path constants found (see list above)"
@@ -228,7 +264,7 @@ test_detector_fires_on_a_deleted_workspace() {
     # Control: prove the instrument can FAIL. A synthetic scan target naming a
     # workspace that has never existed must be reported, otherwise this gate is
     # exactly the vacuous check it was written to prevent.
-    local fixture="$FIXTURE_DIR/.gate-paths-exist-fixture.ts"
+    local fixture="$FIXTURE_DIR/${FIXTURE_NAME_PREFIX}fixture.$FIXTURE_PID_SUFFIX.ts"
     # BLOCKER: expanding fixture now binds the specific path into the trap so cleanup fires even if the variable is later reassigned
     # shellcheck disable=SC2064
     trap "rm -f '$fixture'" RETURN
@@ -240,16 +276,21 @@ test_detector_fires_on_a_deleted_workspace() {
     # "the walk never reached the fixture". Diagnosing the wrong thing cost a
     # full bisect across four batch shapes.
     assert_scan_is_whole
-    local dead
+    local dead own
     dead="$(collect_dead_paths)"
-    assert_contains "$dead" "packages/definitely-not-a-workspace" \
+    # Scoped to OUR fixture by name. A concurrent invocation plants the same
+    # dead path under its own pid, and an unscoped assertion would pass off that
+    # one -- a control that can be satisfied by somebody else's fixture is not a
+    # control.
+    own="$(printf '%s\n' "$dead" | grep -F -- "-fixture.$FIXTURE_PID_SUFFIX.ts" || true)"
+    assert_contains "$own" "packages/definitely-not-a-workspace" \
         "detector must report a path under a nonexistent workspace"
     log_pass "detector fires on a deleted workspace (control case)"
 }
 
 test_detector_ignores_runtime_and_glob_paths() {
     # Shape check: the two biggest false-positive sources must stay silent.
-    local fixture="$FIXTURE_DIR/.gate-paths-exist-noise-fixture.ts"
+    local fixture="$FIXTURE_DIR/${FIXTURE_NAME_PREFIX}noise-fixture.$FIXTURE_PID_SUFFIX.ts"
     # BLOCKER: expanding fixture now binds the specific path into the trap so cleanup fires even if the variable is later reassigned
     # shellcheck disable=SC2064
     trap "rm -f '$fixture'" RETURN

--- a/.ci/scripts/test/gates/test-gate-paths-exist.sh
+++ b/.ci/scripts/test/gates/test-gate-paths-exist.sh
@@ -282,7 +282,9 @@ test_detector_fires_on_a_deleted_workspace() {
     # dead path under its own pid, and an unscoped assertion would pass off that
     # one -- a control that can be satisfied by somebody else's fixture is not a
     # control.
-    own="$(printf '%s\n' "$dead" | grep -F -- "-fixture.$FIXTURE_PID_SUFFIX.ts" || true)"
+    # Anchored on the full fixture basename: a suffix match ("-fixture.<pid>")
+    # also catches this pid's noise-fixture, whose name ends the same way.
+    own="$(printf '%s\n' "$dead" | grep -F -- "${FIXTURE_NAME_PREFIX}fixture.$FIXTURE_PID_SUFFIX.ts" || true)"
     assert_contains "$own" "packages/definitely-not-a-workspace" \
         "detector must report a path under a nonexistent workspace"
     log_pass "detector fires on a deleted workspace (control case)"

--- a/.ci/scripts/test/gates/test-profiler-coverage.sh
+++ b/.ci/scripts/test/gates/test-profiler-coverage.sh
@@ -407,8 +407,10 @@ YAML
 }
 
 test_nest_probe_is_not_coverage() {
-    # Coverage is DIRECT until the nest probe proves a nested post: hook fires.
-    # Counting the wrapper would be a fail-open, so assert it does not.
+    # Nesting works (run 31252148469), but that did NOT make every composite
+    # coverage: only a DECLARED, verified wrapper counts. nest-probe is the
+    # probe's own instrument and is deliberately not one, so a job carrying it
+    # is still uncovered.
     local d="$1"
     mkdir -p "$d/wf"
     cat >"$d/wf/fixture.yml" <<'YAML'
@@ -433,10 +435,11 @@ YAML
 }
 
 test_declared_wrapper_counts_as_coverage() {
-    # The extension path the header promises: the day profiler-probe.yml proves
-    # a nested post: hook fires, ONE ref in COVERING_ACTIONS covers every job
-    # that already calls the wrapper. Exercised here so it is live code rather
-    # than a comment that has never run.
+    # The UNVERIFIED extension seam, for a wrapper that lives outside this
+    # repo's action tree: a ref named in PROFILER_COVERAGE_COVERING_ACTIONS is
+    # taken on trust. Exercised here so it is live code rather than a comment
+    # that has never run. (The built-in wrapper list is the verified path, and
+    # is pinned by test_setup_workspace_is_builtin_coverage below.)
     local d="$1"
     mkdir -p "$d/wf"
     cat >"$d/wf/fixture.yml" <<'YAML'
@@ -461,6 +464,121 @@ YAML
     assert_exit_code 0 "$rc" "a declared covering wrapper must count as coverage (output: $LAST_OUT)"
     assert_contains "$LAST_OUT" "1/1 Linux job(s) profiled" "counts the wrapped job as covered"
     log_pass "a wrapper declared in COVERING_ACTIONS counts as coverage"
+}
+
+test_setup_workspace_is_builtin_coverage() {
+    # THE PHASE-1 INVARIANT. profiler-probe.yml run 31252148469 proved a nested
+    # post: hook fires, so ./.github/actions/setup-workspace carries the
+    # profiler and every job calling it is covered. Driven with NO seam at all
+    # here: if somebody reverts the built-in wrapper list to empty, or deletes
+    # the profiler step out of setup-workspace, this case goes red -- which is
+    # the only thing standing between that edit and ~26 jobs that report as
+    # profiled while profiling nothing.
+    local d="$1"
+    mkdir -p "$d/wf"
+    cat >"$d/wf/fixture.yml" <<'YAML'
+on:
+  workflow_dispatch:
+jobs:
+  fixture-wrapped:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: ./.github/actions/setup-workspace
+        with:
+          natives: 'true'
+      - run: echo work
+YAML
+    : >"$d/allow"
+    local rc=0
+    run_gate "$d/wf" "$d/allow" 1 1 1 || rc=$?
+    assert_exit_code 0 "$rc" "a job using setup-workspace must count as covered with no seam set (output: $LAST_OUT)"
+    assert_contains "$LAST_OUT" "1/1 Linux job(s) profiled" "counts the wrapped job as covered"
+    log_pass "setup-workspace is built-in coverage, seam-free"
+}
+
+test_other_composite_is_not_coverage() {
+    # CONTROL for the case above: a DIFFERENT local composite, same shape. Only
+    # a verified wrapper counts; "uses some composite" must not.
+    local d="$1"
+    mkdir -p "$d/wf"
+    cat >"$d/wf/fixture.yml" <<'YAML'
+on:
+  workflow_dispatch:
+jobs:
+  fixture-wrapped:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: ./.github/actions/app-token
+      - run: echo work
+YAML
+    : >"$d/allow"
+    local rc=0
+    run_gate "$d/wf" "$d/allow" 1 1 1 || rc=$?
+    assert_exit_code 1 "$rc" "an unrelated composite must not count as coverage"
+    assert_contains "$LAST_OUT" "does not use ./.github/actions/profiler" "reports it as uncovered"
+    log_pass "a composite that is not a declared wrapper is not coverage"
+}
+
+test_wrapper_that_lost_the_profiler_refuses() {
+    # The fail-open this verification exists to stop: deleting one `uses:` line
+    # from setup-workspace would silently uncover every job that calls it, and
+    # the gate would still print a clean coverage line. It must REFUSE instead.
+    local d="$1"
+    mkdir -p "$d/wf" "$d/hollow-wrapper"
+    cat >"$d/wf/fixture.yml" <<'YAML'
+on:
+  workflow_dispatch:
+jobs:
+  fixture-slim:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: ./.github/actions/profiler
+        with:
+          runner-label: ubuntu-slim
+      - run: echo work
+YAML
+    cat >"$d/hollow-wrapper/action.yml" <<'YAML'
+name: Hollow Wrapper
+description: A composite that used to carry the profiler and no longer does.
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: echo work
+YAML
+    : >"$d/allow"
+
+    local rc=0
+    LAST_OUT="$(PROFILER_COVERAGE_WORKFLOW_DIR="$d/wf" \
+        PROFILER_COVERAGE_ALLOWLIST="$d/allow" \
+        PROFILER_COVERAGE_WRAPPER_DIRS="$d/hollow-wrapper" \
+        PROFILER_COVERAGE_MIN_WORKFLOWS=1 PROFILER_COVERAGE_MIN_JOBS=1 \
+        PROFILER_COVERAGE_MIN_LINUX=1 bash "$GATE" 2>&1)" || rc=$?
+    assert_exit_code 1 "$rc" "a wrapper that does not use the profiler must refuse"
+    assert_contains "$LAST_OUT" "covering wrapper" "names the wrapper it checked"
+    assert_not_contains "$LAST_OUT" "Linux job(s) profiled" "must not print a success line"
+
+    # A wrapper directory that is not there at all is the same failure one step
+    # earlier, and must refuse rather than silently cover nothing.
+    rc=0
+    LAST_OUT="$(PROFILER_COVERAGE_WORKFLOW_DIR="$d/wf" \
+        PROFILER_COVERAGE_ALLOWLIST="$d/allow" \
+        PROFILER_COVERAGE_WRAPPER_DIRS="$d/no-such-wrapper" \
+        PROFILER_COVERAGE_MIN_WORKFLOWS=1 PROFILER_COVERAGE_MIN_JOBS=1 \
+        PROFILER_COVERAGE_MIN_LINUX=1 bash "$GATE" 2>&1)" || rc=$?
+    assert_exit_code 1 "$rc" "a wrapper directory with no action.yml must refuse"
+    assert_contains "$LAST_OUT" "has no action.yml" "names the missing contract"
+
+    # CONTROL: the REAL wrapper, named explicitly, is accepted -- so the two
+    # refusals above are the verification working, not the seam being unusable.
+    rc=0
+    LAST_OUT="$(PROFILER_COVERAGE_WORKFLOW_DIR="$d/wf" \
+        PROFILER_COVERAGE_ALLOWLIST="$d/allow" \
+        PROFILER_COVERAGE_WRAPPER_DIRS=".github/actions/setup-workspace" \
+        PROFILER_COVERAGE_MIN_WORKFLOWS=1 PROFILER_COVERAGE_MIN_JOBS=1 \
+        PROFILER_COVERAGE_MIN_LINUX=1 bash "$GATE" 2>&1)" || rc=$?
+    assert_exit_code 0 "$rc" "the real setup-workspace wrapper must verify (output: $LAST_OUT)"
+    log_pass "a wrapper is verified to carry the profiler, and refuses when it does not"
 }
 
 test_stale_allowlist_entries_fail() {
@@ -608,6 +726,9 @@ with_temp_dir test_runner_label_problems_fail
 with_temp_dir test_malformed_reference_fails
 with_temp_dir test_nest_probe_is_not_coverage
 with_temp_dir test_declared_wrapper_counts_as_coverage
+with_temp_dir test_setup_workspace_is_builtin_coverage
+with_temp_dir test_other_composite_is_not_coverage
+with_temp_dir test_wrapper_that_lost_the_profiler_refuses
 with_temp_dir test_stale_allowlist_entries_fail
 with_temp_dir test_empty_workflow_dir_refuses
 with_temp_dir test_missing_workflow_dir_refuses

--- a/.ci/scripts/test/run-all.sh
+++ b/.ci/scripts/test/run-all.sh
@@ -17,8 +17,14 @@
 # than general: two of these tests WRITE INTO THE REAL TREE, because the code
 # they exercise hardcodes the real tree and cannot be pointed at a fixture.
 #
-#   test-gate-paths-exist.sh   plants and deletes .ci/scripts/.gate-paths-exist{,-noise}-fixture.ts
+#   test-gate-paths-exist.sh   plants and deletes .ci/scripts/.gate-paths-exist{,-noise}-fixture.<pid>.ts
 #   test-gate-anti-vacuity.sh  plants and deletes scripts/.gate-anti-vacuity-fixture.ts
+#
+# The <pid> in the first pair is not decoration: this schedule serialises the W
+# chain within ONE battery, and two independent batteries (two sessions) used to
+# collide on fixed filenames -- each trap deleting the other's fixture, which
+# read as "the detector is broken". The pid makes those two runs disjoint; the
+# schedule below still handles the in-battery half.
 #
 # Meanwhile a good dozen other tests RECURSIVELY ENUMERATE those same two
 # directories -- `cp -r`, `find`, `grep -r`, or a gate that does one of those on

--- a/.ci/scripts/test/test-install-methods.sh
+++ b/.ci/scripts/test/test-install-methods.sh
@@ -144,7 +144,22 @@ esac
 DOCKER_IMAGE="ghcr.io/rediacc/rdc"
 SITE_URL="${SITE_URL:-https://www.rediacc.com}"
 # RELEASES_BASE_URL is set by constants.sh (sourced via common.sh) as readonly
-# REPO_CHANNEL: optional channel path segment (e.g., "stable", "edge", or "" for staging)
+# REPO_CHANNEL: channel path segment ("stable", "edge", "pr-<n>"), or EMPTY
+# meaning THIS RUN STAGED NO ARTIFACTS (schedule / workflow_dispatch, whose
+# stage-artifacts step never writes R2).
+#
+# Empty deliberately does NOT default to "stable". That was tried on
+# 2026-08-08 to cure the nightly's apt/quick-install 404s and reverted the
+# same day: test_binary_download's comment already names the reason -- a
+# nightly downloading stable turns MAIN's nightly red when a past RELEASE
+# breaks, and those two signals must not be conflated. The 404s' actual
+# cause was that the apt and quick-install tests LACKED the channel-less
+# skip guard the binary/update/verify tests have carried all along, so
+# they fetched root urls (/apt/gpg.key, /cli/install.sh) that the
+# <dir>/<channel>/ layout has never published, while promote-r2-to-stable
+# had in fact published every stable file (verified 200 live). The fix is
+# the same `return 77` guard on those tests, not a default that changes
+# what a red nightly means.
 REPO_CHANNEL="${REPO_CHANNEL:-}"
 # Build repo URL: ${RELEASES_BASE_URL}/apt[/${REPO_CHANNEL}] etc.
 if [[ -n "$REPO_CHANNEL" ]]; then
@@ -762,6 +777,19 @@ test_apt_install() {
         return 0
     fi
 
+    # Same channel-less case as test_binary_download: this run staged no
+    # artifacts, and the channel URL this test fetches names a path that
+    # does not exist (the layout is <dir>/<channel>/; there is no root
+    # tree). Before 2026-08-08 this family had NO such guard, so every
+    # schedule run 404ed here and the nightly stayed red for days while
+    # the release pipeline was blamed -- promote-r2-to-stable had in
+    # fact published every stable file. AFTER the DRY_RUN block on
+    # purpose: dry-run output stays unchanged for the args gate.
+    if [[ -z "$REPO_CHANNEL" ]]; then
+        log_warn "No REPO_CHANNEL: skipping APT install (expected on schedule and workflow_dispatch)."
+        return 77
+    fi
+
     run_container_version_test "APT ($label)" docker run --rm "$distro" bash -c "
         set -e
         # Point apt at the Azure-hosted Ubuntu mirror. The upstream
@@ -822,6 +850,19 @@ test_dnf_install() {
         return 0
     fi
 
+    # Same channel-less case as test_binary_download: this run staged no
+    # artifacts, and the channel URL this test fetches names a path that
+    # does not exist (the layout is <dir>/<channel>/; there is no root
+    # tree). Before 2026-08-08 this family had NO such guard, so every
+    # schedule run 404ed here and the nightly stayed red for days while
+    # the release pipeline was blamed -- promote-r2-to-stable had in
+    # fact published every stable file. AFTER the DRY_RUN block on
+    # purpose: dry-run output stays unchanged for the args gate.
+    if [[ -z "$REPO_CHANNEL" ]]; then
+        log_warn "No REPO_CHANNEL: skipping DNF install (expected on schedule and workflow_dispatch)."
+        return 77
+    fi
+
     run_container_version_test "DNF ($label)" docker run --rm "$distro" bash -c "
         set -e
         # Add repo
@@ -846,6 +887,19 @@ test_apk_install() {
     if [[ "$DRY_RUN" == "true" ]]; then
         log_info "[DRY-RUN] Would test APK install on $label"
         return 0
+    fi
+
+    # Same channel-less case as test_binary_download: this run staged no
+    # artifacts, and the channel URL this test fetches names a path that
+    # does not exist (the layout is <dir>/<channel>/; there is no root
+    # tree). Before 2026-08-08 this family had NO such guard, so every
+    # schedule run 404ed here and the nightly stayed red for days while
+    # the release pipeline was blamed -- promote-r2-to-stable had in
+    # fact published every stable file. AFTER the DRY_RUN block on
+    # purpose: dry-run output stays unchanged for the args gate.
+    if [[ -z "$REPO_CHANNEL" ]]; then
+        log_warn "No REPO_CHANNEL: skipping APK install (expected on schedule and workflow_dispatch)."
+        return 77
     fi
 
     run_container_version_test "APK ($label)" docker run --rm "$distro" sh -c "
@@ -873,6 +927,19 @@ test_pacman_install() {
     if [[ "$DRY_RUN" == "true" ]]; then
         log_info "[DRY-RUN] Would test Pacman install on $label"
         return 0
+    fi
+
+    # Same channel-less case as test_binary_download: this run staged no
+    # artifacts, and the channel URL this test fetches names a path that
+    # does not exist (the layout is <dir>/<channel>/; there is no root
+    # tree). Before 2026-08-08 this family had NO such guard, so every
+    # schedule run 404ed here and the nightly stayed red for days while
+    # the release pipeline was blamed -- promote-r2-to-stable had in
+    # fact published every stable file. AFTER the DRY_RUN block on
+    # purpose: dry-run output stays unchanged for the args gate.
+    if [[ -z "$REPO_CHANNEL" ]]; then
+        log_warn "No REPO_CHANNEL: skipping Pacman install (expected on schedule and workflow_dispatch)."
+        return 77
     fi
 
     run_container_version_test "Pacman ($label)" docker run --rm "$distro" bash -c "
@@ -903,6 +970,19 @@ test_npm_install() {
     if [[ "$DRY_RUN" == "true" ]]; then
         log_info "[DRY-RUN] Would test npm install on $label"
         return 0
+    fi
+
+    # Same channel-less case as test_binary_download: this run staged no
+    # artifacts, and the channel URL this test fetches names a path that
+    # does not exist (the layout is <dir>/<channel>/; there is no root
+    # tree). Before 2026-08-08 this family had NO such guard, so every
+    # schedule run 404ed here and the nightly stayed red for days while
+    # the release pipeline was blamed -- promote-r2-to-stable had in
+    # fact published every stable file. AFTER the DRY_RUN block on
+    # purpose: dry-run output stays unchanged for the args gate.
+    if [[ -z "$REPO_CHANNEL" ]]; then
+        log_warn "No REPO_CHANNEL: skipping npm install (expected on schedule and workflow_dispatch)."
+        return 77
     fi
 
     local npm_url="${RELEASES_BASE_URL}/npm${REPO_CHANNEL_SUFFIX}/rediacc-cli-latest.tgz"
@@ -974,6 +1054,19 @@ test_quick_install() {
     if [[ "$DRY_RUN" == "true" ]]; then
         log_info "[DRY-RUN] Would test quick install on $label"
         return 0
+    fi
+
+    # Same channel-less case as test_binary_download: this run staged no
+    # artifacts, and the channel URL this test fetches names a path that
+    # does not exist (the layout is <dir>/<channel>/; there is no root
+    # tree). Before 2026-08-08 this family had NO such guard, so every
+    # schedule run 404ed here and the nightly stayed red for days while
+    # the release pipeline was blamed -- promote-r2-to-stable had in
+    # fact published every stable file. AFTER the DRY_RUN block on
+    # purpose: dry-run output stays unchanged for the args gate.
+    if [[ -z "$REPO_CHANNEL" ]]; then
+        log_warn "No REPO_CHANNEL: skipping quick install (expected on schedule and workflow_dispatch)."
+        return 77
     fi
 
     local expected_channel="${REPO_CHANNEL:-stable}"

--- a/.github/actions/profiler/action.yml
+++ b/.github/actions/profiler/action.yml
@@ -57,7 +57,9 @@ inputs:
     default: ''
 
 runs:
-  using: node20
+  # node20 is deprecated on GitHub runners (forced onto Node 24 with a warning
+  # in every job since 2025-09); declare what actually runs.
+  using: node24
   main: index.js
   # Explicit even though always() is the default: this hook exists precisely to
   # profile the runs that fail, and a silent default is not worth relying on.

--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -48,6 +48,29 @@ inputs:
 runs:
   using: composite
   steps:
+    # FIRST, deliberately. The profiler's `main` starts a detached sampler and
+    # its `post` writes the panel, so everything after this line is measured --
+    # including the node setup and the cache restore, which are the very costs
+    # this action exists to cut. It consumes none of this action's inputs and
+    # produces no outputs, so it cannot perturb anything below it; a missing
+    # sampler or a non-Linux runner makes it a no-op warning rather than a
+    # failure.
+    #
+    # NESTING IS PROVEN, NOT ASSUMED. A JavaScript action's `post:` hook firing
+    # from inside a composite is what profiler-probe.yml was dispatched to
+    # settle: run 31252148469 saw the panel appear on BOTH ubuntu-slim and
+    # ubuntu-latest through a composite wrapper.
+    #
+    # NO runner-label, and it cannot be fixed here: a composite cannot read its
+    # caller's `runs-on`, and there is no RUNNER_LABEL in the runner's
+    # environment to fall back on. index.js resolves the absent input to
+    # 'unknown', which records the tier and the sample series exactly as before
+    # and only leaves HOST_LEAK unarmed (sampler-linux.sh:251-254 arms it off a
+    # '*slim*' label). That is the honest trade for one line here instead of a
+    # `runner-label:` threaded through 26 jobs, and on a cgroup tier the
+    # enforced quota already substitutes for the label.
+    - uses: ./.github/actions/profiler
+
     - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
       with:
         node-version: ${{ inputs.node-version }}

--- a/.github/workflows/autopilot.yml
+++ b/.github/workflows/autopilot.yml
@@ -26,21 +26,33 @@ name: Autopilot
 # The dispatch also carries the round's model, its reasoning effort, and an
 # optional hold-open debug session (see the model job).
 #
-# STAGE FLAGS, all repo VARIABLES, all fail closed (ABSENT MEANS OFF).
-# None of them exist yet, so this workflow lands INERT; enabling a stage is a
-# variable flip, never a commit (03-v2-autonomy.md section 8):
+# STAGE FLAGS, all Actions VARIABLES (repo-level, or org-level scoped to this
+# repo -- `vars.` reads both), all fail closed (ABSENT MEANS OFF). None of them
+# exist yet, so this workflow lands INERT; enabling a stage is a variable flip,
+# never a commit (03-v2-autonomy.md section 8):
 #   AUTOPILOT_ENABLED           master switch: gate runs and logs (S1+)
 #   AUTOPILOT_ALLOW_STATE       state-comment writes (S2+)
 #   AUTOPILOT_ALLOW_FINISH      deterministic ready-flip / done (S3+)
-#   AUTOPILOT_MODEL             model rounds run; pushes stay dry-run (S4+)
+#   AUTOPILOT_ALLOW_MODEL       model rounds run; pushes stay dry-run (S4+)
 #   AUTOPILOT_ALLOW_PUSH        real pushes (S5+)
 #   AUTOPILOT_ALLOW_SUBMODULES  reserved for increment 2 (S6); unread today
+# EVERY STAGE FLAG IS A BOOLEAN: the only value that arms one is the literal
+# string `true`. AUTOPILOT_ALLOW_MODEL carries the ALLOW_ prefix for that
+# reason -- it is the S4 SWITCH, never a model name. The model NAME is the
+# `model` dispatch input, recorded in the campaign. Putting a model name in
+# this flag reads as false: the model job never starts, and the loop arms,
+# decides go and does nothing with no error anywhere (renamed 2026-08-08 for
+# exactly that trap; 03-v2-autonomy.md section 8).
 # Plus configuration variables: AUTOPILOT_AUTHOR_ALLOWLIST (empty allows
 # NOBODY), AUTOPILOT_APPLIER_ALLOWLIST, AUTOPILOT_LABEL, AUTOPILOT_MAX_ROUNDS,
 # AUTOPILOT_BOT_LOGIN, AUTOPILOT_GIT_NAME, AUTOPILOT_GIT_EMAIL.
 #
-# Secrets: AUTOPILOT_APP_ID / AUTOPILOT_PRIVATE_KEY (the rediacc-autopilot
-# app, NO bypass on the console ruleset) and CLAUDE_CODE_OAUTH_TOKEN.
+# IDENTITY, and the split matters: AUTOPILOT_APP_ID is an org VARIABLE
+# (`vars.AUTOPILOT_APP_ID`, visibility scoped to console), NOT a secret. Setting
+# it with `gh secret set AUTOPILOT_APP_ID` APPEARS TO SUCCEED and leaves the
+# variable empty, which silently breaks every app-token mint below. Only
+# AUTOPILOT_PRIVATE_KEY (the rediacc-autopilot app's key; the app has NO bypass
+# on the console ruleset) and CLAUDE_CODE_OAUTH_TOKEN are secrets.
 
 on:
   workflow_run:
@@ -285,10 +297,16 @@ jobs:
     # The model runs only on a go decision for a model mode, and only when the
     # model stage is armed. Ready-flip and done are deterministic and go to
     # the finish job instead.
+    #
+    # AUTOPILOT_ALLOW_MODEL is the S4 SWITCH, not the model name: the only
+    # value that arms it is `true`. The model NAME comes from the `model`
+    # dispatch input / the campaign field, and reaches the round via
+    # needs.gate.outputs.model. Putting a model name in this variable reads as
+    # false and disarms the whole job silently.
     if: >-
       needs.gate.outputs.decision == 'go' &&
       (needs.gate.outputs.mode == 'fix' || needs.gate.outputs.mode == 'review-response') &&
-      vars.AUTOPILOT_MODEL == 'true'
+      vars.AUTOPILOT_ALLOW_MODEL == 'true'
     runs-on: ubuntu-latest
     # 30 for a normal round. A debug-shell dispatch holds the runner open for
     # up to `hold-duration` (300) AFTER the round, so it needs its own
@@ -786,10 +804,12 @@ jobs:
           preset: cd
           repositories: console
 
-      # Dispatch every armed PR unconditionally: the dispatched gate run
+      # Dispatch every LABEL-armed PR unconditionally: the dispatched gate run
       # dedups against the ledger at zero model cost, so a naive sweep is
       # cheap and the sweeper stays 4 lines instead of re-implementing the
-      # gate (03-v2-autonomy.md section 9).
+      # gate (03-v2-autonomy.md section 9). Note the scope: a PR armed only by
+      # an open CAMPAIGN carries no label, so this sweep does not reach it --
+      # campaign rounds ride their own workflow_run events.
       - name: Dispatch armed PRs
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}

--- a/.profiler-coverage-allowlist
+++ b/.profiler-coverage-allowlist
@@ -26,7 +26,7 @@ profiler-probe.yml:facts-slim
 profiler-probe.yml:post-nested-latest
 profiler-probe.yml:post-nested-slim
 
-# BLOCKER: rollout ledger for the runner profiler, which landed 2026-08-05 with one live job (profiler-probe.yml:post-direct-latest) and 90 jobs still unwired. Enumerated rather than waived so the gate is BLOCKING for every job added from today on, and so the burn-down is a visible diff instead of a habit: each line is deleted by the commit that adds the profiler step to that job, and the gate rejects the line the moment the job is covered, so a forgotten deletion is a build failure rather than dead weight. The shape of the burn-down depends on the answer profiler-probe.yml is dispatched to get -- if a nested post: hook fires, one uses: in setup-workspace covers most of these at once and COVERING_ACTIONS in the gate grows by one line; if it does not, each job needs its own edit.
+# BLOCKER: rollout ledger for the runner profiler, which landed 2026-08-05 with one live job (profiler-probe.yml:post-direct-latest) and 90 jobs still unwired. Enumerated rather than waived so the gate is BLOCKING for every job added from today on, and so the burn-down is a visible diff instead of a habit: each line is deleted by the commit that adds the profiler step to that job, and the gate rejects the line the moment the job is covered, so a forgotten deletion is a build failure rather than dead weight. Phase 1 landed 2026-08-08 and burned 25 of these lines at once: profiler-probe.yml run 31252148469 proved on real runners that a JavaScript action's post: hook DOES fire from inside a composite, so one uses: in .github/actions/setup-workspace plus one verified wrapper in the gate covered every job that already calls it. What remains here is the jobs that do NOT call setup-workspace -- they set up their own toolchain, or run nothing that needs node -- and each of those still needs its own edit.
 #
 # autopilot.yml
 autopilot.yml:finish
@@ -45,54 +45,34 @@ cd-deploy-account.yml:read-regions
 # cd-deploy-worker.yml
 cd-deploy-worker.yml:deploy
 #
-# cd-stage.yml
-cd-stage.yml:stage
-#
 # cd-v2.yml
 cd-v2.yml:init
 cd-v2.yml:publish
 cd-v2.yml:smoke-test
 cd-v2.yml:tag-and-release
 #
-# ci-build-cli.yml
-ci-build-cli.yml:build-cli-executables
-#
 # ci-build-docker.yml
-ci-build-docker.yml:build-cli
 ci-build-docker.yml:build-cli-docker
 ci-build-docker.yml:build-cli-docker-skip
 ci-build-docker.yml:build-devcontainer-amd64
 ci-build-docker.yml:build-devcontainer-arm64
 ci-build-docker.yml:build-devcontainer-manifest
-ci-build-docker.yml:build-json
 ci-build-docker.yml:build-renet-docker
 ci-build-docker.yml:build-renet-skip
 ci-build-docker.yml:build-server-docker-amd64
 ci-build-docker.yml:build-server-docker-arm64
 ci-build-docker.yml:build-server-docker-manifest
 ci-build-docker.yml:build-server-docker-skip
-ci-build-docker.yml:build-www
 #
 # ci-build-renet.yml
 ci-build-renet.yml:build-renet
 ci-build-renet.yml:cross-compile-smoke
 ci-build-renet.yml:extract-renet
 #
-# ci-ops-test.yml
-ci-ops-test.yml:ops-platform-check
-ci-ops-test.yml:ops-vm-provision
-#
 # ci-quality.yml
 ci-quality.yml:quality-branch
-ci-quality.yml:quality-code
-ci-quality.yml:quality-content
-ci-quality.yml:quality-go
-ci-quality.yml:quality-i18n
-ci-quality.yml:quality-packages
-ci-quality.yml:quality-security
 ci-quality.yml:quality-static
 ci-quality.yml:quality-submodule-branches
-ci-quality.yml:quality-www-build
 #
 # ci.yml
 ci.yml:breakpoint-lifecycle
@@ -130,19 +110,8 @@ ct-install-methods.yml:test-linux-x64
 #
 # ct-tests.yml
 ct-tests.yml:migration-test
-ct-tests.yml:test-account-e2e
-ct-tests.yml:test-drills
-ct-tests.yml:test-e2e-ceph
-ct-tests.yml:test-e2e-ceph-workers
-ct-tests.yml:test-e2e-k8s
-ct-tests.yml:test-e2e-k8s-ceph
-ct-tests.yml:test-e2e-k8s-multinode
-ct-tests.yml:test-e2e-migrate
-ct-tests.yml:test-e2e-workers
-ct-tests.yml:test-fork-isolation
 ct-tests.yml:test-license-enforcement
 ct-tests.yml:test-renet
-ct-tests.yml:test-unit
 #
 # ct-update-flow.yml
 ct-update-flow.yml:test-linux-x64

--- a/docs/agent/ci-gates.md
+++ b/docs/agent/ci-gates.md
@@ -159,15 +159,18 @@ Two design points worth knowing before you edit a workflow:
 - **It fails CLOSED on what it cannot resolve.** `runs-on: ${{ inputs.runner }}`
   has no static answer, so the job counts as REQUIRING coverage. "We could not
   tell" costs an allowlist line with a reason; it is never silently exempt.
-- **Coverage is DIRECT.** A wrapping composite action does not count, because
-  whether a JavaScript action's `post:` hook fires when nested inside a composite
-  is the open question `profiler-probe.yml` exists to answer. It is
-  `workflow_dispatch`-only and has never been dispatched, so nobody knows yet;
-  compare the `post-direct-latest` and `post-nested-latest` job summaries after a
-  dispatch, which are identical except for the nesting precisely so "no panel"
-  can be told apart from "the action is broken". When it answers yes, set
-  `PROFILER_COVERAGE_COVERING_ACTIONS`'s default in the gate to the wrapping
-  composite and every job that already calls it is covered in one line.
+- **Coverage counts `setup-workspace` as a wrapper.** The open question this
+  bullet used to carry — does a JavaScript action's `post:` hook fire when
+  nested inside a composite? — was ANSWERED YES on 2026-08-08 by dispatching
+  `profiler-probe.yml` (run 31252148469: `Post Run ./.github/actions/profiler/
+  nest-probe: success` on both ubuntu-slim and ubuntu-latest). The profiler is
+  therefore wired as one early step in `.github/actions/setup-workspace`, that
+  composite is the gate's built-in wrapper default (`WRAPPER_DIRS`, still
+  extendable via `PROFILER_COVERAGE_WRAPPER_DIRS`), and the 25 ledger lines
+  for jobs covered that way are burned. The same probe settled the container
+  facts: GitHub's slim is cgroup **v1** (the sampler's v1 fallback resolves
+  cpu+memory), host views are container-scoped there (`nproc`=1,
+  MemTotal≈4.8 GiB), `awk` and `node` are present, and a sample costs ~742µs.
 
   **Do not flip that seam without also extending the CONFIG relation.** The
   configuration checks only inspect DIRECT uses, and a composite forwards a

--- a/docs/ci-overhaul/03-v2-autonomy.md
+++ b/docs/ci-overhaul/03-v2-autonomy.md
@@ -366,6 +366,15 @@ never needs a commit.
 
 Rollback at any stage: flip the variable (seconds) or revoke the installation (also seconds).
 
+> **2026-08-08, the S4 flag was renamed `AUTOPILOT_MODEL` -> `AUTOPILOT_ALLOW_MODEL`.** Every
+> stage flag is a boolean armed only by the literal `true`, but this one shared a name with
+> the `model` dispatch input, which is a model NAME (`claude-sonnet-5` / `claude-opus-5`).
+> Setting `AUTOPILOT_MODEL=claude-opus-5` to "pick the model" read as false at the model job's
+> `if:`, so the loop armed, decided go, and did nothing, with no error anywhere. The
+> `ALLOW_` prefix puts it in the family it belongs to (`ALLOW_STATE` / `ALLOW_FINISH` /
+> `ALLOW_PUSH`) and makes the switch-versus-value distinction visible in the name. No
+> variable of either name exists yet, so the rename cost nothing operationally.
+
 ---
 
 ## 9. Cost

--- a/docs/ci-overhaul/06-progress.md
+++ b/docs/ci-overhaul/06-progress.md
@@ -3093,3 +3093,82 @@ by test-shell-counter-increment.sh but never defined anywhere (silent only becau
 that file runs without -e; its finding report would have printed "command not
 found" instead of the finding), and the Stop hook's task-queue blindness described
 in the session records rode the same branch.
+
+## Phase 2 of the post-merge wave: probe answers wired in (2026-08-08)
+
+Phase 1 (read-only validation, this session, evidence on worklist tick
+#9b7741bb) dispatched `Profiler Probe` run 31252148469 and a
+schedule-equivalent Console CI run 31252149485, and settled every question
+the 2026-08-05 wave had left open. Phase 2 then landed the consequences,
+all uncommitted:
+
+**The probe's two answers, and what each changed.** (1) A JS action's
+`post:` hook FIRES when the action is invoked through a composite wrapper,
+on both ubuntu-slim and ubuntu-latest. So the profiler rollout is ONE step
+in `.github/actions/setup-workspace` (:72) plus that composite becoming the
+coverage gate's built-in wrapper default, not 26 per-job edits: coverage
+went 1/97 -> 26/97 in one change and 25 ledger lines burned (96 -> 71).
+The `runner-label` input is deliberately NOT threaded through the wrapper:
+on a cgroup tier the enforced quota substitutes for the label, and the
+label's only job (arming HOST_LEAK) does not survive a composite that
+cannot know `runs-on`. (2) GitHub's real slim container is cgroup V1 -- the
+local docker proof was v2, so the sampler's v1 fallback path is the one
+production exercises, and the probe watched it resolve cpu+memory
+correctly. Host views are container-scoped on slim (nproc=1,
+MemTotal~4.8GiB), awk AND node exist there, and a sample costs ~742us
+against the ~1ms estimate.
+
+**The nightly's last red was OUR TEST, not the release pipeline -- and the
+first fix for it was wrong, caught by a gate within the hour.** Both the
+nightly and the fresh dispatch failed only Validate Install Methods, always
+as `curl: (22) ... 404`: with the nightly's deliberately EMPTY channel the
+apt and quick-install tests fetched root urls (/apt/gpg.key,
+/cli/install.sh) that the <dir>/<channel>/ layout has never published,
+while promote-r2-to-stable.sh had published every stable file (verified
+200 live across apt/rpm/cli/apk/archlinux). Fix #1 -- default REPO_CHANNEL
+to "stable" -- made the urls resolve and BROKE the design:
+test-installmethods-args.sh failed on "an all-skipped run is a success",
+because test_binary_download:462 already documents why empty must stay
+empty (a nightly downloading stable turns MAIN's nightly red when a past
+RELEASE breaks; the two signals must not be conflated). The real defect
+was that six package-family tests (apt, dnf, apk, pacman, npm, quick)
+LACKED the channel-less `return 77` skip guard their siblings
+(binary/update/verify/promotion) have carried all along. Fix #2, the one
+that stands: the same guard on all six, placed after each DRY_RUN block so
+dry-run output is unchanged. A channel-less apt run now reports "0 passed,
+0 failed, 3 skipped" with the reason named. Two lessons, both old ones: a
+404 names the fetcher's url, not the publisher's tree; and a fix that
+makes a red go green is not right until the gates that encode the DESIGN
+agree -- the args gate paid for itself completely here.
+
+**The 2026-08-05 cold case is closed.** test-gate-paths-exist.sh planted
+FIXED-filename fixtures in tracked .ci/scripts, so two concurrent battery
+runs deleted each other's fixtures -- exactly the "control came back empty
+only during a full run" signature chased across a four-shape bisect at the
+time. The fixtures now carry the pid (FIXTURE_PID_SUFFIX), the scan scopes
+itself with a cross-pid glob, and the fix is proven by the failing scenario
+itself: two fully concurrent instances, both 7/7 green, re-run
+independently by the session lead. The SCAN_FLOOR guard stays as the
+loudness backstop. Credit: val-local's read-only sweep spotted the fixed
+filenames.
+
+**Autopilot loose ends.** AUTOPILOT_MODEL is renamed AUTOPILOT_ALLOW_MODEL
+(the S4 boolean was named like a model VALUE; `AUTOPILOT_MODEL=claude-opus-5`
+read as false and silently disarmed the model job -- no error anywhere).
+The old name survives only in 03-v2-autonomy.md's dated rename note. The
+identity comment at autopilot.yml:52-58 now states the split precisely:
+AUTOPILOT_APP_ID is an org VARIABLE (gh secret set on it appears to succeed
+while vars. stays empty -- the exact defect the operator fixed once
+already); only AUTOPILOT_PRIVATE_KEY and CLAUDE_CODE_OAUTH_TOKEN are
+secrets. FOUND, REPORTED, NOT FIXED: the sweeper enumerates only
+LABEL-armed PRs (gh pr list --label), so a campaign-armed PR that misses a
+workflow_run event stalls silently; reaching those means scanning state
+comments for `campaign: open` -- an S6-era decision, its comment corrected
+meanwhile.
+
+**Second live data point for external_quality.** The dispatch ran with
+EXTERNAL_QUALITY_MODE: soft in both wrapped Quality/Go steps and all ten
+Quality lanes green, matching the nightly. Still true and still stated
+plainly: no upstream drift existed on either data point, so the downgrade
+branch (warn + exit 0 on a REAL external failure) remains test-proven only
+until the world moves.

--- a/docs/ci-overhaul/06-progress.md
+++ b/docs/ci-overhaul/06-progress.md
@@ -3172,3 +3172,36 @@ Quality lanes green, matching the nightly. Still true and still stated
 plainly: no upstream drift existed on either data point, so the downgrade
 branch (warn + exit 0 on a REAL external failure) remains test-proven only
 until the world moves.
+
+## First fleet-wide live profiler run, and the review-actor facts around it (2026-08-09)
+
+PR #560 (branch 0808-5) carried the wiring into a real `pull_request` run,
+31279251398, and the profiler's first fleet-wide outing on genuine jobs:
+
+- All 26 setup-workspace jobs ran the profiler main ("sampling every 10s
+  into $RUNNER_TEMP/profiler-<job>-<pid>.tsv") and every post hook concluded
+  success (~148ms each on warm jobs).
+- **Panels are proven by construction, not by page-scrape.** The run page's
+  server-rendered HTML shows annotations but lazy-loads job summaries, so an
+  unauthenticated fetch "sees" no panels. The chain that actually proves
+  them: panel.sh exits non-zero on any of its own failures and index.js
+  refuses to swallow that (`process.exitCode = res.status`); all 26 posts
+  were green; and a local drive of panel.sh with exit 0 always appends a
+  `## Runner Profile:` section to GITHUB_STEP_SUMMARY, even in the
+  degenerate no-samples case. Eyeball the run page for the rendered panels.
+- **The sample-floor guard fired in production on its first day**: one 41s
+  job got 3 samples against the 4 expected and the run carries the exact
+  annotation designed for it ("the sampler was starved or died early") —
+  a warning, not a hard fail, because strict mode is off fleet-wide.
+- The same run's deprecation banner surfaced that the action declared
+  `node20` while GitHub already force-runs it on Node 24; it now declares
+  `node24` (the repo's only JS action, so the class is one file).
+
+Two external-links facts from the same wave, for the record: the hard-mode
+PR gate caught gnupg.org answering 000 (down from two networks; the
+docs.appimage.org outage from earlier the same day had meanwhile recovered)
+— external flap, absorbed with the designed `no-external-quality` label. A
+label applied mid-PR needs a real push to take effect: `external_quality`
+is computed from the EVENT payload's label snapshot (ci.yml:129) and
+`pull_request` triggers only on [opened, synchronize], so a bare rerun
+re-reads the unlabeled payload.


### PR DESCRIPTION
## Summary

Post-merge wave phase 2: the profiler built on the 0805 wave gets wired fleet-wide, plus four fixes found and verified during post-merge validation.

- **Profiler rollout phase 1**: one `uses:` step in `.github/actions/setup-workspace/action.yml` profiles every job that mounts the workspace (the probe run 31252148469 proved a JS action's `post:` hook fires through a composite wrapper). `check-profiler-coverage.sh` now treats setup-workspace as its built-in wrapper, coverage 1/97 → 26/97 Linux jobs, and 25 now-covered entries are burned from `.profiler-coverage-allowlist` (96 → 71) — the gate rejects stale entries, so the ledger can only shrink.
- **Fixture race fix** (`test-gate-paths-exist.sh`): fixtures carry a PID suffix; two concurrent battery runs previously deleted each other's plants (root cause of the 2026-08-05 cold case). Concurrent-pair repro: both instances 7/7, exit 0.
- **Autopilot loose ends**: `AUTOPILOT_MODEL` → `AUTOPILOT_ALLOW_MODEL` (it gates, it doesn't name a model); identity comment corrected (APP_ID is an org **variable**); sweeper comment states its label-armed-only reach.
- **Install-methods nightly (#544)**: six package-family tests lacked the channel-less `return 77` skip guard their siblings had, so schedule/dispatch runs 404ed against a channel the run never staged. Deliberately NOT defaulted to `stable` — that would let a broken past release redden main's nightly (the first attempted fix did exactly this and `test-installmethods-args` caught it).
- **Docs**: `docs/ci-overhaul/06-progress.md` dated section, `docs/agent/ci-gates.md` profiler facts from the probe, `03-v2-autonomy.md` rename note.

## Surface changes

No CLI or product surface changes. CI-only: every setup-workspace job now emits a profiler panel in its summary; `vars.AUTOPILOT_ALLOW_MODEL` replaces `vars.AUTOPILOT_MODEL` (variable not yet set anywhere, so no behavior change).

## Submodule Branches

No submodule changes in this wave; all pointers unchanged from main.

## Verification

- `bash .ci/scripts/quality/check-profiler-coverage.sh` → 26/97 profiled, 71 allowlisted, exit 0; planted burned-line refused.
- `REPO_CHANNEL="" .../test-install-methods.sh --method apt` → 0 passed, 0 failed, 3 skipped; `test-installmethods-args.sh` all PASS.
- `test-gate-paths-exist.sh` concurrent pair: both 7/7 exit 0.
- `npm run ci` battery (205 gates): only standing red is `check:ci-external-links` on docs.appimage.org being unreachable upstream (curl 000 — external drift, the class the soft path exists for).

## Round 2 (2026-08-08)

- Run 31278900664 red: `check:ci-external-links` (hard mode) on https://www.gnupg.org/gph/en/manual/c235.html — the site answers 000 from two networks right now; pure external flap (meanwhile docs.appimage.org, down earlier today, recovered). Applied the designed `no-external-quality` label; this push carries it into the event payload (rerun would not — the mode is computed from the event's label snapshot).
- Same run's deprecation warning fixed: the profiler action declared `node20` while GitHub force-runs it on Node 24; it now declares `node24` (only JS action in the repo).

## Round 3 (2026-08-09)

- Run 31279251398 fully green (0 failed, 0 cancelled) — the profiler's first fleet-wide live run: all 26 post hooks success, panels proven by construction (panel.sh exit-0 always writes; posts green), and the sample-floor guard annotated a marginal 41s job exactly as designed.
- Claude review attempt on `a79bd07` died with `error_max_turns` (no report); per the attempt comment, this push earns the next pass.
- Docs: first-live-run verification + the label-snapshot/rerun gotcha recorded in `06-progress.md`.

## Round 5 (2026-08-09)

- Review attempt 2 on `e1af517` completed: **no blocking defects, approve** (empty `review-findings`). Its one nit — the own-fixture grep also matched the same-pid noise fixture — was real; fixed in `7634ebb47` by anchoring on the full fixture basename (suite 7/7 after).

<!-- pushed-head:begin -->
**Last pushed:** `7634ebb47`

- `7634ebb47` test(gates): anchor the own-fixture filter on the full basename
- `e1af517cf` docs(ci-overhaul): first fleet-wide live profiler run verified; label-snapshot gotcha recorded
- `a79bd073e` fix(ci): profiler action declares node24, the runtime it already gets
- `32d906f59` feat(ci): wire the profiler fleet-wide; fix the nightly channel guard, the fixture race, and autopilot loose ends
- `47ca9c963` chore(release-state): advance contract floor to v1.2.3 [skip ci]
<!-- pushed-head:end -->
