### PR TITLE
fix(hooks): STATE.md holds one owned section per session, merged not overwritten

### DIFF
--- a/.ci/scripts/quality/check-python-lint.sh
+++ b/.ci/scripts/quality/check-python-lint.sh
@@ -24,6 +24,15 @@
 #      it. If the control cannot fire, this exits non-zero WITHOUT judging the
 #      real files, because a verdict from an instrument that cannot fail is
 #      worse than no verdict.
+#   3. AN UNTRACKED FILE, silently omitted. Found live 2026-08-09: this gate
+#      reported "27 files, All checks passed!" while wl_checklist.py, the
+#      newest and second-largest module of the Stop-hook program, was untracked
+#      and therefore never in the list. A format violation in it was caught
+#      only by running ruff by hand. The omission is invisible by construction:
+#      a shorter list still passes the floor, so nothing looks wrong. The list
+#      now includes untracked-but-not-ignored Python, and control 3 below
+#      plants an untracked file to prove the enumeration reaches it. Gitignored
+#      files stay excluded, which is what keeps venvs and build output out.
 #
 # The control plants F821 (undefined name) specifically, because that is the
 # rule that caught the real bug. If a future config change disables it, this
@@ -52,10 +61,38 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 # A read loop, NOT mapfile: check-commands.sh rejects mapfile as unavailable in
 # the minimal CI shell, and it is right -- the gate failed on exactly that.
+# ONE enumerator, used by the real list AND by control 3 below. It is a function
+# specifically so the control cannot drift from the thing it guards: an earlier
+# draft of control 3 ran its own copy of this query, which meant editing the real
+# enumeration left the control green -- a check that cannot fail, introduced by
+# the very commit that was fixing one.
+enumerate_py() {
+    git ls-files --cached --others --exclude-standard -- '*.py' ':!:private/**'
+}
+
+# ---- CONTROL 3: the ENUMERATION must reach an UNTRACKED file -----------------
+# Runs before the real list is built, because a list that omits files silently
+# is not worth counting. Found live 2026-08-09: `git ls-files` alone reported
+# "27 files, All checks passed!" while wl_checklist.py, the newest and second
+# largest module of the Stop-hook program, was untracked and never in the list.
+# The name is runtime-keyed so a crashed earlier run cannot make this pass by
+# leaving its specimen behind.
+enum_probe="enum_probe_$$_$(date +%s).py"
+cleanup_probe() { rm -f "$REPO_ROOT/$enum_probe"; }
+trap cleanup_probe EXIT
+printf 'x = 1\n' >"$REPO_ROOT/$enum_probe"
+if ! enumerate_py | grep -qx -- "$enum_probe"; then
+    echo "${RED}✗ CONTROL FAILED${NC}: the file enumeration did not return a planted" >&2
+    echo "  UNTRACKED Python file (${enum_probe}), so this gate is blind to exactly" >&2
+    echo "  the case that shipped on 2026-08-09. Refusing to judge the real files." >&2
+    exit 1
+fi
+cleanup_probe
+
 PY_FILES=()
 while IFS= read -r _f; do
     [[ -n "$_f" ]] && PY_FILES+=("$_f")
-done < <(git ls-files -- '*.py' ':!:private/**')
+done < <(enumerate_py)
 count="${#PY_FILES[@]}"
 
 # The floor is a real number, not 1. The interesting failure is a glob that
@@ -109,7 +146,10 @@ fi
 # ancestry, then point --config at it explicitly. That way this also proves the
 # config path the real run uses actually resolves.
 control_dir="$(mktemp -d)"
-trap 'rm -rf "$control_dir"' EXIT
+# Covers the probe too: bash EXIT traps REPLACE rather than stack, so this line
+# silently disarms cleanup_probe above. The probe is already removed by here, but
+# a future reordering would otherwise leak a stray .py into a SHARED worktree.
+trap 'rm -rf "$control_dir"; cleanup_probe' EXIT
 cat >"$control_dir/control.py" <<'PYEOF'
 def planted():
     # F821: `undefined_on_purpose` is never bound anywhere.

--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -1,5 +1,5 @@
 ---
-description: Distill the current session into a durable handoff - a docs/<slug>/ design suite (README + numbered docs + PROMPT.md), a seeded program-state dir (MANIFEST/reports/checkpoints), and a memory pointer - then print the concise pointer prompt for a fresh session. First token of the arguments is the slug; if docs/<slug>/ already exists this runs in update mode (refresh stale sections, regenerate PROMPT.md, report the delta).
+description: Distill the current session into a durable handoff - a hook-enforced docs/<slug>/CHECKLIST.md, a docs/<slug>/ design suite (README + numbered docs + PROMPT.md), a seeded program-state dir (MANIFEST/reports/checkpoints), and a memory pointer - then print the concise pointer prompt for a fresh session. First token of the arguments is the slug; if docs/<slug>/ already exists this runs in update mode (refresh stale sections, re-verify the checklist, regenerate PROMPT.md, report the delta).
 argument-hint: "[slug] (kebab-case dir under docs/; omit and one is proposed; existing dir = update mode)"
 disable-model-invocation: true
 allowed-tools: Bash(ls:*), Bash(git branch:*), Bash(git status:*), Bash(date:*)
@@ -19,6 +19,13 @@ if genuinely ambiguous. If `docs/<slug>/` exists: UPDATE mode (re-verify and ref
 stale sections, regenerate PROMPT.md wholesale, report exactly what changed).
 Otherwise CREATE mode.
 
+UPDATE mode also carries the checklist forward: re-verify every deliverable `file:`
+token against the tree, and append newly-discovered waves with fresh monotonic `wN`
+ids. Never delete an item, never renumber one, never un-tick one. A checklist already
+at `Status: done` that gains new waves flips back to `Status: executing`, and the
+report says so. `Status: superseded` is terminal: an abandoned program is left alone,
+not revived.
+
 ## Workflow
 
 1. **Inventory the session.** Collect: operator-locked decisions (verbatim, marked
@@ -33,10 +40,37 @@ Otherwise CREATE mode.
    Anything not re-verifiable is labeled a hypothesis. Never write a confident claim
    from memory; never trust a zero from an instrument without a planted control.
 
-3. **Write `docs/<slug>/` adaptively** (typical 3-7 files; do not pad):
+3. **Write `docs/<slug>/CHECKLIST.md` before any other file.** It is the first write
+   of the invocation, not a wrap-up at the end. `Status: producing`; `Owner:` your
+   8-char session prefix (the same one you tag worklist items with); one `dN` line per
+   deliverable you are about to write (README, `01-verified-context.md`, every
+   `NN-topic.md`, the execution guide, PROMPT.md, and the program-state `MANIFEST.md`
+   by its absolute `~` path); one `wN` line per wave in the README's `## Scope`, with
+   ids in the README's wave order. The grammar, so a fresh session need not look it up:
+
+   ```
+   # Handoff checklist: <slug>
+   Status: producing            <- producing|executing|done|superseded, in the first 10 lines
+   Owner: 99ccf057              <- 8-char session prefix, required while producing
+
+   ## Deliverables
+   - [ ] d1 file:docs/<slug>/README.md
+   - [ ] d2 file:docs/<slug>/PROMPT.md
+   - [ ] d3 file:~/.claude/projects/-home-muhammed-monorepo-console/programs/<slug>/MANIFEST.md
+
+   ## Waves
+   - [ ] w1 Wave A: <one-line title>
+   ```
+
+   Deliverables are file-verified: every `file:` path must exist and be non-empty, and
+   the tick is bookkeeping while the file is the truth. The Stop hook will not let this
+   session stop until every `file:` verifies AND you flip `Status: producing` to
+   `Status: executing` -- that is exactly why it is written first.
+
+4. **Write `docs/<slug>/` adaptively** (typical 3-7 files; do not pad):
    - `README.md` with the mandatory sections: title + scope paragraph (names the
      source session, links the memory file and program-state dir); `## Read order`;
-     `## Non-negotiable working ethos` (see step 4); `## Staffing` (see step 5);
+     `## Non-negotiable working ethos` (see step 5); `## Staffing` (see step 6);
      `## Scope` with waves and an `**Explicitly OUT**` ledger; `## Operator decision
      points (ask EARLY, in one round)` numbered with RECOMMENDED defaults.
    - `01-verified-context.md` always: verified current state, the holes/numbers, an
@@ -48,7 +82,7 @@ Otherwise CREATE mode.
      `AS-BUILT` / `frozen` / `forward-looking` when documenting as-built work. Add a
      `spec/` subdir only for large as-built suites.
 
-4. **Ethos block (baked, copy into every README):** Validate, do not believe: every
+5. **Ethos block (baked, copy into every README):** Validate, do not believe: every
    file:line reference is a hypothesis, re-verify against the tree, run the real
    thing, read stdout and stderr separately, plant a control before trusting any
    zero. Everything stays local and uncommitted: no commit/branch/push/PR unless the
@@ -56,7 +90,7 @@ Otherwise CREATE mode.
    Testing and concurrency support are first-class deliverables. NO em dashes in any
    authored text, in any language.
 
-5. **Staffing section (baked, its own section in README AND PROMPT.md):** Opus is
+6. **Staffing section (baked, its own section in README AND PROMPT.md):** Opus is
    the default for coding sub-agents. **Fable for the challenging pieces AND for
    planning agents.** Sonnet for all translation/naturalization work. At most 2
    concurrent writers with disjoint file ownership stated verbatim in every prompt;
@@ -64,7 +98,7 @@ Otherwise CREATE mode.
    against the artifacts before anything builds on it. The handoff NAMES which
    pieces are Fable-tier.
 
-6. **Seed durable program state** at
+7. **Seed durable program state** at
    `~/.claude/projects/-home-muhammed-monorepo-console/programs/<slug>/`:
    `MANIFEST.md` skeleton (model policy line; wave/status table; active-agents table
    with their `reports/` paths; discovered-bugs list; checkpoints notes) plus empty
@@ -76,31 +110,43 @@ Otherwise CREATE mode.
    patches land in `checkpoints/` (a host reboot once destroyed a /tmp scratchpad;
    durable state exists because of that).
 
-7. **Wire in the worklist Stop hook** (fail-closed): the execution guide and
+8. **Wire in the worklist Stop hook** (fail-closed): the execution guide and
    PROMPT.md instruct the implementing session to seed the shared worklist at start
-   (path via `.claude/hooks/stop/worklist.py --path`): one `- [ ]` item per wave,
-   tagged with the session prefix; decision points asked in one early round and
-   parked as `- [?]` if deferred; background delegation held as
-   `- [>] (prefix) until:<ISO>Z ...` leases renewed on wake; `- [x]` only after
-   probing the artifact; queued future waves stay NOTE lines promoted when they
-   start.
+   (path via `.claude/hooks/stop/worklist.py --path`): one item per wave, tagged with
+   the session prefix and carrying the checklist token, seeded as
+   `worklist.py --add <me> 'cl:<slug>/<wN> <wave title>'`. The token is what links the
+   store item to the checklist: the hook blocks ANY stopping session while a wave is
+   neither ticked in `CHECKLIST.md` nor covered by such an item, because an uncovered
+   wave is unclaimed work. Tick the `wN` box only after the store item is ticked with
+   probed evidence, and once every wave is ticked set `Status: done`. Decision points
+   are asked in one early round and parked as `- [?]` if deferred; background
+   delegation held as `- [>] (prefix) until:<ISO>Z ...` leases renewed on wake;
+   `- [x]` only after probing the artifact; queued future waves stay NOTE lines
+   promoted when they start.
 
-8. **Write `docs/<slug>/PROMPT.md` and print it verbatim in chat.** Contents, kept
+9. **Write `docs/<slug>/PROMPT.md` and print it verbatim in chat.** Contents, kept
    concise: mission sentence pointing at `docs/<slug>/README.md` and its read order;
    two-sentence validation ethos; ask-the-decision-points-early instruction; the
-   staffing section from step 5; the program-state paths from step 6; the worklist
-   seeding instruction from step 7; the local-and-uncommitted line; the testing
+   staffing section from step 6; the program-state paths from step 7; the
+   `docs/<slug>/CHECKLIST.md` path plus the worklist seeding instruction from step 8,
+   spelled out with the literal token format `cl:<slug>/<wN>` so the consuming session
+   can seed without reading anything else; the local-and-uncommitted line; the testing
    emphasis; the definition of done.
 
-9. **Append ONE pointer line** to the auto-memory `MEMORY.md` (title, docs path,
-   one-line hook). Update mode: refresh the existing line instead of adding another.
+10. **Append ONE pointer line** to the auto-memory `MEMORY.md` (title, docs path,
+    one-line hook). Update mode: refresh the existing line instead of adding another.
 
-10. **Report**: file list with sizes; em-dash scan over every new/changed file
-    (must be zero, all languages); the seeded program-state paths; the printed
-    prompt. In update mode, also the section-level delta.
+11. **Report**: file list with sizes; em-dash scan over every new/changed file
+    (must be zero, all languages); the seeded program-state paths; the checklist
+    verification state, meaning every `file:` token verified against the tree and
+    `Status:` flipped from producing to executing; the printed prompt. In update
+    mode, also the section-level delta and the checklist delta (new `wN` ids
+    appended, `file:` tokens re-verified, any `done -> executing` flip).
 
 ## Constraints
 
-This invocation writes ONLY under `docs/<slug>/`, the `programs/<slug>/` state dir,
-and the single MEMORY.md pointer line. It never touches code and never commits. If it
-delegates verification sweeps, they are held as leased `- [>]` worklist items.
+This invocation writes ONLY under `docs/<slug>/` (including `docs/<slug>/CHECKLIST.md`,
+which is written first and is the one file this command must never skip), the
+`programs/<slug>/` state dir, and the single MEMORY.md pointer line. It never touches
+code and never commits. If it delegates verification sweeps, they are held as leased
+`- [>]` worklist items.

--- a/.claude/hooks/pre-edit/block-agent-state-shape.sh
+++ b/.claude/hooks/pre-edit/block-agent-state-shape.sh
@@ -1,26 +1,35 @@
 #!/usr/bin/env bash
-# Shape-guard for .agent/<branch>/STATE.md on the Edit/Write tool path.
+# Deny EVERY direct tool write to .agent/<branch>/STATE.md.
 #
 # WHY THIS EXISTS. The old compact-recovery handover lived at a TMPDIR path
 # nobody would ever open with Write, so a CLI-side refusal was a complete gate.
 # STATE.md lives at a normal repo path, and any agent reaches for Write first:
 # a CLI-only refusal is bypassed by the most natural tool in the box, and the
-# session bypassing it would not know it had. This guard is the half that
-# actually closes the hole (operator decision 2026-07-30: it ships WITH the
-# migration, not after).
+# session bypassing it would not know it had.
 #
-# Two rules, and the second is one the CLI could never enforce:
-#   1. Edit/MultiEdit/NotebookEdit on STATE.md -> DENY outright. STATE.md is
-#      REWRITTEN, never appended to or patched (.agent/README.md); partial
-#      edits are how a narrative document accretes stale layers.
-#   2. Write on STATE.md -> the same shape rule the Stop check reads with:
-#      250-4000 chars and a '## Next action' section. Kept in lockstep with
-#      wl_store.agent_state_shape; if the constants move there, move them here.
+# WHY THE SHAPE CHECK LEFT THIS FILE (2026-08-09). This guard used to DENY Edit
+# and merely shape-check Write: 250-4000 chars and a '## Next action' section,
+# the same rule the Stop check reads with. That was the right gate for a
+# document whose contract was "rewrite the whole thing every time". The
+# contract is now one OWNED SECTION PER SESSION, merged in place, because
+# rewrite-every-time met three live sessions in one checkout and a session
+# obeying a staleness nag destroyed a peer's entire state document.
+#
+# A shape-only shell guard cannot enforce merge semantics. A whole-file Write
+# can be perfectly shaped and still delete every peer's section -- exactly as
+# thoroughly as the old CLI did -- so a guard that measured its LENGTH was
+# waving through the only defect that matters. Only the CLI can merge, so the
+# CLI is the only writer.
+#
+# The escape hatches that matter survive: restoring a backup is `cp` in Bash,
+# and worklist.py is a script anyone can run. The residual is a Bash heredoc
+# straight onto the path, which no PreToolUse hook can see; that is handled by
+# the unowned-section rule in wl_store.agent_state_parse and the timestamp
+# fallback in agent_state_state, rather than pretended away.
 #
 # RULES.md and TRAPS.md are deliberately untouched: RULES.md is sharpened by
 # normal edits, TRAPS.md is appended by hand, and neither has a shape gate.
 IN=$(cat)
-TOOL=$(jq -r '.tool_name // empty' <<<"$IN" 2>/dev/null)
 FILE=$(jq -r '.tool_input.file_path // .tool_input.notebook_path // empty' <<<"$IN" 2>/dev/null)
 
 case "$FILE" in
@@ -28,33 +37,5 @@ case "$FILE" in
     *) exit 0 ;;
 esac
 
-if [[ "$TOOL" != "Write" ]]; then
-    echo "❌ BLOCKED: STATE.md is REWRITTEN, never appended to or patched (see .agent/README.md). Use Write with the full document, or worklist.py --state <me> with the body on stdin, which also records the freshness signature." >&2
-    exit 2
-fi
-
-CONTENT=$(jq -r '.tool_input.content // empty' <<<"$IN" 2>/dev/null)
-LEN=$(printf '%s' "$CONTENT" | awk '{gsub(/^[ \t]+|[ \t]+$/,"")} {n+=length($0)+1} END {print n+0}')
-if ((LEN < 250)); then
-    echo "❌ BLOCKED: this STATE.md is thin (${LEN} chars, minimum 250). A stub is not a recovery document; the next session inherits ONLY what is written here." >&2
-    exit 2
-fi
-# The cap SCALES with the number of `## SESSION` blocks, matching
-# wl_store.agent_state_max_chars. The document is per BRANCH but the budget is
-# per SESSION, and a flat cap left the second session ~1850 usable chars --
-# whose cheapest remedy is deleting the other session's block, the exact loss
-# this document warns about. Kept in lockstep with wl_store deliberately: this
-# guard fires on a direct Write, that one on `--state`, and a guard stricter
-# than the tool would block a body the tool accepts.
-BLOCKS=$(grep -ciE '^[ \t]*##[ \t]+SESSION\b' <<<"$CONTENT" || true)
-((BLOCKS < 1)) && BLOCKS=1
-MAXLEN=$((4000 * BLOCKS))
-if ((LEN > MAXLEN)); then
-    echo "❌ BLOCKED: this STATE.md is bloated (${LEN} chars, maximum ${MAXLEN} = ${BLOCKS} session block(s) x 4000). Standing rules belong in RULES.md and hard-won lessons in ../TRAPS.md; STATE.md carries only what is volatile." >&2
-    exit 2
-fi
-if ! grep -qiE '^[ \t]*#{1,6}[ \t]*next action\b' <<<"$CONTENT"; then
-    echo "❌ BLOCKED: this STATE.md has no '## Next action' section, which is the one thing it exists to answer. Length is a proxy for value; the next action IS the value." >&2
-    exit 2
-fi
-exit 0
+echo "❌ BLOCKED: STATE.md is not written by tools. It holds ONE OWNED SECTION PER SESSION, and only worklist.py can merge yours in without destroying a peer's. A whole-file Write deletes every other session's section, which is how a live campaign's state document was lost on 2026-08-09. Send YOUR SECTION'S BODY ALONE (250-4000 chars, with a '## Next action' section, no '## SESSION' heading -- the tool writes that) on stdin:  .claude/hooks/stop/worklist.py --state <your-prefix> <<'EOF' ... EOF   See .agent/README.md if present (that tree is gitignored, so a fresh clone will not have it; this message is the contract)." >&2
+exit 2

--- a/.claude/hooks/stop/test-worklist-v5.sh
+++ b/.claude/hooks/stop/test-worklist-v5.sh
@@ -1719,7 +1719,7 @@ say "answer
 ## Remaining
 | #7 | thing | pending, me |"
 task 7 pending "thing"
-age_state deadbeef -60                                    # stamped an hour AHEAD
+age_state deadbeef -60                                           # stamped an hour AHEAD
 touch -d '40 minutes ago' "$BASE/proj/.agent/agenttest/STATE.md" # the honest age
 check "44c FIRE: a future-stamped section falls back to mtime and goes stale" block "STATE.md is stale"
 # CONTROL 1: a stamp inside the tolerated skew is still TRUSTED, so this is a

--- a/.claude/hooks/stop/test-worklist-v5.sh
+++ b/.claude/hooks/stop/test-worklist-v5.sh
@@ -75,6 +75,14 @@ setup() {
     # the AMBIENT case rather than the leak: it is a real knob, so a value in the
     # operator's own shell would silently retune the streak under the suite.
     unset WORKLIST_BG_OUTPUT_DIR WORKLIST_HARNESS_PID WORKLIST_QUIET_WAKES
+    # The STATE.md reap knobs, reset for exactly the reason above. Case 29h
+    # points WORKLIST_PROJECTS_DIR at a fixture transcript dir to make a peer
+    # section reap-eligible; leaked forward, every later case would judge
+    # section liveness against that stale directory. Unset, wl_core.projects_dir
+    # falls back to ~/.claude/projects/<slug>, which does not exist for a
+    # mktemp fixture root, so it answers "" and no section is ever reaped by
+    # transcript age -- which is the hermetic default this suite needs.
+    unset WORKLIST_PROJECTS_DIR WORKLIST_DEAD_HOURS WORKLIST_ARCHIVE_HOURS
     # PINNED, NOT INHERITED. The hook no-ops when GITHUB_ACTIONS=true, so a suite
     # that inherits the ambient value passes locally and silently no-ops in CI,
     # where 30 cases came back with empty output and read as failures.
@@ -129,8 +137,93 @@ task() { # task <id> <status> <subject> [blockedBy-csv]
 # without the CLI: written by an older flow, hand-edited, by a raw Write, or
 # truncated by a full disk. So the shape cases plant the file and the refusal
 # gets its own case.
+#
+# SINCE THE SECTION FORMAT (2026-08-09), a plant with no `## SESSION` heading
+# is specifically a LEGACY document: agent_state_parse turns it into one
+# unowned section, and the read path judges that section as if it were the
+# caller's. That is deliberate and is what keeps every shape case below
+# meaningful without a stamped fixture -- but it also means these cases now
+# exercise the mtime FALLBACK rather than the heading stamp, so any case whose
+# subject is AGE must use age_state on a real stamped section instead.
 plant_state() { # plant_state <body>
     printf '%s' "$1" >"$BASE/proj/.agent/agenttest/STATE.md"
+}
+
+# The same raw plant, named for what the new cases use it for: a whole
+# DOCUMENT (possibly multi-section) placed on disk without going through the
+# merge, which is the only way to fabricate a peer's section for a read case.
+plant_doc() { # plant_doc <text>
+    printf '%s' "$1" >"$BASE/proj/.agent/agenttest/STATE.md"
+}
+
+mk_section() { # mk_section <owner> <minutes-ago> <body> -> one stamped section
+    python3 -c '
+import sys, time
+owner, mins, body = sys.argv[1], float(sys.argv[2]), sys.argv[3]
+stamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - mins * 60))
+sys.stdout.write("## SESSION %s %s\n\n%s\n" % (owner, stamp, body.strip()))
+' "$1" "$2" "$3"
+}
+
+section_now() { # section_now <owner> <body> -> one section stamped now
+    mk_section "$1" 0 "$2"
+}
+
+age_state() { # age_state <owner> <minutes-ago> -- backdate that section's stamp
+    # The heading stamp is the age source now, so `touch -d` no longer ages a
+    # section written by --state: it moves the file's mtime, which is only the
+    # FALLBACK for an unstamped section. A case that keeps touching the file
+    # would silently test the fallback instead of the rule, so this helper
+    # EXITS NON-ZERO when the owner's heading is not there rather than aging
+    # nothing and passing quietly.
+    python3 - "$BASE/proj/.agent/agenttest/STATE.md" "$1" "$2" <<'PYEOF'
+import re, sys, time
+path, owner, mins = sys.argv[1], sys.argv[2], float(sys.argv[3])
+stamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - mins * 60))
+text = open(path, encoding="utf-8").read()
+new, n = re.subn(
+    r"(?m)^(##[ \t]+SESSION[ \t]+%s\b)[ \t]*.*$" % re.escape(owner),
+    lambda m: m.group(1) + " " + stamp,
+    text,
+)
+if n != 1:
+    sys.exit("age_state: expected ONE '## SESSION %s' heading, found %d" % (owner, n))
+open(path, "w", encoding="utf-8").write(new)
+PYEOF
+}
+
+section_of() { # section_of <owner> -- that section rendered, or nothing
+    python3 - "$(dirname "$HOOK")" "$BASE/proj/.agent/agenttest/STATE.md" "$1" <<'PYEOF'
+import os, sys
+sys.path.insert(0, sys.argv[1])
+import wl_store as S
+try:
+    text = open(sys.argv[2], encoding="utf-8").read()
+    mtime = os.path.getmtime(sys.argv[2])
+except OSError:
+    sys.exit(0)
+for s in S.agent_state_parse(text, mtime):
+    if s["owner"] == sys.argv[3]:
+        sys.stdout.write(S.agent_state_render([s]))
+PYEOF
+}
+
+state_as() { # state_as <prefix> <body> -- merge a section as ANOTHER session
+    # LOUD ON FAILURE, deliberately. The first draft swallowed stderr, and a
+    # peer body two characters under the 250-char floor was silently refused:
+    # three cases then asserted the ABSENCE of a section that had never been
+    # written, and two of them would have passed for the wrong reason. A helper
+    # whose failure is invisible turns every case built on it into a vacuity.
+    local out rc
+    out="$(printf '%s' "$2" |
+        TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" WORKLIST_TASKS_DIR="$BASE/tasks" \
+            WORKLIST_AGENT_BRANCH=agenttest WORKLIST_SESSION_ID="$(peer_id "$1")" \
+            python3 "$HOOK" --state "$1" 2>&1)"
+    rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+        fail "FIXTURE BROKEN: state_as $1 was refused (rc=$rc): ${out:0:200}"
+        return 1
+    fi
 }
 
 # A STATE.md fresh enough and well-shaped enough to satisfy the gate. Keeps the
@@ -309,6 +402,40 @@ pass() {
 fail() {
     echo "  FAIL: $1"
     FAIL=$((FAIL + 1))
+}
+
+run_as() { # run_as <prefix> -- drive a Stop event as ANOTHER live session
+    # The whole point of the per-session STATE.md rule is that two sessions on
+    # one branch get DIFFERENT verdicts, and a suite that can only ever stop as
+    # `deadbeef` cannot observe that. Both the event's session_id and
+    # WORKLIST_SESSION_ID move together, exactly as they do for a real peer.
+    local sid
+    sid="$(peer_id "$1")"
+    printf '{"session_id":"%s","cwd":"%s","transcript_path":"%s","session_crons":%s,"background_tasks":%s}' \
+        "$sid" "$BASE/proj" "$BASE/t.jsonl" "${CRONS:-[]}" "${BG:-[]}" |
+        TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" WORKLIST_TASKS_DIR="$BASE/tasks" \
+            WORKLIST_SESSION_ID="$sid" \
+            WORKLIST_AGENT_BRANCH="${WORKLIST_AGENT_BRANCH-agenttest}" \
+            WORKLIST_JUDGE="${JUDGE_MODE:-off}" GITHUB_ACTIONS="${GHA:-}" \
+            python3 "$HOOK" 2>"$BASE/err.txt"
+}
+
+check_as() { # check_as <prefix> <label> <expect-decision> <must-contain>
+    local who="$1" label="$2" want="$3" needle="$4" out
+    out="$(run_as "$who")"
+    local got
+    got="$(python3 -c 'import json,sys
+raw=sys.stdin.read().strip()
+print(json.loads(raw).get("decision","allow") if raw else "allow")' <<<"$out" 2>/dev/null)"
+    if [[ "$got" == "$want" ]] && grep -qF "$needle" <<<"$out"; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label (want=$want got=$got, needle '$needle' $(grep -qF "$needle" <<<"$out" && echo present || echo MISSING))"
+        echo "        out: ${out:0:220}"
+        [[ -s "$BASE/err.txt" ]] && echo "        err: $(head -c 200 "$BASE/err.txt")"
+        FAIL=$((FAIL + 1))
+    fi
 }
 
 check() { # check <label> <expect-decision> <must-contain>
@@ -550,6 +677,62 @@ else
     FAIL=$((FAIL + 1))
 fi
 
+echo "== 21b. PostCompact puts MY section first and LABELS the peer's =="
+# A compacted session reads top-down, and the block it must act on is its own.
+# The peer's section rides along because this checkout runs several sessions at
+# once and a peer's section is the only place the reader learns which
+# uncommitted files are not theirs to sweep -- but it must be unmistakably
+# marked as not theirs to rewrite, or the briefing itself becomes the next
+# clobber's instruction.
+setup
+hand_now
+PEER_BODY='Session cafe1234 owns packages/cli/src/services/licensing and the two drill scripts under scripts/dev, all of them uncommitted. A git add -A from any other session in this checkout would sweep them into somebody else s commit, which is the cross-session fact that has no home in a per-session file.
+
+## Next action
+Finish the renewal drill and report the soft-claim slot count.'
+state_as cafe1234 "$PEER_BODY"
+out="$(printf '{"session_id":"%s","cwd":"%s"}' "$SID" "$BASE/proj" |
+    TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" WORKLIST_AGENT_BRANCH=agenttest \
+        python3 "$HOOK" --post-compact 2>/dev/null)"
+OWN_AT="$(python3 -c "import sys; print(sys.stdin.read().find('ci-overhaul session'))" <<<"$out")"
+PEER_AT="$(python3 -c "import sys; print(sys.stdin.read().find('SESSION cafe1234'))" <<<"$out")"
+if [[ "$OWN_AT" -ge 0 && "$PEER_AT" -gt "$OWN_AT" ]] &&
+    grep -qF "NOT YOURS" <<<"$out" && grep -qF "owns packages/cli" <<<"$out"; then
+    pass "21b: own section first, peer's after it and labelled NOT YOURS"
+else
+    fail "21b: ordering/labelling wrong (own@$OWN_AT peer@$PEER_AT): ${out:0:300}"
+fi
+# CONTROL: with no peer section there is no peers block at all, so the label is
+# information about the file rather than boilerplate on every briefing.
+setup
+hand_now
+out="$(printf '{"session_id":"%s","cwd":"%s"}' "$SID" "$BASE/proj" |
+    TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" WORKLIST_AGENT_BRANCH=agenttest \
+        python3 "$HOOK" --post-compact 2>/dev/null)"
+if grep -qF "ci-overhaul session" <<<"$out" && ! grep -qF "OTHER SESSIONS' SECTIONS" <<<"$out"; then
+    pass "21b CONTROL: a solo document produces no peers block"
+else
+    fail "21b CONTROL: a peers block appeared with no peers: ${out:0:300}"
+fi
+
+echo "== 20b. PostCompact with NO section of MY OWN still hands back the peer's =="
+# Before sections, this path returned NO state content whatsoever: a compacted
+# session on a branch where only a peer had written was told to reconstruct
+# from what survived, while the peer's section sat unread in the file in front
+# of it. The instruction to write one must survive too, or this becomes a way
+# to inherit a peer's document as your own.
+setup
+state_as cafe1234 "$PEER_BODY"
+out="$(printf '{"session_id":"%s","cwd":"%s"}' "$SID" "$BASE/proj" |
+    TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" WORKLIST_AGENT_BRANCH=agenttest \
+        python3 "$HOOK" --post-compact 2>/dev/null)"
+if grep -qF "NO STATE.md" <<<"$out" && grep -qF "owns packages/cli" <<<"$out" &&
+    grep -qF "NOT YOURS" <<<"$out"; then
+    pass "20b: the own-missing instruction AND the peer's body are both returned"
+else
+    fail "20b: the missing branch dropped the peer's section: ${out:0:300}"
+fi
+
 echo "== 22. an UNREADABLE transcript blames the HOOK, not the session =="
 setup
 brief_now
@@ -724,35 +907,13 @@ refuse() { # refuse <label> <body-producing-command...>
     fi
 }
 refuse "an over-long body" python3 -c "print('## Next action: go ' + 'x'*4100)"
-# The cap is PER SESSION but the document is PER BRANCH: with a flat 4000 a
-# second session got `4000 minus the neighbour's block` and was refused eleven
-# times in one session, and its cheapest remedy was DELETING the other block --
-# the very loss this document exists to prevent. So the cap scales with the
-# number of `## SESSION` headings. This body would be refused under a flat cap
-# and must be ACCEPTED now; the control immediately after proves the scaled cap
-# still refuses, so this is not a blanket lift.
-two_session_body() {
-    python3 -c "
-print('## SESSION A')
-print('a'*3000)
-print('## SESSION B')
-print('b'*2500)
-print('## Next action')
-print('carry on')"
-}
-if two_session_body | TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" \
-    WORKLIST_AGENT_BRANCH=agenttest python3 "$HOOK" --state deadbeef >/dev/null 2>&1; then
-    pass "a 2-session body over the flat cap is accepted (the cap scales per block)"
-else
-    fail "the scaled cap regressed: a 2-session body under 2x4000 was refused"
-fi
-refuse "a 2-session body over the SCALED cap" python3 -c "
-print('## SESSION A')
-print('a'*4200)
-print('## SESSION B')
-print('b'*4200)
-print('## Next action')
-print('go')"
+# The cap is FLAT again, and 29g below is why that is now safe. It was briefly
+# SCALED by the number of `## SESSION` headings, because the budget was per
+# session while the document was per branch and a flat cap's cheapest remedy
+# was deleting the neighbour's block. Since --state merges one owned section,
+# the budget and the document have the same scope and a multi-section body is
+# not an over-budget document at all -- it is a whole-document paste, which is
+# refused for a different and stronger reason.
 refuse "a stub body" printf 'wip'
 refuse "an aimless body (no Next action section)" python3 -c "print('y'*400)"
 # CONTROL: a well-shaped body must still be written, or the guard is just a
@@ -775,6 +936,214 @@ if cmp -s "$BASE/state.good" "$STATE_FILE"; then
 else
     fail "a refused rewrite MUTATED the previous STATE.md"
 fi
+
+echo "== 29f. TWO sessions share one branch and BOTH sections survive =="
+# THE INCIDENT, 2026-08-09. Three sessions were live in one checkout on main.
+# The staleness gate nagged 99ccf057 about a document 2fd369e0 owned, 99ccf057
+# rewrote it, and a peer's entire state document -- a live canary campaign,
+# attempt 6 in flight, five flag flips, an operator-owned design question --
+# was destroyed. It came back only because the single-slot .prev backup was
+# read before the next write overwrote it.
+#
+# The assertion is a BYTE COMPARISON of A's rendered section across B's write,
+# not an allow: an allow would prove the gate was satisfied, and the thing that
+# failed was never the gate.
+setup
+brief_now
+hand_now # A = deadbeef
+A_BEFORE="$(section_of deadbeef)"
+B_BODY='This is session B, running the licensing drill on a fork of the bench universe, with the mint tool staged and the activation cap already lifted to five. Nothing here overlaps session A, and losing it would cost the drill.
+
+## Next action
+Re-run the license-e2e battery against the fork and read the failure reason verbatim.'
+state_as cafe1234 "$B_BODY"
+A_AFTER="$(section_of deadbeef)"
+if [[ -n "$A_BEFORE" && "$A_BEFORE" == "$A_AFTER" ]]; then
+    pass "29f: a peer's write leaves A's section byte-identical, stamp included"
+else
+    fail "29f: B's write MUTATED A's section: before='${A_BEFORE:0:80}' after='${A_AFTER:0:80}'"
+fi
+if grep -qF "This is session B" "$STATE_FILE" && grep -qF "ci-overhaul session" "$STATE_FILE"; then
+    pass "29f: the merged document carries BOTH sections"
+else
+    fail "29f: a section is missing from the merged document: $(head -c 200 "$STATE_FILE")"
+fi
+# CONTROL: B writing AGAIN replaces only B's section. Without this the case
+# would pass on a tool that merely refused to write anything at all.
+B_ONE="$(section_of cafe1234)"
+sleep 1 # so an advanced stamp is observable at second resolution
+state_as cafe1234 "${B_BODY/session B/session B, round two}"
+if [[ "$(section_of deadbeef)" == "$A_BEFORE" ]] &&
+    [[ "$(section_of cafe1234)" != "$B_ONE" ]] &&
+    grep -qF "round two" "$STATE_FILE"; then
+    pass "29f CONTROL: a second write replaces only its own section, A untouched"
+else
+    fail "29f CONTROL: the second write hit the wrong section"
+fi
+
+echo "== 29g. --state REFUSES a body carrying a '## SESSION' heading =="
+# The old habit is pasting the WHOLE document, and that habit is what destroyed
+# a peer's document. The tool now writes the heading itself, so a body with one
+# in it is a whole-document paste; refusing teaches the contract at zero cost,
+# because the previous document is untouched.
+setup
+brief_now
+hand_now
+cp "$STATE_FILE" "$BASE/state.before29g"
+WHOLE_DOC="$(
+    cat <<EOF
+## SESSION deadbeef 2026-08-09T18:30:00Z
+
+$STATE_BODY
+EOF
+)"
+out="$(printf '%s' "$WHOLE_DOC" | TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" \
+    WORKLIST_AGENT_BRANCH=agenttest python3 "$HOOK" --state deadbeef 2>&1)"
+rc=$?
+if [[ "$rc" -ne 0 ]] && grep -qF "looks like the WHOLE document" <<<"$out"; then
+    pass "29g FIRE: a body with a '## SESSION' heading is refused, naming the contract"
+else
+    fail "29g: a whole-document paste was accepted: rc=$rc '${out:0:200}'"
+fi
+if cmp -s "$BASE/state.before29g" "$STATE_FILE"; then
+    pass "29g: the refusal left the document byte-identical"
+else
+    fail "29g: a REFUSED whole-document write still mutated the document"
+fi
+# CONTROL: the same body WITHOUT the heading is accepted, so the refusal keys
+# on the heading and not on the body being long or familiar.
+if printf '%s' "$STATE_BODY" | TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" \
+    WORKLIST_AGENT_BRANCH=agenttest python3 "$HOOK" --state deadbeef >/dev/null 2>&1; then
+    pass "29g CONTROL: the same body without the heading is accepted"
+else
+    fail "29g CONTROL: the heading check refused a plain section body"
+fi
+
+echo "== 29h. a DEAD peer's section is reaped, and archived BEFORE it is dropped =="
+# Reaping is the one path that deletes content nobody chose to delete, so it is
+# the one path with an append-only archive rather than a single slot. Liveness
+# is the repo's existing notion (owner_age_hours over the transcript dir), with
+# the section's own stamp as the fallback for an owner that has no transcript.
+setup
+brief_now
+hand_now
+mkdir -p "$BASE/projects"
+export WORKLIST_PROJECTS_DIR="$BASE/projects"
+DEAD_BODY='Session ghost1234 was driving the ceph cutover rehearsal and has not been seen since. Its last recorded position is the RBD snapshot step on carrier two, with the node sync verified and the fork not yet taken.
+
+## Next action
+Take the fork once node sync is confirmed on all three carriers.'
+LIVE_BODY='Session live5678 is watching the nightly on main and is very much alive, which is the whole point of this control: an age in the DOCUMENT must not outvote a transcript that is still being written.
+
+## Next action
+Read the nightly job log and diagnose any red.'
+plant_doc "$(section_of deadbeef)
+$(mk_section ghost1234 1800 "$DEAD_BODY")
+$(mk_section live5678 1800 "$LIVE_BODY")"
+: >"$BASE/projects/live5678-1111-2222-3333-444444444444.jsonl" # a fresh transcript
+REAPED="$(TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" python3 "$HOOK" --path)"
+REAPED="${REAPED%.md}.agentstate.reaped.agenttest.md"
+age_state deadbeef 1800 # the writer's OWN section is 30h old too
+out="$(printf '%s' "$STATE_BODY" | TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" \
+    WORKLIST_TASKS_DIR="$BASE/tasks" WORKLIST_AGENT_BRANCH=agenttest \
+    python3 "$HOOK" --state deadbeef 2>&1)"
+if ! grep -qF "ghost1234" "$STATE_FILE" && grep -qF "Session ghost1234" "$REAPED" 2>/dev/null; then
+    pass "29h FIRE: the dead peer's section is gone from STATE.md and present in the archive"
+else
+    fail "29h: reap/archive wrong (in doc: $(grep -c ghost1234 "$STATE_FILE"), archive: $(head -c 80 "$REAPED" 2>&1))"
+fi
+if grep -qF "Session live5678" "$STATE_FILE"; then
+    pass "29h CONTROL 1: a peer with a fresh transcript is NOT reaped despite a 30h stamp"
+else
+    fail "29h CONTROL 1: a LIVE peer's section was reaped"
+fi
+# CONTROL 2 asserts the ABSENCE of the writer from the archive, not the
+# presence of its section in the document: the write re-adds its own section
+# either way, so a presence check would pass even on a tool that reaped it
+# first and then wrote it back with the old body lost.
+if [[ "$(grep -c '## SESSION deadbeef' "$STATE_FILE")" == "1" ]] &&
+    ! grep -qF "SESSION deadbeef" "$REAPED" 2>/dev/null; then
+    pass "29h CONTROL 2: the writer's own 30h-old section is never reaped"
+else
+    fail "29h CONTROL 2: the writer reaped or duplicated its own section: $(head -c 200 "$STATE_FILE")"
+fi
+if grep -qF "sections REAPED as dead" <<<"$out" && grep -qF "$REAPED" <<<"$out"; then
+    pass "29h: the write names what it reaped and where the archive went"
+else
+    fail "29h: the reap was silent: '${out:0:220}'"
+fi
+unset WORKLIST_PROJECTS_DIR
+
+echo "== 29i. a LEGACY single-section document is ADOPTED, never destroyed =="
+# Three checkouts hold a pre-section STATE.md on disk right now. The first
+# merge on such a branch must keep that text, because it may be an in-flight
+# peer's only record -- which is exactly the loss this whole change is about.
+setup
+brief_now
+LEGACY_BODY='This document predates the section format entirely. It belongs to whichever session wrote it last, it has no heading, and if the first sectioned write deletes it then this change has reproduced the very incident it was built to prevent.
+
+## Next action
+Preserve me verbatim under a legacy heading.'
+plant_doc "$LEGACY_BODY"
+printf '%s' "$STATE_BODY" | TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" \
+    WORKLIST_TASKS_DIR="$BASE/tasks" WORKLIST_AGENT_BRANCH=agenttest \
+    python3 "$HOOK" --state deadbeef >/dev/null 2>&1
+if grep -qF "## SESSION legacy" "$STATE_FILE" && grep -qF "predates the section format" "$STATE_FILE" &&
+    grep -qF "## SESSION deadbeef" "$STATE_FILE"; then
+    pass "29i FIRE: the legacy text survives under a legacy heading beside the new section"
+else
+    fail "29i: the legacy document was lost: $(head -c 250 "$STATE_FILE")"
+fi
+# CONTROL: aged past the dead horizon it is REAPED -- into the archive, never
+# into nothing. Adoption is a grace period, not a permanent squatter.
+mkdir -p "$BASE/projects"
+export WORKLIST_PROJECTS_DIR="$BASE/projects"
+REAPED="$(TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" python3 "$HOOK" --path)"
+REAPED="${REAPED%.md}.agentstate.reaped.agenttest.md"
+age_state legacy 1800
+printf '%s' "$STATE_BODY" | TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" \
+    WORKLIST_TASKS_DIR="$BASE/tasks" WORKLIST_AGENT_BRANCH=agenttest \
+    python3 "$HOOK" --state deadbeef >/dev/null 2>&1
+if ! grep -qF "predates the section format" "$STATE_FILE" &&
+    grep -qF "predates the section format" "$REAPED" 2>/dev/null; then
+    pass "29i CONTROL: an aged legacy section is reaped INTO THE ARCHIVE, not into nothing"
+else
+    fail "29i CONTROL: aged legacy handling wrong (doc: $(grep -c predates "$STATE_FILE"), archive: $(grep -c predates "$REAPED" 2>/dev/null))"
+fi
+unset WORKLIST_PROJECTS_DIR
+
+echo "== 29j. a MALFORMED document is never silently replaced =="
+# Fail closed: the parser must degrade rather than discard. A document that
+# yields no usable section is still SOMEBODY'S text, and the write that lands
+# beside it must leave it recoverable from the document itself and from .prev.
+setup
+brief_now
+JUNK='half a sentence with no heading and no next action, well under the floor'
+plant_doc "$JUNK"
+BACKUP="$(TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" python3 "$HOOK" --path)"
+BACKUP="${BACKUP%.md}.agentstate.prev.agenttest.md"
+printf '%s' "$STATE_BODY" | TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" \
+    WORKLIST_TASKS_DIR="$BASE/tasks" WORKLIST_AGENT_BRANCH=agenttest \
+    python3 "$HOOK" --state deadbeef >/dev/null 2>&1
+if grep -qF "$JUNK" "$STATE_FILE"; then
+    pass "29j: an unparseable body is preserved in the document, not discarded"
+else
+    fail "29j: the malformed body vanished: $(head -c 200 "$STATE_FILE")"
+fi
+if [[ "$(cat "$BACKUP" 2>/dev/null)" == "$JUNK" ]]; then
+    pass "29j: and the original bytes are also in the .prev backup"
+else
+    fail "29j: .prev does not hold the original: '$(head -c 80 "$BACKUP" 2>&1)'"
+fi
+# CONTROL: the caller's own verdict is unaffected by the junk beside it. The
+# junk is under the thin floor, and a shape check that judged the whole FILE
+# would call this document thin and block a session whose own section is fine.
+task 7 pending "thing"
+say "answer
+
+## Remaining
+- #7 thing (pending)"
+check "29j CONTROL: a peer's malformed text never blocks my own good section" allow ""
 
 echo "== 29e. a SHORT or body-less --state refuses instead of HANGING =="
 # REGRESSION GATE for the defect session 4c3e095a reported as #7c1c2629 and
@@ -823,12 +1192,19 @@ else
     fail "the absent-stdin branch swallowed the thin diagnosis: '${thin_out:0:200}'"
 fi
 
-echo "== 29c. a clobbered STATE.md is RECOVERABLE from the backup =="
-# Two live sessions share one branch, and --state is last-write-wins by design.
+echo "== 29c. the OUTGOING document is recoverable from the backup =="
+# Two live sessions share one branch, and --state used to be last-write-wins.
 # What was not by design is that the loss was permanent: session 84611aab
 # replaced session b9491d9c's 0-minute-old document twice, and neither body
 # could be recovered -- the event log stores item TEXT, never STATE bodies.
-# The write path now keeps exactly one previous body beside the lock.
+# The write path keeps exactly one previous DOCUMENT beside the lock.
+#
+# Since the merge (2026-08-09) a peer write cannot clobber anything, so this
+# case is no longer about a clobber: 29f owns that property. What is left for
+# the backup to cover is a bug in the MERGE itself, which is why the copy is of
+# the whole outgoing document and why one slot is enough. The assertions moved
+# from `== $VICTIM` to "contains VICTIM", because the outgoing document now
+# holds every section rather than just the one being replaced.
 setup
 brief_now
 hand_now # writes STATE_BODY
@@ -847,24 +1223,24 @@ printf '%s' "$VICTIM" |
 out="$(printf '%s' "$STATE_BODY" |
     TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" WORKLIST_AGENT_BRANCH=agenttest \
         WORKLIST_SESSION_ID="$(peer_id cafe1234)" python3 "$HOOK" --state cafe1234 2>&1)"
-if [[ "$(cat "$BACKUP" 2>/dev/null)" == "$VICTIM" ]]; then
-    pass "the clobbered body is byte-recoverable from the backup"
+if grep -qF "PR #547 merged to main at 01:30Z" "$BACKUP" 2>/dev/null; then
+    pass "the outgoing document is recoverable from the backup"
 else
-    fail "the backup does not hold the clobbered body: '$(head -c 120 "$BACKUP" 2>&1)'"
+    fail "the backup does not hold the outgoing document: '$(head -c 120 "$BACKUP" 2>&1)'"
 fi
 # The backup must be the OUTGOING document, never the incoming one -- a copy
 # taken after os.replace would look like a backup and restore nothing.
-if [[ "$(cat "$BACKUP" 2>/dev/null)" != "$STATE_BODY" ]]; then
-    pass "CONTROL: the backup is the outgoing body, not the one just written"
+if ! grep -qF "Round 23 went red" "$BACKUP" 2>/dev/null; then
+    pass "CONTROL: the backup is the outgoing document, not the one just written"
 else
     fail "the backup captured the INCOMING body; restoring it is a no-op"
 fi
-# The session that destroyed the document has to be TOLD where the copy went,
-# in the same line that tells it something was replaced.
-if grep -qF "previous body saved to" <<<"$out" && grep -qF "$BACKUP" <<<"$out"; then
+# The writing session has to be TOLD where the copy went, in the same line that
+# tells it something was there before.
+if grep -qF "previous document saved to" <<<"$out" && grep -qF "$BACKUP" <<<"$out"; then
     pass "the success line names the backup path"
 else
-    fail "the clobber was silent about recovery: '${out:0:200}'"
+    fail "the write was silent about recovery: '${out:0:200}'"
 fi
 # CONTROL: the FIRST write on a branch replaces nothing, so it must not claim
 # a backup exists -- an unconditional path in that line would send the next
@@ -873,7 +1249,7 @@ rm -f "$STATE_FILE" "$BACKUP"
 out="$(printf '%s' "$STATE_BODY" |
     TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" WORKLIST_AGENT_BRANCH=agenttest \
         python3 "$HOOK" --state deadbeef 2>&1)"
-if grep -qF "previous body saved to" <<<"$out"; then
+if grep -qF "previous document saved to" <<<"$out"; then
     fail "a first write with nothing to replace still advertised a backup"
 else
     pass "CONTROL: a first write advertises no backup"
@@ -907,8 +1283,9 @@ printf '%s' "$STATE_BODY" |
 printf '%s' "$VICT_A" |
     TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" WORKLIST_AGENT_BRANCH=otherbranch \
         WORKLIST_SESSION_ID="$(peer_id cafe1234)" python3 "$HOOK" --state cafe1234 >/dev/null 2>&1
-if [[ "$(cat "$BACKUP_A" 2>/dev/null)" == "$VICT_A" ]] &&
-    [[ "$(cat "$BACKUP_B" 2>/dev/null)" == "$STATE_BODY" ]]; then
+if grep -qF "Recover me from the branch-A backup" "$BACKUP_A" 2>/dev/null &&
+    grep -qF "Round 23 went red" "$BACKUP_B" 2>/dev/null &&
+    ! grep -qF "Recover me from the branch-A backup" "$BACKUP_B" 2>/dev/null; then
     pass "29d: each branch keeps its own backup; a write elsewhere cannot destroy it"
 else
     fail "29d: cross-branch write clobbered the backup (A: $(head -c 40 "$BACKUP_A" 2>&1))"
@@ -920,7 +1297,7 @@ out="$(printf '%s' "$STATE_BODY" |
     TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" WORKLIST_AGENT_BRANCH=agenttest \
         python3 "$HOOK" --state deadbeef 2>&1)"
 rmdir "$BACKUP_A" 2>/dev/null
-if grep -qF "backup copy FAILED" <<<"$out" && ! grep -qF "previous body saved to" <<<"$out"; then
+if grep -qF "backup copy FAILED" <<<"$out" && ! grep -qF "previous document saved to" <<<"$out"; then
     pass "29d CONTROL: a failed backup write warns instead of naming a phantom file"
 else
     fail "29d CONTROL: the failed backup was advertised as saved: '${out:0:200}'"
@@ -1225,7 +1602,8 @@ check "no found-not-fixed list, no complaint" allow ""
 
 echo "== 44. a STATE.md just over the limit is STALE (the limit is load-bearing) =="
 # NOTE: 44 and 45 are ONE indivisible fixture; 45 has no setup of its own and
-# reads $HAND set here. Do not reorder or insert a setup between them.
+# re-stamps the section 44 planted. Do not reorder or insert a setup between
+# them.
 setup
 brief_now
 hand_now
@@ -1234,18 +1612,132 @@ say "answer
 ## Remaining
 | #7 | thing | pending, me |"
 task 7 pending "thing"
-# Age it past the default without touching the clock: the check reads mtime.
+# Age it past the default without touching the clock. AGE COMES FROM THE
+# SECTION'S HEADING STAMP since 2026-08-09, not from the file's mtime, so this
+# re-stamps the section rather than touching the file: mtime is per FILE while
+# the obligation is per SESSION, and a peer's write used to reset everyone's
+# clock. `touch -d` here would silently exercise the unstamped fallback instead
+# of the rule under test.
 # The limit is 15 minutes, and the pair BRACKETS it: 16 must block, 14 must
 # not. A single far-past fixture would keep passing if the constant were
 # raised to an hour by accident. The world has moved since hand_now banked the
 # signature (task 7 landed after), so world-keyed staleness is armed.
-HAND="$BASE/proj/.agent/agenttest/STATE.md"
-touch -d '16 minutes ago' "$HAND"
+age_state deadbeef 16
 check "a 16-minute-old STATE.md blocks at the 15-minute limit" block "STATE.md is stale"
 
 echo "== 45. and one just inside it does not =="
-touch -d '14 minutes ago' "$HAND"
+age_state deadbeef 14
 check "a 14-minute-old STATE.md is inside the 15-minute limit" allow ""
+
+echo "== 44b. staleness is PER SESSION: one session's write cannot silence another =="
+# THE OTHER HALF OF THE 2026-08-09 INCIDENT, and the half that made the first
+# half inevitable. Age used to come from the file's MTIME, which is per FILE,
+# while the recorded signature is per SESSION. So a peer's write reset
+# everyone's clock: session B's 30-minute-stale document read "ok" the instant
+# session A wrote, and -- worse than a skipped stop -- wl_checks then banked
+# A's world signature as B's own, so B adopted a document describing A's world
+# as its own recovery artifact. Reproduced against the real function before the
+# fix: ('stale', 30) became ('ok', 0) purely because A wrote.
+#
+# A mutation that reverts the age source to p.stat().st_mtime must turn this
+# case red.
+setup
+brief_now
+brief_other cafe1234
+hand_now # A = deadbeef, stamped now
+B_BODY='Session B is holding the canary campaign: attempt 6 is in flight behind watch id 9be21c, five flags are flipped, and v1.2.24 is released. None of this is session A material and none of it may be silenced by session A writing.
+
+## Next action
+Read attempt 6 to completion and record the flag states before touching anything.'
+state_as cafe1234 "$B_BODY"
+age_state cafe1234 30 # B is stale; A is not. A's write above is the "peer write".
+# B needs work of its OWN outstanding, because the STATE.md violation only
+# fires when something remains for that session: the tasks in the fixture dir
+# are keyed to `deadbeef`, so without this B has an empty plate and the case
+# would pass vacuously by never reaching the check under test.
+as_peer cafe1234 reqcli --add cafe1234 "B's own open item" >/dev/null
+task 7 pending "thing"
+newturn
+say "answer
+
+## Remaining
+- #7 thing (pending)"
+B_SIG_BEFORE="$(python3 -c "
+import json, pathlib
+p = pathlib.Path('${WL%.md}.state-cafe1234.json')
+print(json.loads(p.read_text()).get('state_sig', '') if p.exists() else '')")"
+# FOCUS=off for B's two stops. B legitimately has TWO violations (its open item
+# and its stale section) and the focus mechanism surfaces one, so a focused run
+# would assert the needle's absence for a reason that has nothing to do with
+# the rule under test -- and the anti-vacuity control below would then pass on
+# a hook that never computed staleness at all.
+export WORKLIST_FOCUS=off
+check_as cafe1234 "44b FIRE: the STALE session B is nagged" block "STATE.md is stale"
+unset WORKLIST_FOCUS
+check "44b: session A, fresh, is NOT nagged by B's staleness" allow ""
+# THE BANKING HALF, which is worse than the skipped stop it hid behind. On a
+# "stale" verdict nothing may be banked, or the next stop would compare against
+# a signature recorded DURING the block and clear itself. Under the mtime bug B
+# got an "ok" verdict off A's write and banked A's world as its own.
+B_SIG_AFTER="$(python3 -c "
+import json, pathlib
+p = pathlib.Path('${WL%.md}.state-cafe1234.json')
+print(json.loads(p.read_text()).get('state_sig', '') if p.exists() else '')")"
+if [[ -n "$B_SIG_BEFORE" && "$B_SIG_BEFORE" == "$B_SIG_AFTER" ]]; then
+    pass "44b: B's banked signature is untouched by its stale block and by A's stop"
+else
+    fail "44b: B's signature moved during the block ('${B_SIG_BEFORE:0:12}' -> '${B_SIG_AFTER:0:12}')"
+fi
+# ANTI-VACUITY. Re-stamp B fresh: the nag must go away. Without this the case
+# would pass on a hook that simply blocks every peer for every reason.
+age_state cafe1234 1
+export WORKLIST_FOCUS=off
+OUT="$(run_as cafe1234)"
+unset WORKLIST_FOCUS
+# The second half of the anti-vacuity: B must still be SPEAKING (it still owns
+# an open item), so the missing needle is the staleness verdict changing rather
+# than the hook having gone quiet.
+if ! grep -qF "STATE.md is stale" <<<"$OUT" && grep -qF "OPEN worklist item" <<<"$OUT"; then
+    pass "44b ANTI-VACUITY: a freshly stamped section B is no longer nagged"
+else
+    fail "44b ANTI-VACUITY: B is nagged even when fresh, or went silent: ${OUT:0:220}"
+fi
+
+echo "== 44c. a FUTURE heading stamp cannot buy permanent freshness =="
+# FOUND ON THE LIVE DOCUMENT, not imagined: driving this code against the real
+# .agent/main/STATE.md for the first time showed a peer's hand-written heading
+# stamped 101 minutes AHEAD -- almost certainly local time written with a Z. A
+# trusted future stamp makes that section permanently fresh, which is worse
+# than the unstamped fallback it would otherwise have taken, because the entire
+# point of per-section staleness is that a section cannot dodge its own clock.
+# A future stamp is therefore treated exactly like an unparseable one.
+setup
+brief_now
+hand_now
+say "answer
+
+## Remaining
+| #7 | thing | pending, me |"
+task 7 pending "thing"
+age_state deadbeef -60                                    # stamped an hour AHEAD
+touch -d '40 minutes ago' "$BASE/proj/.agent/agenttest/STATE.md" # the honest age
+check "44c FIRE: a future-stamped section falls back to mtime and goes stale" block "STATE.md is stale"
+# CONTROL 1: a stamp inside the tolerated skew is still TRUSTED, so this is a
+# rule about wrong clocks rather than a blanket distrust of the future.
+age_state deadbeef -2
+check "44c CONTROL: a stamp 2 minutes ahead is inside the skew and stays fresh" allow ""
+# CONTROL 2: and the fallback is really the mtime, not a hardcoded stale. Same
+# future stamp, fresh file: allowed.
+age_state deadbeef -60
+touch -d '1 minute ago' "$BASE/proj/.agent/agenttest/STATE.md"
+task 8 pending "moved"
+newturn
+say "answer
+
+## Remaining
+| #7 | thing | pending, me |
+| #8 | moved | pending, me |"
+check "44c CONTROL: the untrusted stamp falls back to mtime, which here is fresh" allow ""
 
 echo "== 46. CONTROL: an open item still blocks off a runner =="
 setup
@@ -2504,6 +2996,7 @@ ARITY = {
     "V_AGENT_STATE": ("b", "s", "", 250, 4000, "m"),
     "V_AGENT_BOOTSTRAP": ("b", "b", "b"), "V_AGENT_STILL_ABSENT": ("b",),
     "N_AGENT_BLIND": ("r",), "CLI_STATE_REFUSED": ("v", "d", 250, 4000),
+    "N_AGENT_PEERS": ("br", "rows"), "CLI_STATE_WHOLE_DOC": ("m",),
     "N_UNREAD_REPORTS": (2, "b", "rows", "p", "p", "m"),
     "CLI_REAP_USAGE": (), "CLI_REAP_UNKNOWN": ("t", "l"),
     "N_ROSTER_STALE": (20, 1, 19, "p", "m"),
@@ -2581,6 +3074,7 @@ ARITY = {
     "CTX_POSTCOMPACT_MISSING": ("p", "b", "m"),
     "CTX_POSTCOMPACT_NO_BRANCH": ("t",),
     "CTX_POSTCOMPACT_BRIEFING": ("d", "s", "r", "p", "t"),
+    "CTX_POSTCOMPACT_PEERS": ("b",),
     "JUDGE_PROMPT": {"streak": 1, "remaining": "r", "leases": 0, "loop": "l",
                      "citations": "c", "message": "m", "traps": "t"},
     "REGGATE_PROMPT": {"fixset": "f", "keys": "k"},
@@ -3441,8 +3935,7 @@ printf 'You are picking up the ci-overhaul session driving PR #543 to green on b
     TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" WORKLIST_TASKS_DIR="$BASE/tasks" \
         WORKLIST_AGENT_BRANCH=agenttest python3 "$HOOK" --state deadbeef >/dev/null
 check "fresh STATE.md, settled world: allowed" allow ""
-HAND="$BASE/proj/.agent/agenttest/STATE.md"
-touch -d '25 minutes ago' "$HAND"
+age_state deadbeef 25 # the heading stamp is the age source, not the file mtime
 check "an OLD STATE.md with an UNCHANGED world is NOT stale (the poll trap is dead)" allow ""
 task 8 pending "the new thing"
 newturn
@@ -4219,7 +4712,7 @@ say "answer
 ## Remaining
 - the flag decision, deferred with a default"
 check "T12 baseline stop allows" allow ""
-touch -d '25 minutes ago' "$BASE/proj/.agent/agenttest/STATE.md"
+age_state deadbeef 25
 reqcli --poll deadbeef >/dev/null
 OUT="$(run)"
 RC=$?
@@ -4272,7 +4765,7 @@ else
     fail "154a CONTROL: the stop emitted nothing at all: ${OUT:0:260}"
 fi
 # The FOCUS=off dump-all block carried the section too; it must not any more.
-touch -d '20 minutes ago' "$BASE/proj/.agent/agenttest/STATE.md"
+age_state deadbeef 20
 task 8 pending "moved"
 newturn
 say "answer
@@ -5081,7 +5574,7 @@ say "answer
 ## Remaining
 - #7 thing (pending)"
 run >/dev/null
-touch -d '20 minutes ago' "$BASE/proj/.agent/agenttest/STATE.md"
+age_state deadbeef 20
 reqcli --lease deadbeef "$FID" +90 worker:bw9 "renewing the watch lease" >/dev/null
 newturn
 say "answer
@@ -7446,7 +7939,7 @@ L1_TABLE=(
     "--update|--update @ME@ $I_UPDATE moved-a-bit|updated #"
     "--lease|--lease @ME@ $I_LEASE +30 worker:l1bg|leased #"
     "--list|--list --open @ME@|l1-list-item"
-    "--state|--state @ME@|STATE.md written"
+    "--state|--state @ME@|STATE.md section written"
     "--loop|--loop @ME@ 2099-01-01T00:00:00Z 1 l1-label|loop declared"
     "--brief|--brief @ME@ l1-brief-text|brief recorded"
     "--reap|--reap @ME@ l1task9|reaped 1 task"

--- a/.claude/hooks/stop/test-worklist-v5.sh
+++ b/.claude/hooks/stop/test-worklist-v5.sh
@@ -2545,7 +2545,9 @@ ARITY = {
     "V_CL_SHAPE": ("d", "rows"), "V_CL_UNREADABLE": ("e",),
     "V_CL_PRODUCING": ("s", 0, 1, "rows", "d"), "V_CL_PRODUCING_DONE": ("s", "d"),
     "V_CL_FLIP": ("d", "executing", "rows", "d"), "V_CL_WAVES": ("s", "d", "rows"),
-    "N_CL_FOREIGN": ("s", "o", ""), "CTX_CHECKLISTS": ("listing",),
+    "N_CL_FOREIGN": ("s", "o", ""),
+    "N_CL_FOREIGN_DRIFT": ("d", "executing", "o", "rows"),
+    "CTX_CHECKLISTS": ("listing",),
     "CTX_PLANS": ("b", "l"), "CTX_PLANS_EXCERPT": ("p", "b"),
     "V_UNCITED": ("x",), "V_FOUND_NOT_FIXED": None, "V_UNSTATED": ("#1",),
     "V_MISLABELLED": ("x",), "V_OUT_OF_SYNC": (1, "#1"),
@@ -8694,7 +8696,10 @@ echo "== 202. checklists_sig() is STAT-ONLY, and the unreadable file proves it =
 # version that opened files would pay exactly the cost the fast path exists to
 # avoid. A chmod-000 checklist is the instrument -- stat still answers where
 # read cannot, so the signature must come back while the ADJUDICATION (which
-# does read) fails closed into the ALWAYS-tier unreadable violation.
+# does read) fails closed into the ALWAYS-tier unreadable violation. The key
+# it fails closed UNDER is asserted too, and it is per-slug (`cl-shape:locked`)
+# for the reason case 204 pins: one unreadable checklist must not evict a
+# second one from the rotation.
 setup
 mkdir -p "$BASE/proj/docs/locked"
 printf 'Status: executing\n' >"$BASE/proj/docs/locked/CHECKLIST.md"
@@ -8731,7 +8736,7 @@ if grep -qE "^SIG [0-9a-f]{16}$" <<<"$OUT"; then
 else
     fail "202: the stat-only signature raised or came back malformed: ${OUT:0:300}"
 fi
-if grep -q "^V cl-shape True 1$" <<<"$OUT" && grep -q "^TEXT True$" <<<"$OUT"; then
+if grep -q "^V cl-shape:locked True 1$" <<<"$OUT" && grep -q "^TEXT True$" <<<"$OUT"; then
     pass "202: and the reading half fails CLOSED, ALWAYS-tier, naming itself a hook bug"
 else
     fail "202: an unreadable checklist did not fail closed: ${OUT:0:300}"
@@ -8780,6 +8785,199 @@ if ! grep -qF "LIVE HANDOFF CHECKLISTS" <<<"$out"; then
 else
     fail "203 CONTROL: the listing surfaced a done handoff: ${out:0:400}"
 fi
+
+# ---------------------------------------------------------------------------
+# 204-206 v20b: ONE KEY PER CHECKLIST, and an advisory that gives no orders.
+# Both gaps were found by the automated review on PR #563, and both are about
+# a second concurrent handoff, which this repo ran two of on the day they
+# landed.
+#
+# 204/205 pin the KEY. Every checklist finding used to be pushed under a fixed
+# string -- "cl-waves", "cl-foreign" and friends -- while two things downstream
+# read that string as an IDENTITY. The focused block's rotation builds its tie
+# breaker with `order = {v[0]: i for ...}`, a dict comp in which duplicate keys
+# COLLAPSE, so two violations sharing a key get identical sort tuples and `min`
+# returns the first one forever; and outq_add finds a non-sticky entry by key
+# alone, so the second advisory OVERWRITES the first rather than queueing
+# beside it. The second handoff was therefore starved permanently, not for a
+# stop or two, and only ever showed up inside the "N more outstanding" count.
+#
+# 206 pins the AUDIENCE. The drift text was built once and routed either to a
+# blocking violation (owner) or to the advisory (non-owner), so a session that
+# does not own the handoff was told to restore the artifacts "in this turn".
+# Acting on that means editing another session's header or its files, which is
+# how a peer's shared STATE.md was destroyed here.
+
+echo "== 204. two handoffs, two keys: the rotation serves BOTH, one per stop =="
+setup
+say "done for now"
+brief_now
+hand_now
+cldeliver docs/alpha/README.md "the readme"
+cldeliver docs/beta/README.md "the readme"
+clfile alpha <<'MD'
+# Handoff checklist: alpha
+Status: executing
+
+## Deliverables
+- [x] d1 file:docs/alpha/README.md
+
+## Waves
+- [ ] w1 Wave A: wire the alpha thing
+MD
+clfile beta <<'MD'
+# Handoff checklist: beta
+Status: executing
+
+## Deliverables
+- [x] d1 file:docs/beta/README.md
+
+## Waves
+- [ ] w1 Wave A: wire the beta thing
+MD
+OUT1="$(run)"
+OUT2="$(run)"
+if grep -qF "handoff 'alpha' (docs/alpha/CHECKLIST.md)" <<<"$OUT1$OUT2" &&
+    grep -qF "handoff 'beta' (docs/beta/CHECKLIST.md)" <<<"$OUT1$OUT2"; then
+    pass "204: two uncovered waves in one check class are both itemized across two stops"
+else
+    fail "204: one handoff starved the other in the rotation: 1=${OUT1:0:300} 2=${OUT2:0:300}"
+fi
+if ! grep -qF "handoff 'beta'" <<<"$OUT1" && ! grep -qF "handoff 'alpha'" <<<"$OUT2"; then
+    pass "204: and it is still ONE per stop, in battery order -- the block did not widen"
+else
+    fail "204: the focused block stopped rotating: 1=${OUT1:0:300} 2=${OUT2:0:300}"
+fi
+as_peer cafe0000 reqcli --add cafe0000 "cl:alpha/w1 Wave A: wire the alpha thing" >/dev/null
+as_peer cafe0000 reqcli --add cafe0000 "cl:beta/w1 Wave A: wire the beta thing" >/dev/null
+OUT="$(run)"
+RC=$?
+if [[ "$RC" -eq 0 ]] && ! grep -qF "UNCOVERED" <<<"$OUT" && ! grep -qF '"decision": "block"' <<<"$OUT"; then
+    pass "204 CONTROL: both waves claimed, so neither per-slug key is left outstanding"
+else
+    fail "204 CONTROL: a per-slug key outlived the wave it belonged to: ${OUT:0:400}"
+fi
+
+echo "== 205. two FOREIGN advisories, two keys: the second no longer eats the first =="
+# Leg 1 is the needle's own control: with only alpha planted, beta's needle
+# must be MISSING. Without it, leg 2 could pass on a grep that matches
+# anything, which is the failure mode a two-needle assertion hides best.
+#
+# EACH LEG GETS ITS OWN FIXTURE, and that is not tidiness. Draining an
+# advisory latches it in the queue's `shown` ledger, so planting beta beside an
+# ALREADY-SHOWN alpha suppresses alpha through the refresh window -- correct
+# behaviour that looks exactly like the overwrite bug and would have made this
+# case fire for the wrong reason.
+setup
+say "done for now"
+brief_now
+hand_now
+export WORKLIST_REPORT_PER_STOP=6
+clfile alpha <<'MD'
+# Handoff checklist: alpha
+Status: producing
+Owner: cafe0000
+
+## Deliverables
+- [ ] d1 file:docs/alpha/README.md
+
+## Waves
+- [ ] w1 Wave A: wire the alpha thing
+MD
+OUT="$(run)"
+if grep -qF "docs/alpha/CHECKLIST.md is 'Status: producing'" <<<"$OUT" &&
+    ! grep -qF "docs/beta/CHECKLIST.md" <<<"$OUT"; then
+    pass "205 CONTROL: one foreign handoff, one advisory, and beta's needle can be absent"
+else
+    fail "205 CONTROL: the single-checklist baseline is not what it claims: ${OUT:0:400}"
+fi
+setup
+say "done for now"
+brief_now
+hand_now
+export WORKLIST_REPORT_PER_STOP=6
+clfile alpha <<'MD'
+# Handoff checklist: alpha
+Status: producing
+Owner: cafe0000
+
+## Deliverables
+- [ ] d1 file:docs/alpha/README.md
+
+## Waves
+- [ ] w1 Wave A: wire the alpha thing
+MD
+clfile beta <<'MD'
+# Handoff checklist: beta
+Status: producing
+Owner: cafe0000
+
+## Deliverables
+- [ ] d1 file:docs/beta/README.md
+
+## Waves
+- [ ] w1 Wave A: wire the beta thing
+MD
+OUT="$(run)"
+RC=$?
+if [[ "$RC" -eq 0 ]] && grep -qF "docs/alpha/CHECKLIST.md is 'Status: producing'" <<<"$OUT" &&
+    grep -qF "docs/beta/CHECKLIST.md is 'Status: producing'" <<<"$OUT"; then
+    pass "205: both foreign handoffs ride the report; neither advisory overwrites the other"
+else
+    fail "205: one foreign advisory replaced the other in the queue: ${OUT:0:600}"
+fi
+unset WORKLIST_REPORT_PER_STOP
+
+echo "== 206. a foreign DRIFT advisory reports it; it does not order the reader around =="
+setup
+say "done for now"
+brief_now
+hand_now
+export WORKLIST_REPORT_PER_STOP=6
+clfile demo <<'MD'
+# Handoff checklist: demo
+Status: executing
+Owner: cafe0000
+
+## Deliverables
+- [x] d1 file:docs/demo/README.md
+
+## Waves
+- [x] w1 Wave A: wire the thing
+MD
+OUT="$(run)"
+RC=$?
+if [[ "$RC" -eq 0 ]] && grep -qF "d1 docs/demo/README.md -- MISSING" <<<"$OUT" &&
+    grep -qF "Reported, never blocked on." <<<"$OUT" &&
+    grep -qF "cafe0000" <<<"$OUT" && ! grep -qF "in this turn" <<<"$OUT"; then
+    pass "206: a non-owner is told about the drift and is handed no instruction to act on"
+else
+    fail "206: the foreign drift advisory still issues the owner's order: rc=$RC ${OUT:0:600}"
+fi
+if grep -qF "another session's" <<<"$OUT"; then
+    pass "206: and it says out loud that repairing it here would overwrite live work"
+else
+    fail "206: nothing warned the reader off editing a peer's checklist: ${OUT:0:600}"
+fi
+clfile demo <<'MD'
+# Handoff checklist: demo
+Status: executing
+Owner: deadbeef
+
+## Deliverables
+- [x] d1 file:docs/demo/README.md
+
+## Waves
+- [x] w1 Wave A: wire the thing
+MD
+OUT="$(run)"
+if grep -qF '"decision": "block"' <<<"$OUT" && grep -qF "reality disagrees" <<<"$OUT" &&
+    grep -qF "in this turn" <<<"$OUT"; then
+    pass "206 CONTROL: the SAME drift under its owner still blocks, imperative intact"
+else
+    fail "206 CONTROL: ownership stopped deciding who is ordered to repair: ${OUT:0:600}"
+fi
+unset WORKLIST_REPORT_PER_STOP
 
 echo
 echo "  passed=$PASS failed=$FAIL"

--- a/.claude/hooks/stop/test-worklist-v5.sh
+++ b/.claude/hooks/stop/test-worklist-v5.sh
@@ -2541,6 +2541,11 @@ ARITY = {
     "CLI_TRIAGE_SELF": {"id": "i", "me": "m", "why": "", "context": "c",
                         "branch": "b"},
     "TRIAGE_PROMPT": {"finding": "f", "context": "c"},
+    # v20: the /handoff checklist gate (wl_checklist, docs/<slug>/CHECKLIST.md).
+    "V_CL_SHAPE": ("d", "rows"), "V_CL_UNREADABLE": ("e",),
+    "V_CL_PRODUCING": ("s", 0, 1, "rows", "d"), "V_CL_PRODUCING_DONE": ("s", "d"),
+    "V_CL_FLIP": ("d", "executing", "rows", "d"), "V_CL_WAVES": ("s", "d", "rows"),
+    "N_CL_FOREIGN": ("s", "o", ""), "CTX_CHECKLISTS": ("listing",),
     "CTX_PLANS": ("b", "l"), "CTX_PLANS_EXCERPT": ("p", "b"),
     "V_UNCITED": ("x",), "V_FOUND_NOT_FIXED": None, "V_UNSTATED": ("#1",),
     "V_MISLABELLED": ("x",), "V_OUT_OF_SYNC": (1, "#1"),
@@ -8179,6 +8184,601 @@ if grep -q "^TIP ''$" <<<"$OUT"; then
     pass "192: the backoff ladder treats an off-minute hourly poll as capped, not unknown"
 else
     fail "192: poll_backoff_tip mis-handled an off-minute hourly poll: $(grep '^TIP' <<<"$OUT")"
+fi
+
+# ---------------------------------------------------------------------------
+# 193-203 v20: the /handoff checklist gate (docs/<slug>/CHECKLIST.md).
+#
+# THE GAP THESE PIN: /handoff wrote a design suite and then TOLD the next
+# session, in prose inside PROMPT.md, to seed the worklist. Prose gates
+# nothing, so a handoff whose PROMPT.md was ignored or compacted away dropped
+# program work silently. CHECKLIST.md is the machine-readable half, and its
+# two halves are enforced by DIFFERENT means: deliverables are FILE-VERIFIED
+# (the tick is bookkeeping, the file is the truth) while waves are
+# tick-on-trust with store linkage through the `cl:<slug>/<wN>` token. Every
+# case below is paired with a clean-fixture control, because a gate nobody has
+# watched stay silent is a gate nobody knows fires for the right reason.
+
+clfile() { # clfile <slug>  -- body on stdin, written to docs/<slug>/CHECKLIST.md
+    mkdir -p "$BASE/proj/docs/$1"
+    cat >"$BASE/proj/docs/$1/CHECKLIST.md"
+}
+
+cldeliver() { # cldeliver <relpath> [content] -- a deliverable file under the repo
+    mkdir -p "$BASE/proj/$(dirname "$1")"
+    printf '%s' "${2-x}" >"$BASE/proj/$1"
+}
+
+echo "== 193. ZERO OVERHEAD: a repo with no checklist never hears the word =="
+# The cost claim in wl_checklist's docstring is that a repo keeping no
+# handoffs pays one glob and says nothing. That is only half a control: a
+# silent gate and a dead gate look identical from here, so the second leg
+# plants one checklist into the SAME fixture and demands the words appear.
+setup
+say "done for now"
+brief_now
+hand_now
+OUT="$(run)"
+if ! grep -qi "handoff" <<<"$OUT" && ! grep -qF "CHECKLIST" <<<"$OUT"; then
+    pass "193: no docs/<slug>/CHECKLIST.md means not one word about handoffs"
+else
+    fail "193: the gate talked about checklists that do not exist: ${OUT:0:300}"
+fi
+clfile demo <<'MD'
+# Handoff checklist: demo
+Status: producing
+Owner: deadbeef
+
+## Deliverables
+- [ ] d1 file:docs/demo/README.md
+
+## Waves
+- [ ] w1 Wave A: wire the thing
+MD
+OUT="$(run)"
+if grep -qF "docs/demo/CHECKLIST.md" <<<"$OUT" && grep -qi "handoff" <<<"$OUT"; then
+    pass "193 CONTROL-FOR-THE-CONTROL: one planted checklist and the same fixture speaks"
+else
+    fail "193 CONTROL: the silence above was a DEAD gate, not a cheap one: ${OUT:0:300}"
+fi
+
+echo "== 194. producing + a missing deliverable blocks its OWNER =="
+setup
+say "done for now"
+brief_now
+hand_now
+clfile demo <<'MD'
+# Handoff checklist: demo
+Status: producing
+Owner: deadbeef
+
+## Deliverables
+- [ ] d1 file:docs/demo/README.md
+
+## Waves
+- [ ] w1 Wave A: wire the thing
+MD
+OUT="$(run)"
+if grep -qF "DO NOT VERIFY" <<<"$OUT" && grep -qF "d1 docs/demo/README.md -- MISSING" <<<"$OUT"; then
+    pass "194: the producing owner is blocked, and the row names the file and the verdict"
+else
+    fail "194: the producing block did not name the missing deliverable: ${OUT:0:400}"
+fi
+check "194: and the decision is block, not a note on an allowed stop" block "0 of 1 are present"
+
+echo "== 194b. producing + everything verified: ONE step left, and it is the flip =="
+cldeliver docs/demo/README.md "the readme"
+OUT="$(run)"
+if grep -qF "ONE step remains and it is the flip" <<<"$OUT" &&
+    grep -qF "'Status: producing' to 'Status: executing'" <<<"$OUT" &&
+    ! grep -qF "DO NOT VERIFY" <<<"$OUT"; then
+    pass "194b: a verified producing checklist demands the status flip, nothing else"
+else
+    fail "194b: the flip demand is wrong: ${OUT:0:400}"
+fi
+
+echo "== 195. a FOREIGN producing checklist is reported, never blocked on =="
+setup
+say "done for now"
+brief_now
+hand_now
+export WORKLIST_REPORT_PER_STOP=6
+clfile demo <<'MD'
+# Handoff checklist: demo
+Status: producing
+Owner: cafe0000
+
+## Deliverables
+- [ ] d1 file:docs/demo/README.md
+
+## Waves
+- [ ] w1 Wave A: wire the thing
+MD
+OUT="$(run)"
+RC=$?
+if [[ "$RC" -eq 0 ]] && ! grep -qF '"decision": "block"' <<<"$OUT" &&
+    grep -qF "that session's to finish" <<<"$OUT"; then
+    pass "195: another session's producing handoff rides the report and blocks nobody"
+else
+    fail "195: a foreign producing checklist was mis-adjudicated: ${OUT:0:400}"
+fi
+if ! grep -qF "adopt it by editing" <<<"$OUT"; then
+    pass "195 CONTROL: a LIVE owner gets no adoption hint (that would be a land grab)"
+else
+    fail "195 CONTROL: the adoption hint fired on a live owner: ${OUT:0:400}"
+fi
+
+echo "== 195b. the same checklist, owner's transcript DEAD: adopt or supersede =="
+# projects_dir is the transcript's own directory (wl_checks.py:1678), so an
+# aged cafe0000*.jsonl beside the fixture transcript is exactly what
+# owner_age_hours reads. Planted rather than mocked, for that reason.
+touch -d '-48 hours' "$BASE/cafe0000-dead.jsonl"
+OUT="$(run)"
+if grep -qF "adopt it by editing the 'Owner:' line" <<<"$OUT" &&
+    grep -qF "docs/demo/CHECKLIST.md" <<<"$OUT" && grep -qF "superseded" <<<"$OUT"; then
+    pass "195b: a dead owner turns the advisory into an adoption offer"
+else
+    fail "195b: no adoption hint for an abandoned handoff: ${OUT:0:500}"
+fi
+unset WORKLIST_REPORT_PER_STOP
+
+echo "== 196. TICKED but missing: the file is the truth, the tick is bookkeeping =="
+# The wave is claimed by a peer rather than ticked, so the deliverable check
+# is the ONLY thing that can speak here and the control below is a real allow
+# instead of a different violation wearing the same fixture.
+setup
+say "done for now"
+brief_now
+hand_now
+clfile demo <<'MD'
+# Handoff checklist: demo
+Status: executing
+
+## Deliverables
+- [x] d1 file:docs/demo/README.md
+
+## Waves
+- [ ] w1 Wave A: wire the thing
+MD
+as_peer cafe0000 reqcli --add cafe0000 "cl:demo/w1 Wave A: wire the thing" >/dev/null
+OUT="$(run)"
+if grep -qF "reality disagrees" <<<"$OUT" &&
+    grep -qF "d1 docs/demo/README.md -- MISSING" <<<"$OUT"; then
+    pass "196: a ticked box does not save a deliverable that is not on disk"
+else
+    fail "196: the ticked-but-missing deliverable passed: ${OUT:0:400}"
+fi
+
+echo "== 196b. EMPTY is not MISSING, and the row says which =="
+cldeliver docs/demo/README.md ""
+OUT="$(run)"
+if grep -qF "d1 docs/demo/README.md -- EMPTY" <<<"$OUT" &&
+    ! grep -qF -- "-- MISSING" <<<"$OUT"; then
+    pass "196b: a 0-byte deliverable reads as EMPTY, distinctly from MISSING"
+else
+    fail "196b: the truncated deliverable was mis-named: ${OUT:0:400}"
+fi
+cldeliver docs/demo/README.md "the readme"
+check "196b CONTROL: a non-empty file clears the check entirely" allow ""
+
+echo "== 197. an UNCOVERED wave blocks, and carries its own one-command exit =="
+setup
+say "done for now"
+brief_now
+hand_now
+cldeliver docs/demo/README.md "the readme"
+clfile demo <<'MD'
+# Handoff checklist: demo
+Status: executing
+
+## Deliverables
+- [x] d1 file:docs/demo/README.md
+
+## Waves
+- [ ] w1 Wave A: wire the thing
+MD
+OUT="$(run)"
+if grep -qF "w1 UNCOVERED" <<<"$OUT" && grep -qF "cl:demo/w1" <<<"$OUT" &&
+    grep -qF -- "--add deadbeef 'cl:demo/w1 Wave A: wire the thing'" <<<"$OUT"; then
+    pass "197: the uncovered wave names its token and the exact --add that claims it"
+else
+    fail "197: the uncovered wave has no runnable exit: ${OUT:0:500}"
+fi
+
+echo "== 197b. claiming it with --add moves the work into the ORDINARY open-items check =="
+# DISJOINTNESS, not merely absence: the cl-waves needle must go while the
+# open-item it created appears, because a gate that stopped firing AND took
+# the work with it would look identical from a one-needle assertion.
+reqcli --add deadbeef "cl:demo/w1 Wave A: wire the thing" >/dev/null
+export WORKLIST_FOCUS=off
+OUT="$(run)"
+if ! grep -qF "UNCOVERED" <<<"$OUT" && grep -qF "OPEN worklist item" <<<"$OUT" &&
+    grep -qF "cl:demo/w1" <<<"$OUT"; then
+    pass "197b: a claimed wave stops blocking as a wave and starts blocking as an item"
+else
+    fail "197b: coverage either did not register or swallowed the work: ${OUT:0:500}"
+fi
+unset WORKLIST_FOCUS
+
+echo "== 197c. a PEER's item covers the wave for everybody, which is the point =="
+setup
+say "done for now"
+brief_now
+hand_now
+cldeliver docs/demo/README.md "the readme"
+clfile demo <<'MD'
+# Handoff checklist: demo
+Status: executing
+
+## Deliverables
+- [x] d1 file:docs/demo/README.md
+
+## Waves
+- [ ] w1 Wave A: wire the thing
+MD
+as_peer cafe0000 reqcli --add cafe0000 "cl:demo/w1 Wave A: wire the thing" >/dev/null
+OUT="$(run)"
+RC=$?
+if [[ "$RC" -eq 0 ]] && ! grep -qF "UNCOVERED" <<<"$OUT" && ! grep -qF '"decision": "block"' <<<"$OUT"; then
+    pass "197c: once ANY session claims the wave, the redundant block on the others lifts"
+else
+    fail "197c: a peer-claimed wave still blocked this session: ${OUT:0:400}"
+fi
+
+echo "== 198. DONE-BUT-UNTICKED: the store settled it, the box did not =="
+setup
+say "done for now"
+brief_now
+hand_now
+cldeliver docs/demo/README.md "the readme"
+clfile demo <<'MD'
+# Handoff checklist: demo
+Status: executing
+
+## Deliverables
+- [x] d1 file:docs/demo/README.md
+
+## Waves
+- [ ] w1 Wave A: wire the thing
+MD
+IID=$(reqcli --add deadbeef "cl:demo/w1 Wave A: wire the thing" | grep -oE '#[0-9a-f]+' | tr -d '#')
+reqcli --tick deadbeef "$IID" "wave A landed, suite run green, exit 0" >/dev/null
+OUT="$(run)"
+if grep -qF "w1 DONE-BUT-UNTICKED" <<<"$OUT" && grep -qF "#$IID" <<<"$OUT" &&
+    grep -qF "tick '- [x] w1' in docs/demo/CHECKLIST.md" <<<"$OUT"; then
+    pass "198: a ticked store item with an unticked box is called out with the box to tick"
+else
+    fail "198: the settled wave did not demand its tick: ${OUT:0:500}"
+fi
+
+echo "== 198b. every box ticked under 'executing' means the status is stale =="
+clfile demo <<'MD'
+# Handoff checklist: demo
+Status: executing
+
+## Deliverables
+- [x] d1 file:docs/demo/README.md
+
+## Waves
+- [x] w1 Wave A: wire the thing
+MD
+OUT="$(run)"
+if grep -qF "everything is settled; set 'Status: done'" <<<"$OUT"; then
+    pass "198b: an all-settled executing checklist is asked for the last edit it needs"
+else
+    fail "198b: a finished program was left at executing forever: ${OUT:0:400}"
+fi
+
+echo "== 199. 'done' is INACTIVE, and is gated on being honestly done =="
+setup
+say "done for now"
+brief_now
+hand_now
+cldeliver docs/demo/README.md "the readme"
+clfile demo <<'MD'
+# Handoff checklist: demo
+Status: done
+
+## Deliverables
+- [x] d1 file:docs/demo/README.md
+
+## Waves
+- [x] w1 Wave A: wire the thing
+MD
+OUT="$(run)"
+RC=$?
+if [[ "$RC" -eq 0 ]] && ! grep -qF "CHECKLIST" <<<"$OUT" && ! grep -qF '"decision": "block"' <<<"$OUT"; then
+    pass "199: a genuinely done handoff costs a later session nothing at all"
+else
+    fail "199: a done checklist is still talking: ${OUT:0:400}"
+fi
+clfile demo <<'MD'
+# Handoff checklist: demo
+Status: done
+
+## Deliverables
+- [x] d1 file:docs/demo/README.md
+
+## Waves
+- [ ] w1 Wave A: wire the thing
+MD
+OUT="$(run)"
+if grep -qF "reality disagrees" <<<"$OUT" &&
+    grep -qF "wave w1 is not ticked, yet the checklist claims done" <<<"$OUT"; then
+    pass "199: 'done' with an unticked wave is a lie the next session would believe"
+else
+    fail "199: a dishonest done header passed: ${OUT:0:400}"
+fi
+
+echo "== 199b. 'superseded' is the terminal escape and adjudicates nothing =="
+clfile demo <<'MD'
+# Handoff checklist: demo
+Status: superseded
+
+## Deliverables
+- [ ] d1 file:docs/demo/GONE.md
+
+## Waves
+- [ ] w1 Wave A: wire the thing
+MD
+OUT="$(run)"
+RC=$?
+if [[ "$RC" -eq 0 ]] && ! grep -qF "CHECKLIST" <<<"$OUT" && ! grep -qF '"decision": "block"' <<<"$OUT"; then
+    pass "199b: an abandoned program stops costing anything the moment it says so"
+else
+    fail "199b: superseded still adjudicated: ${OUT:0:400}"
+fi
+
+echo "== 200. the SHAPE gate collects every defect, and scopes itself to the bad file =="
+# One error per stop would cost one turn per typo, so the parser collects them
+# all. The clean checklist alongside is the control: a malformed file must not
+# smear its verdict over its neighbours.
+setup
+say "done for now"
+brief_now
+hand_now
+cldeliver docs/good/README.md "the readme"
+clfile good <<'MD'
+# Handoff checklist: good
+Status: done
+
+## Deliverables
+- [x] d1 file:docs/good/README.md
+
+## Waves
+- [x] w1 Wave A: the finished one
+MD
+clfile broken <<'MD'
+# Handoff checklist: broken
+Owner: deadbeef
+
+## Deliverables
+- [ ] d1 nothing verifies this one
+- [ ] d1 file:docs/broken/README.md
+- [ ] w9 a wave id under the deliverables
+
+## Waves
+- [z] w1 a state character that does not exist
+MD
+OUT="$(run)"
+NROWS=0
+for needle in "no 'Status:' line in the first 10 lines" \
+    "does not belong under that section" \
+    "carries no 'file:<path>' token" \
+    "duplicate id 'd1'" \
+    "not a checklist item"; do
+    grep -qF "$needle" <<<"$OUT" && NROWS=$((NROWS + 1))
+done
+if grep -qF "is MALFORMED" <<<"$OUT" && [[ "$NROWS" -ge 3 ]]; then
+    pass "200: the malformed checklist blocks and reports $NROWS defects in one pass"
+else
+    fail "200: shape diagnosis is thin (rows=$NROWS): ${OUT:0:600}"
+fi
+if grep -qF "docs/broken/CHECKLIST.md is MALFORMED" <<<"$OUT" &&
+    ! grep -qF "docs/good/CHECKLIST.md" <<<"$OUT"; then
+    pass "200 CONTROL: the clean checklist beside it is never mentioned"
+else
+    fail "200 CONTROL: the shape verdict smeared onto a healthy file: ${OUT:0:600}"
+fi
+
+echo "== 201. the poll fast path FORFEITS on a live checklist, stat-only =="
+# The banked pollbase carries clsig and cl_live (wl_checks.bank_pollbase).
+# Leg 1 banks a LIVE-but-non-blocking world (wave claimed by a peer), so
+# cl_live=1 with an unchanged signature -- which is the only thing that can
+# make the silent path forfeit here. Legs 2 and 3 are the controls: the same
+# dance with no checklist at all, and with a settled one, must stay silent.
+setup
+brief_now
+hand_now
+cldeliver docs/demo/README.md "the readme"
+clfile demo <<'MD'
+# Handoff checklist: demo
+Status: executing
+
+## Deliverables
+- [x] d1 file:docs/demo/README.md
+
+## Waves
+- [ ] w1 Wave A: wire the thing
+MD
+as_peer cafe0000 reqcli --add cafe0000 "cl:demo/w1 Wave A: wire the thing" >/dev/null
+say "answer
+
+## Remaining
+- nothing of mine"
+check "201: the full stop allows and banks the checklist world" allow ""
+BANK="$(cat "${WL%.md}.pollbase-deadbeef")"
+if grep -qF '"cl_live": 1' <<<"$BANK" && grep -qE '"clsig": "[0-9a-f]{16}"' <<<"$BANK"; then
+    pass "201: the pollbase banks the live count beside a stat-only signature"
+else
+    fail "201: the checklist world was not banked: $BANK"
+fi
+reqcli --poll deadbeef >/dev/null
+OUT="$(run)"
+if [[ -n "$OUT" ]]; then
+    pass "201: a live checklist forfeits the silent poll even with an unchanged world"
+else
+    fail "201: the poll went silent while a live handoff was outstanding"
+fi
+setup
+brief_now
+hand_now
+say "answer
+
+## Remaining
+- nothing of mine"
+check "201 CONTROL: baseline stop with no checklist at all" allow ""
+if grep -qF '"cl_live": 0' <<<"$(cat "${WL%.md}.pollbase-deadbeef")"; then
+    pass "201 CONTROL: a repo with no handoffs banks cl_live=0, which is what keeps polls free"
+else
+    fail "201 CONTROL: an empty repo banked a live count: $(cat "${WL%.md}.pollbase-deadbeef")"
+fi
+reqcli --poll deadbeef >/dev/null
+OUT="$(run)"
+RC=$?
+if [[ "$RC" -eq 0 && -z "$OUT" ]]; then
+    pass "201 CONTROL: with no checklist the poll stop is still perfectly silent"
+else
+    fail "201 CONTROL: the gate broke the silent path for everyone: rc=$RC '${OUT:0:200}'"
+fi
+setup
+brief_now
+hand_now
+cldeliver docs/demo/README.md "the readme"
+clfile demo <<'MD'
+# Handoff checklist: demo
+Status: done
+
+## Deliverables
+- [x] d1 file:docs/demo/README.md
+
+## Waves
+- [x] w1 Wave A: wire the thing
+MD
+say "answer
+
+## Remaining
+- nothing of mine"
+check "201 CONTROL: baseline stop with a SETTLED checklist" allow ""
+reqcli --poll deadbeef >/dev/null
+OUT="$(run)"
+RC=$?
+if [[ "$RC" -eq 0 && -z "$OUT" ]]; then
+    pass "201 CONTROL: a done program costs polls nothing, exactly as promised"
+else
+    fail "201 CONTROL: a settled checklist still charged the poll: rc=$RC '${OUT:0:200}'"
+fi
+# The banked cl_live is still 0, so the ONLY thing that can forfeit the silent
+# path on the next poll is the moved signature -- and the battery it pays for
+# is what catches the un-tick this edit smuggled in.
+clfile demo <<'MD'
+# Handoff checklist: demo
+Status: done
+
+## Deliverables
+- [x] d1 file:docs/demo/README.md
+
+## Waves
+- [ ] w1 Wave A: wire the thing
+MD
+reqcli --poll deadbeef >/dev/null
+OUT="$(run)"
+if grep -qF "reality disagrees" <<<"$OUT"; then
+    pass "201: a MOVED signature forfeits too, so an edited checklist cannot hide behind a poll"
+else
+    fail "201: an edited checklist slipped past the poll fast path: '${OUT:0:200}'"
+fi
+
+echo "== 202. checklists_sig() is STAT-ONLY, and the unreadable file proves it =="
+# A contract, not an optimisation: the poll path compares this value, and a
+# version that opened files would pay exactly the cost the fast path exists to
+# avoid. A chmod-000 checklist is the instrument -- stat still answers where
+# read cannot, so the signature must come back while the ADJUDICATION (which
+# does read) fails closed into the ALWAYS-tier unreadable violation.
+setup
+mkdir -p "$BASE/proj/docs/locked"
+printf 'Status: executing\n' >"$BASE/proj/docs/locked/CHECKLIST.md"
+chmod 000 "$BASE/proj/docs/locked/CHECKLIST.md"
+OUT=$(
+    cd "$(dirname "$HOOK")" && CLROOT="$BASE/proj" python3 - <<'PYEOF'
+import os
+import sys
+
+sys.path.insert(0, ".")
+import wl_checklist as CL
+
+root = os.environ["CLROOT"]
+path = os.path.join(root, "docs", "locked", "CHECKLIST.md")
+try:
+    open(path).read()
+    print("READABLE yes")
+except OSError:
+    print("READABLE no")
+print("SIG", CL.checklists_sig(root))
+v, a, live = CL.checklist_findings(root, None, "deadbeef-1111", "")
+print("V", v[0][0], v[0][1], live)
+print("TEXT", "THIS IS A HOOK BUG" in v[0][2])
+PYEOF
+)
+chmod 644 "$BASE/proj/docs/locked/CHECKLIST.md"
+if grep -q "^READABLE no$" <<<"$OUT"; then
+    pass "202 CONTROL: the fixture really is unreadable, so the leg below means something"
+else
+    fail "202 CONTROL: chmod 000 did not deny this process (running as root?): ${OUT:0:200}"
+fi
+if grep -qE "^SIG [0-9a-f]{16}$" <<<"$OUT"; then
+    pass "202: checklists_sig returns a signature for a file it may not open"
+else
+    fail "202: the stat-only signature raised or came back malformed: ${OUT:0:300}"
+fi
+if grep -q "^V cl-shape True 1$" <<<"$OUT" && grep -q "^TEXT True$" <<<"$OUT"; then
+    pass "202: and the reading half fails CLOSED, ALWAYS-tier, naming itself a hook bug"
+else
+    fail "202: an unreadable checklist did not fail closed: ${OUT:0:300}"
+fi
+rm -f "$BASE/proj/docs/locked/CHECKLIST.md"
+
+echo "== 203. SessionStart hands a new session the live checklists =="
+setup
+cldeliver docs/demo/README.md "the readme"
+clfile demo <<'MD'
+# Handoff checklist: demo
+Status: executing
+Owner: cafe0000
+
+## Deliverables
+- [x] d1 file:docs/demo/README.md
+
+## Waves
+- [x] w1 Wave A: wire the thing
+- [ ] w2 Wave B: land the rest
+MD
+out="$(printf '{"session_id":"%s","cwd":"%s"}' "$SID" "$BASE/proj" |
+    TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" WORKLIST_AGENT_BRANCH=agenttest \
+        python3 "$HOOK" --session-start 2>/dev/null)"
+if grep -qF "LIVE HANDOFF CHECKLISTS" <<<"$out" &&
+    grep -qF "docs/demo/CHECKLIST.md [executing] owner=cafe0000 deliverables 1/1 verified, waves 1/2 settled" <<<"$out"; then
+    pass "203: the listing carries status, owner and both progress fractions"
+else
+    fail "203: SessionStart did not hand back the live checklist: ${out:0:400}"
+fi
+clfile demo <<'MD'
+# Handoff checklist: demo
+Status: done
+
+## Deliverables
+- [x] d1 file:docs/demo/README.md
+
+## Waves
+- [x] w1 Wave A: wire the thing
+MD
+out="$(printf '{"session_id":"%s","cwd":"%s"}' "$SID" "$BASE/proj" |
+    TMPDIR="$BASE/tmp" CLAUDE_PROJECT_DIR="$BASE/proj" WORKLIST_AGENT_BRANCH=agenttest \
+        python3 "$HOOK" --session-start 2>/dev/null)"
+if ! grep -qF "LIVE HANDOFF CHECKLISTS" <<<"$out"; then
+    pass "203 CONTROL: a settled checklist is not context anyone needs handed back"
+else
+    fail "203 CONTROL: the listing surfaced a done handoff: ${out:0:400}"
 fi
 
 echo

--- a/.claude/hooks/stop/wl_checklist.py
+++ b/.claude/hooks/stop/wl_checklist.py
@@ -1,0 +1,462 @@
+"""wl_checklist: the /handoff checklist gate over docs/<slug>/CHECKLIST.md.
+
+WHY THIS EXISTS: /handoff distills a session into a docs/<slug>/ design suite
+and then told the FUTURE session, in prose inside PROMPT.md, to seed the
+worklist. Prose is not a gate. Nothing verified that the producing session
+actually wrote every deliverable, and nothing verified that the consuming
+sessions ever covered the waves, so an ignored or compacted-away PROMPT.md
+dropped program work silently and nobody found out.
+
+The checklist is the machine-readable half of a handoff. Its two halves are
+enforced by DIFFERENT means, and confusing them is the whole trap:
+
+  * DELIVERABLES ARE FILE-VERIFIED, period. Every `file:<path>` token must
+    exist and be non-empty. The tick is bookkeeping; the FILE is the truth,
+    so a ticked-but-missing deliverable is called out louder than an
+    unticked one, not quieter.
+  * WAVES ARE TICK-ON-TRUST WITH STORE LINKAGE. A wave is settled by `[x]`,
+    or COVERED by any live worklist item whose text carries the token
+    `cl:<slug>/<wN>`. Evidence discipline then rides the existing --tick
+    gate rather than being re-invented here, and no checklist state is
+    written into the JSONL store (one source of truth, no reconciliation).
+
+FAIL CLOSED, everywhere. A checklist this module cannot parse gates nothing,
+so it BLOCKS rather than passing quietly (the V_CI_UNREADABLE precedent), and
+an unexpected exception becomes an ALWAYS-tier violation naming itself. The
+hook never WRITES a checklist: every exit is one file edit or one worklist
+command a session can complete alone in a single turn.
+
+COST: the full Stop battery reads these files, because they are the
+enforcement point, and a repo with none pays exactly one glob. The poll fast
+path never opens one -- checklists_sig() is stat-only and is banked in the
+pollbase, so a live checklist forfeits the silent path without ever costing a
+read on it.
+"""
+
+import glob
+import hashlib
+import os
+import re
+import stat
+
+import wl_core as C
+import wl_store as S
+import worklist_messages as M
+
+# Header contract, mirroring the PLAN-*.md convention (wl_checks.PLAN_STATUS_RE).
+CL_HEADER_LINES = 10
+CL_STATUS_RE = re.compile(r"^Status:\s*([A-Za-z-]+)\s*$", re.MULTILINE)
+CL_OWNER_RE = re.compile(r"^Owner:\s*([A-Za-z0-9][A-Za-z0-9._-]{0,31})\s*$", re.MULTILINE)
+# Only ' ' and 'x': leases and deferrals are worklist states, not checklist
+# states, and a checklist that grew its own state machine would be a second
+# store to reconcile.
+CL_ITEM = re.compile(r"^\s*-\s*\[(?P<state>[ x])\]\s+(?P<id>[dw][0-9]{1,3})\s+(?P<text>\S.*)$")
+# The INTENDED-checkbox detector, deliberately loose, so a typo'd item is a
+# loud shape error instead of an invisible ignored line. Prose links of the
+# form `- [text](url)` do NOT match: the bracket body is capped at one char.
+CL_BOXLIKE = re.compile(r"^\s*-\s*\[.?\]\s")
+CL_SECTION_RE = re.compile(r"^##\s+(Deliverables|Waves)\s*$", re.IGNORECASE)
+CL_FILE_TOKEN = re.compile(r"\bfile:(\S+)")
+# slug, item id -- the worklist-linkage token, `cl:<slug>/<wN>`. Named _LINK_
+# rather than _TOKEN_ because ruff's S105 (hardcoded-password) fires on any
+# string literal bound to a name containing "TOKEN", and this repo's rule is to
+# fix the finding rather than to noqa past the gate.
+CL_LINK_FMT = "cl:%s/%s"
+CL_LIVE = ("producing", "executing")
+CL_STATES = ("producing", "executing", "done", "superseded")
+
+
+def checklist_paths(root):
+    """Every docs/<slug>/CHECKLIST.md, sorted. One glob is the entire cost of
+    this module for a repo that keeps no handoffs."""
+    return sorted(glob.glob(os.path.join(str(root), "docs", "*", "CHECKLIST.md")))
+
+
+def _rel(root, path):
+    try:
+        return os.path.relpath(path, str(root))
+    except ValueError:
+        return str(path)
+
+
+def checklists_sig(root):
+    """A STAT-ONLY signature of every checklist: sha1 over sorted
+    (relpath, mtime_ns, size).
+
+    Never opens a file, and that is a contract rather than an optimisation:
+    this is what the poll fast path compares against its banked baseline, and
+    a poll that read files would pay the cost the fast path exists to avoid.
+    A path that cannot be stat'd contributes a sentinel instead of raising, so
+    a permission-denied checklist still MOVES the signature (which forfeits
+    the silent path) rather than wedging the poll.
+    """
+    h = hashlib.sha1()
+    for path in checklist_paths(root):
+        rel = _rel(root, path)
+        try:
+            st = os.stat(path)
+            row = (rel, st.st_mtime_ns, st.st_size)
+        except OSError:
+            row = (rel, -1, -1)
+        h.update(("%s|%d|%d\n" % row).encode("utf-8", "replace"))
+    return h.hexdigest()[:16]
+
+
+def _err(lineno, line, why):
+    return "line %d: %s -- %s" % (lineno, (line or "").strip()[:80], why)
+
+
+def parse_checklist(root, path):
+    """{path, rel, slug, status, owner, deliverables, waves, errors}.
+
+    EVERY shape problem is collected, never the first one only: a session
+    handed one error per stop would pay one turn per typo. `status` is the
+    lowercased value and is empty when the header is unusable, which the
+    caller reads as malformed rather than as a state.
+    """
+    out = {
+        "path": str(path),
+        "rel": _rel(root, path),
+        "slug": os.path.basename(os.path.dirname(str(path))),
+        "status": "",
+        "owner": "",
+        "deliverables": [],
+        "waves": [],
+        "errors": [],
+    }
+    with open(str(path), encoding="utf-8", errors="replace") as fh:
+        text = fh.read()
+    lines = text.splitlines()
+    header = "\n".join(lines[:CL_HEADER_LINES])
+
+    m = CL_STATUS_RE.search(header)
+    if not m:
+        out["errors"].append(
+            _err(
+                1,
+                lines[0] if lines else "",
+                "no 'Status:' line in the first %d lines" % CL_HEADER_LINES,
+            )
+        )
+    else:
+        st_val = m.group(1).strip().lower()
+        if st_val not in CL_STATES:
+            out["errors"].append(
+                _err(
+                    header.count("\n", 0, m.start()) + 1,
+                    m.group(0),
+                    "unknown Status '%s'; expected one of %s" % (st_val, ", ".join(CL_STATES)),
+                )
+            )
+        else:
+            out["status"] = st_val
+    mo = CL_OWNER_RE.search(header)
+    if mo:
+        out["owner"] = mo.group(1)
+    elif out["status"] == "producing":
+        out["errors"].append(
+            _err(1, lines[0] if lines else "", "no 'Owner:' line while 'Status: producing'")
+        )
+
+    section, seen = None, {}
+    for n, line in enumerate(lines, 1):
+        ms = CL_SECTION_RE.match(line)
+        if ms:
+            section = ms.group(1).lower()
+            continue
+        if line.startswith("#"):
+            section = None  # any other heading ends the section it followed
+            continue
+        mi = CL_ITEM.match(line)
+        if not mi:
+            if CL_BOXLIKE.match(line):
+                out["errors"].append(
+                    _err(
+                        n,
+                        line,
+                        "not a checklist item; expected '- [ ] d1 file:<path>' "
+                        "or '- [ ] w1 <title>'",
+                    )
+                )
+            continue
+        iid, body = mi.group("id"), mi.group("text").strip()
+        if section is None:
+            out["errors"].append(
+                _err(n, line, "item sits outside '## Deliverables' and '## Waves'")
+            )
+            continue
+        want = "d" if section == "deliverables" else "w"
+        if iid[0] != want:
+            out["errors"].append(
+                _err(
+                    n,
+                    line,
+                    "id '%s' does not belong under that section (expected a '%s' prefix)"
+                    % (iid, want),
+                )
+            )
+            continue
+        if iid in seen:
+            out["errors"].append(
+                _err(n, line, "duplicate id '%s', first seen on line %d" % (iid, seen[iid]))
+            )
+            continue
+        seen[iid] = n
+        item = {"id": iid, "ticked": mi.group("state") == "x", "text": body}
+        if want == "d":
+            item["files"] = CL_FILE_TOKEN.findall(body)
+            if not item["files"]:
+                out["errors"].append(
+                    _err(
+                        n,
+                        line,
+                        "deliverable carries no 'file:<path>' token, so nothing verifies it",
+                    )
+                )
+                continue
+            out["deliverables"].append(item)
+        else:
+            out["waves"].append(item)
+    return out
+
+
+def verify_files(root, files):
+    """[(token, 'ok'|'missing'|'empty')] for the file: tokens of one item.
+
+    A zero-byte file is EMPTY and named distinctly from MISSING, because the
+    two have different causes (a write that never happened versus one that
+    was truncated) and reading them as one hid a truncated PROMPT.md. A path
+    that exists but is not a regular file reads as missing: a directory is
+    not a deliverable.
+    """
+    out = []
+    for tok in files:
+        p = os.path.expanduser(tok)
+        full = p if os.path.isabs(p) else os.path.join(str(root), p)
+        try:
+            st = os.stat(full)
+        except OSError:
+            out.append((tok, "missing"))
+            continue
+        if not stat.S_ISREG(st.st_mode):
+            out.append((tok, "missing"))
+        elif st.st_size == 0:
+            out.append((tok, "empty"))
+        else:
+            out.append((tok, "ok"))
+    return out
+
+
+def _deliverable_rows(root, parsed):
+    """(rows, met, total) -- one row per file: token that does not verify."""
+    rows, met = [], 0
+    for d in parsed["deliverables"]:
+        bad = [(t, v) for t, v in verify_files(root, d["files"]) if v != "ok"]
+        if not bad:
+            met += 1
+            continue
+        rows.extend("    %s %s -- %s" % (d["id"], t, v.upper()) for t, v in bad)
+    return rows, met, len(parsed["deliverables"])
+
+
+def _covering_items(fold, token):
+    """Live store records whose text carries the linkage token.
+
+    Word-bounded and literal-escaped, so `cl:demo/w1` never matches
+    `cl:demo/w10`. Any live state counts as coverage: an open item, a lease
+    and a deferral are all somebody having CLAIMED the wave, which is exactly
+    what an uncovered wave lacks.
+    """
+    rx = re.compile(r"\b%s\b" % re.escape(token))
+    return [
+        rec
+        for rec in (getattr(fold, "items", None) or [])
+        if rx.search(rec.get("line") or rec.get("text") or "")
+    ]
+
+
+def _wave_rows(fold, parsed, session_id):
+    """Problem rows for the unticked waves, each carrying its one-command exit."""
+    me8 = (session_id or "unknown")[:8]
+    slug, rel, rows = parsed["slug"], parsed["rel"], []
+    for w in parsed["waves"]:
+        if w["ticked"]:
+            continue
+        token = CL_LINK_FMT % (slug, w["id"])
+        matches = _covering_items(fold, token)
+        if not matches:
+            # Quotes are stripped from the title because the exit is a shell
+            # command, and an exit a reader has to repair is not an exit.
+            title = w["text"][:60].replace("'", "").replace('"', "")
+            rows.append(
+                "    %s UNCOVERED: no worklist item carries '%s'\n"
+                "        NEXT: .claude/hooks/stop/worklist.py --add %s '%s %s'"
+                % (w["id"], token, me8, token, title)
+            )
+        elif all((r.get("state") or "") == "x" for r in matches):
+            ids = ", ".join("#%s" % r.get("id") for r in matches)
+            rows.append(
+                "    %s DONE-BUT-UNTICKED: store item %s is done with evidence; "
+                "tick '- [x] %s' in %s" % (w["id"], ids, w["id"], rel)
+            )
+    return rows
+
+
+def _adopt_hint(owner, projects_dir, rel):
+    """The adoption sentence for a foreign checklist whose owner is dead, "" otherwise."""
+    try:
+        age = S.owner_age_hours(owner, projects_dir)
+    except Exception:  # noqa: BLE001 -- an advisory hint must never break the gate
+        age = None
+    if age is None or age < float(os.environ.get("WORKLIST_DEAD_HOURS", "24")):
+        return ""
+    return (
+        " That session's transcript has been idle %dh, so the handoff is very "
+        "likely abandoned: adopt it by editing the 'Owner:' line of %s to your "
+        "own prefix, or set 'Status: superseded' if the program is dead." % (int(age), rel)
+    )
+
+
+def _adjudicate(root, path, fold, session_id, projects_dir):
+    """(violations, advisories, live) for ONE checklist. See checklist_findings."""
+    v, a = [], []
+    parsed = parse_checklist(root, path)
+    rel, slug, status, owner = parsed["rel"], parsed["slug"], parsed["status"], parsed["owner"]
+    if parsed["errors"]:
+        # A malformed checklist is adjudicated NO FURTHER: every verdict below
+        # would be read off a file the parser has already said it misread.
+        rows = "\n".join("    " + e for e in parsed["errors"])
+        return [("cl-shape", False, M.V_CL_SHAPE % (rel, rows))], a, 1
+    if status == "superseded":
+        return v, a, 0  # the terminal escape for an abandoned program
+    drows, met, total = _deliverable_rows(root, parsed)
+
+    if status == "done":
+        rows = list(drows)
+        rows.extend(
+            "    wave %s is not ticked, yet the checklist claims done" % w["id"]
+            for w in parsed["waves"]
+            if not w["ticked"]
+        )
+        if not rows:
+            return v, a, 0
+        text = M.V_CL_FLIP % (rel, "done", "\n".join(rows), rel)
+        if C.owned_by_me(owner or None, session_id):
+            v.append(("cl-flip", False, text))
+        else:
+            a.append(("cl-foreign", text, 2))
+        return v, a, 1
+
+    if status == "producing":
+        # Owner is guaranteed present here: its absence is a shape error above.
+        if C.same_session(owner, session_id):
+            if drows:
+                v.append(
+                    (
+                        "cl-producing",
+                        False,
+                        M.V_CL_PRODUCING % (slug, met, total, "\n".join(drows), rel),
+                    )
+                )
+            else:
+                v.append(("cl-producing", False, M.V_CL_PRODUCING_DONE % (slug, rel)))
+        else:
+            a.append(
+                (
+                    "cl-foreign",
+                    M.N_CL_FOREIGN % (slug, owner, _adopt_hint(owner, projects_dir, rel)),
+                    2,
+                )
+            )
+        return v, a, 1
+
+    # executing: two INDEPENDENT checks, because a program can lose an
+    # artifact and drop a wave at the same time and each has its own exit.
+    if drows:
+        # Deliverables are re-verified regardless of their ticks, which is what
+        # catches both a ticked-but-missing artifact and one deleted after the flip.
+        text = M.V_CL_FLIP % (rel, "executing", "\n".join(drows), rel)
+        if C.owned_by_me(owner or None, session_id):
+            v.append(("cl-flip", False, text))
+        else:
+            a.append(("cl-foreign", text, 2))
+    wrows = _wave_rows(fold, parsed, session_id)
+    if not wrows and not drows and all(w["ticked"] for w in parsed["waves"]):
+        wrows = ["    everything is settled; set 'Status: done' in %s" % rel]
+    if wrows:
+        # NOT ownership-gated, deliberately: an uncovered wave is UNCLAIMED
+        # work, the same semantics as an untagged worklist item, so it blocks
+        # whoever tries to stop. The moment anyone claims it with --add it
+        # stops blocking everyone else.
+        v.append(("cl-waves", False, M.V_CL_WAVES % (slug, rel, "\n".join(wrows))))
+    return v, a, 1
+
+
+def checklist_findings(root, fold, session_id, projects_dir):
+    """(violations, advisories, live_count) for every checklist in the repo.
+
+    violations are (key, always, text) ready for run_stop's vadd; advisories
+    are (key, text, prio) ready for outq_add. live_count is what the poll
+    fast path banks: 0 means no checklist can block, so a poll may still take
+    the silent path.
+
+    NEVER RAISES. Any unexpected exception becomes the ALWAYS-tier unreadable
+    violation and counts as live, because a gate that went blind must say so
+    and must not also hand the poll path a clean baseline.
+    """
+    violations, advisories, live = [], [], 0
+    try:
+        paths = checklist_paths(root)
+    except Exception as exc:  # noqa: BLE001 -- fail CLOSED
+        return [("cl-shape", True, M.V_CL_UNREADABLE % str(exc)[:160])], [], 1
+    for path in paths:
+        try:
+            v, a, n = _adjudicate(root, path, fold, session_id, projects_dir)
+        except Exception as exc:  # noqa: BLE001 -- fail CLOSED, per file
+            violations.append(("cl-shape", True, M.V_CL_UNREADABLE % str(exc)[:160]))
+            live += 1
+            continue
+        violations.extend(v)
+        advisories.extend(a)
+        live += n
+    return violations, advisories, live
+
+
+def checklists_block(root):
+    """(listing, n): one line per live-or-malformed checklist, for
+    SessionStart and PostCompact. ("", 0) when there is nothing to say, so a
+    repo without handoffs emits no block at all.
+
+    Reading files HERE is fine: these two events fire once each, unlike the
+    poll path this module is otherwise careful never to charge.
+    """
+    lines = []
+    for path in checklist_paths(root):
+        rel = _rel(root, path)
+        try:
+            p = parse_checklist(root, path)
+        except Exception:  # noqa: BLE001 -- name it, never drop it
+            lines.append("  %s [UNREADABLE] the Stop hook will block on this one" % rel)
+            continue
+        malformed = bool(p["errors"])
+        if not malformed and p["status"] not in CL_LIVE:
+            continue
+        met = sum(
+            1
+            for d in p["deliverables"]
+            if all(v == "ok" for _t, v in verify_files(root, d["files"]))
+        )
+        settled = sum(1 for w in p["waves"] if w["ticked"])
+        lines.append(
+            "  %s [%s] owner=%s deliverables %d/%d verified, waves %d/%d settled"
+            % (
+                rel,
+                "MALFORMED" if malformed else p["status"],
+                p["owner"] or "-",
+                met,
+                len(p["deliverables"]),
+                settled,
+                len(p["waves"]),
+            )
+        )
+    return "\n".join(lines), len(lines)

--- a/.claude/hooks/stop/wl_checklist.py
+++ b/.claude/hooks/stop/wl_checklist.py
@@ -317,6 +317,29 @@ def _adopt_hint(owner, projects_dir, rel):
     )
 
 
+def _ckey(prefix, slug):
+    """The finding key for ONE checklist: `<check-class>:<slug>`.
+
+    A FIXED key per check class was the bug (automated review, PR #563). Two
+    things downstream read the key as an identity, and both starve the second
+    checklist rather than delaying it:
+
+      * the focused block's rotation (wl_checks.py) ties-breaks on
+        `order = {v[0]: i for ...}`, a dict comp in which duplicate keys
+        COLLAPSE, so two violations sharing a key get identical sort tuples and
+        `min` returns the first one on every stop, forever;
+      * outq_add finds a non-sticky entry by key alone, so the second
+        advisory's text OVERWRITES the first's instead of queueing beside it.
+
+    Two concurrent handoffs is an ordinary state here, so the second one simply
+    vanished into the "N more outstanding" count. Scoping by slug costs
+    nothing: the rotation prunes any key that is no longer outstanding, so a
+    settled checklist's key leaves `served` on the next stop. The PREFIX is
+    preserved verbatim so a grep on the check class still matches.
+    """
+    return "%s:%s" % (prefix, slug)
+
+
 def _adjudicate(root, path, fold, session_id, projects_dir):
     """(violations, advisories, live) for ONE checklist. See checklist_findings."""
     v, a = [], []
@@ -326,7 +349,7 @@ def _adjudicate(root, path, fold, session_id, projects_dir):
         # A malformed checklist is adjudicated NO FURTHER: every verdict below
         # would be read off a file the parser has already said it misread.
         rows = "\n".join("    " + e for e in parsed["errors"])
-        return [("cl-shape", False, M.V_CL_SHAPE % (rel, rows))], a, 1
+        return [(_ckey("cl-shape", slug), False, M.V_CL_SHAPE % (rel, rows))], a, 1
     if status == "superseded":
         return v, a, 0  # the terminal escape for an abandoned program
     drows, met, total = _deliverable_rows(root, parsed)
@@ -340,11 +363,22 @@ def _adjudicate(root, path, fold, session_id, projects_dir):
         )
         if not rows:
             return v, a, 0
-        text = M.V_CL_FLIP % (rel, "done", "\n".join(rows), rel)
         if C.owned_by_me(owner or None, session_id):
-            v.append(("cl-flip", False, text))
+            v.append(
+                (
+                    _ckey("cl-flip", slug),
+                    False,
+                    M.V_CL_FLIP % (rel, "done", "\n".join(rows), rel),
+                )
+            )
         else:
-            a.append(("cl-foreign", text, 2))
+            a.append(
+                (
+                    _ckey("cl-foreign", slug),
+                    M.N_CL_FOREIGN_DRIFT % (rel, "done", owner, "\n".join(rows)),
+                    2,
+                )
+            )
         return v, a, 1
 
     if status == "producing":
@@ -353,17 +387,17 @@ def _adjudicate(root, path, fold, session_id, projects_dir):
             if drows:
                 v.append(
                     (
-                        "cl-producing",
+                        _ckey("cl-producing", slug),
                         False,
                         M.V_CL_PRODUCING % (slug, met, total, "\n".join(drows), rel),
                     )
                 )
             else:
-                v.append(("cl-producing", False, M.V_CL_PRODUCING_DONE % (slug, rel)))
+                v.append((_ckey("cl-producing", slug), False, M.V_CL_PRODUCING_DONE % (slug, rel)))
         else:
             a.append(
                 (
-                    "cl-foreign",
+                    _ckey("cl-foreign", slug),
                     M.N_CL_FOREIGN % (slug, owner, _adopt_hint(owner, projects_dir, rel)),
                     2,
                 )
@@ -375,11 +409,22 @@ def _adjudicate(root, path, fold, session_id, projects_dir):
     if drows:
         # Deliverables are re-verified regardless of their ticks, which is what
         # catches both a ticked-but-missing artifact and one deleted after the flip.
-        text = M.V_CL_FLIP % (rel, "executing", "\n".join(drows), rel)
         if C.owned_by_me(owner or None, session_id):
-            v.append(("cl-flip", False, text))
+            v.append(
+                (
+                    _ckey("cl-flip", slug),
+                    False,
+                    M.V_CL_FLIP % (rel, "executing", "\n".join(drows), rel),
+                )
+            )
         else:
-            a.append(("cl-foreign", text, 2))
+            a.append(
+                (
+                    _ckey("cl-foreign", slug),
+                    M.N_CL_FOREIGN_DRIFT % (rel, "executing", owner, "\n".join(drows)),
+                    2,
+                )
+            )
     wrows = _wave_rows(fold, parsed, session_id)
     if not wrows and not drows and all(w["ticked"] for w in parsed["waves"]):
         wrows = ["    everything is settled; set 'Status: done' in %s" % rel]
@@ -388,7 +433,7 @@ def _adjudicate(root, path, fold, session_id, projects_dir):
         # work, the same semantics as an untagged worklist item, so it blocks
         # whoever tries to stop. The moment anyone claims it with --add it
         # stops blocking everyone else.
-        v.append(("cl-waves", False, M.V_CL_WAVES % (slug, rel, "\n".join(wrows))))
+        v.append((_ckey("cl-waves", slug), False, M.V_CL_WAVES % (slug, rel, "\n".join(wrows))))
     return v, a, 1
 
 
@@ -408,12 +453,19 @@ def checklist_findings(root, fold, session_id, projects_dir):
     try:
         paths = checklist_paths(root)
     except Exception as exc:  # noqa: BLE001 -- fail CLOSED
+        # UNSCOPED, and deliberately so: the glob itself failed, so there is no
+        # slug to scope by, and this path returns immediately -- at most one
+        # such finding can exist per stop, so it has nothing to collide with.
         return [("cl-shape", True, M.V_CL_UNREADABLE % str(exc)[:160])], [], 1
     for path in paths:
         try:
             v, a, n = _adjudicate(root, path, fold, session_id, projects_dir)
         except Exception as exc:  # noqa: BLE001 -- fail CLOSED, per file
-            violations.append(("cl-shape", True, M.V_CL_UNREADABLE % str(exc)[:160]))
+            # Per FILE, so scoped like every other per-checklist finding. The
+            # slug is read off the path rather than out of the parse, because
+            # the parse is what just threw.
+            slug = os.path.basename(os.path.dirname(str(path)))
+            violations.append((_ckey("cl-shape", slug), True, M.V_CL_UNREADABLE % str(exc)[:160]))
             live += 1
             continue
         violations.extend(v)

--- a/.claude/hooks/stop/wl_checks.py
+++ b/.claude/hooks/stop/wl_checks.py
@@ -1483,7 +1483,9 @@ def handle_post_compact(event):
         state = "no-branch"
         msg = M.CTX_POSTCOMPACT_NO_BRANCH % traps_block
     else:
-        state, _age, text = S.agent_state_state(root, branch)  # shape + presence only
+        # shape + presence only, but for THIS session's own section.
+        state, _age, text = S.agent_state_state(root, branch, session_id=sid)
+        _, peers, _npeers = S.agent_state_briefing(root, branch, sid, C.projects_dir(root))
         if state in ("missing", "no-dir"):
             msg = M.CTX_POSTCOMPACT_MISSING % (
                 S.agent_state_path(root, branch),
@@ -1506,6 +1508,14 @@ def handle_post_compact(event):
                 S.agent_traps_path(root),
                 traps_block,
             )
+        # AFTER the briefing, on BOTH branches. Own section first is the point:
+        # a compacted session reads top-down, and the block it must act on is
+        # its own. On the missing branch this is the whole state content there
+        # is -- before sections, that branch returned none at all, so a
+        # compacted session on a shared branch was told to reconstruct from
+        # nothing while a peer's section sat in the file unread.
+        if peers:
+            msg += "\n\n" + M.CTX_POSTCOMPACT_PEERS % peers
     # v16: the durable half of the briefing, appended to ALL THREE branches
     # above. STATE.md says what is true right now and can be missing or
     # stale; a plan file says what was DESIGNED and is committed, so it is
@@ -1917,8 +1927,18 @@ def run_stop(event, event_ok, worklist, hook_file):
         root, worklist, session_id, fold=fold, transcript_path=event.get("transcript_path")
     )
     agent_branch = C.git_branch(root)
+    # session_id, not blank: the verdict is about THIS session's own section.
+    # Without it the check judged whichever document happened to be on disk, so
+    # a peer's write reset everyone's clock and -- worse than a skipped stop --
+    # the adopt below banked the PEER'S world signature as this session's own,
+    # making a document describing someone else's world read as this one's
+    # recovery artifact.
     astate, aage, _atext = S.agent_state_state(
-        root, agent_branch, cur_sig=st_sig, saved_sig=state_doc.get("state_sig")
+        root,
+        agent_branch,
+        session_id=session_id,
+        cur_sig=st_sig,
+        saved_sig=state_doc.get("state_sig"),
     )
     if astate == "ok":
         # ADOPT: an "ok" verdict banks the signature so a second session
@@ -2646,6 +2666,43 @@ def run_stop(event, event_ok, worklist, hook_file):
         agent_note = M.N_AGENT_BLIND % root
         # Class 2, volatile: recomputed from the branch state every stop.
         outq_add(worklist, session_id, state_doc, "agent-blind", agent_note, 2)
+    # REPORT-ONLY, and it must stay that way: a session that cannot see its
+    # peers' sections cannot be expected to respect them, but a peer's section
+    # is never this session's obligation. Class 2 volatile, recomputed from the
+    # document every stop, exactly like the blind note above. NEVER reaps here:
+    # a read-only every-turn hook that mutates the shared document is the
+    # fastest route to the next clobber, so it only NAMES what a write would
+    # drop.
+    if agent_branch:
+        try:
+            _p = S.agent_state_path(root, agent_branch)
+            _all = S.agent_state_parse(
+                _p.read_text(encoding="utf-8", errors="replace"), _p.stat().st_mtime
+            )
+            _, _reapable = S.agent_state_dead(_all, session_id, projects_dir)
+            _reap_ids = {id(s) for s in _reapable}
+            _now = time.time()
+            _rows = [
+                "    %-14s %4d min old%s"
+                % (
+                    s["owner"],
+                    int(max(0.0, (_now - s["ts"]) / 60.0)),
+                    "   REAP-ELIGIBLE" if id(s) in _reap_ids else "",
+                )
+                for s in _all
+                if not C.same_session(s["owner"], session_id)
+            ]
+            if _rows:
+                outq_add(
+                    worklist,
+                    session_id,
+                    state_doc,
+                    "agent-peers",
+                    M.N_AGENT_PEERS % (agent_branch, "\n".join(_rows)),
+                    2,
+                )
+        except OSError:
+            pass  # no document, or an unreadable one: the astate branches above own that
     # v18: unread sub-agent reports, on ORDINARY stops as well as at the two
     # boundaries wl_report already covers by hook. SessionStart and PostCompact
     # catch a fresh or compacted session; this catches the far commoner case of

--- a/.claude/hooks/stop/wl_checks.py
+++ b/.claude/hooks/stop/wl_checks.py
@@ -15,6 +15,7 @@ import pathlib
 import re
 import time
 
+import wl_checklist
 import wl_ci
 import wl_core as C
 import wl_email
@@ -354,7 +355,7 @@ def pollbase_path(worklist, session_id):
     return worklist.with_suffix(".pollbase-%s" % (session_id or "unknown")[:8])
 
 
-def bank_pollbase(worklist, session_id, sig):
+def bank_pollbase(worklist, session_id, sig, clsig="", cl_live=-1):
     """Record the world as the poll fast path's baseline.
 
     OPERATOR DECISION, 2026-07-30, overriding the original v9 rule that only an
@@ -372,10 +373,18 @@ def bank_pollbase(worklist, session_id, sig):
     inbox). What banking buys is only this: a poll that changes nothing can
     recognise that nothing changed. The moment real work lands, the signature
     moves and the battery returns on its own.
+
+    v20 banks the handoff-checklist world beside it: `clsig` is the stat-only
+    signature of every docs/<slug>/CHECKLIST.md and `cl_live` is how many of
+    them could block. The defaults are the FAIL-SAFE values, not neutral ones
+    -- cl_live=-1 reads as "unknown, forfeit the silent path", so a future
+    call site that forgets these arguments (and an old baseline written before
+    the keys existed) costs a full battery rather than buying a silent stop.
     """
     with contextlib.suppress(OSError):
         pollbase_path(worklist, session_id).write_text(
-            json.dumps({"sig": sig, "at": C.stamp_now()}), encoding="utf-8"
+            json.dumps({"sig": sig, "at": C.stamp_now(), "clsig": clsig, "cl_live": cl_live}),
+            encoding="utf-8",
         )
 
 
@@ -736,6 +745,15 @@ def docs_drift(root):
 # Cost: SessionStart and PostCompact only. The Stop battery and the poll fast
 # path never read plan files; the guide's single os.path.exists probe per
 # TRIAGED item is the only plan-related work on the stop path.
+#
+# HANDOFF CHECKLISTS ARE THE EXCEPTION, and deliberately so (v20,
+# wl_checklist). docs/<slug>/CHECKLIST.md IS the enforcement point, so the
+# full Stop battery does read those files -- a gate that refuses to look at
+# its own subject is not a gate. The poll fast path still never opens one:
+# checklists_sig() is stat-only and its result is banked in the pollbase
+# beside the world signature, so a live or changed checklist forfeits the
+# silent path without ever charging a poll for a read. A repo that keeps no
+# handoffs pays one glob and nothing else.
 
 PLAN_STATUS_RE = re.compile(r"^Status:\s*([A-Za-z-]+)\s*$", re.MULTILINE)
 PLAN_HEADER_LINES = 10
@@ -922,12 +940,26 @@ def poll_fast_path(worklist, session_id, event):
         return False
     base_p = pollbase_path(worklist, session_id)
     try:
-        base_sig = json.loads(base_p.read_text(encoding="utf-8"))["sig"]
+        base = json.loads(base_p.read_text(encoding="utf-8"))
+        base_sig = base["sig"]
         if time.time() - base_p.stat().st_mtime > POLL_FULL_MAX_MIN * 60:
             return False  # the horizon: a poll stop now pays the battery
     except (OSError, ValueError, KeyError, TypeError):
         return False
     root = C.project_root(C.project_start(event))
+    # v20: a LIVE or CHANGED handoff checklist forfeits the silent path. The
+    # battery is where checklist obligations are adjudicated, and this is the
+    # stat-only half of that contract: no checklist is opened here, only
+    # stat'd, and an old baseline missing the keys reads as cl_live=-1 and
+    # forfeits. Done and superseded checklists bank cl_live=0, so a settled
+    # program costs polls nothing.
+    try:
+        if int(base.get("cl_live", -1)) != 0:
+            return False
+        if wl_checklist.checklists_sig(root) != base.get("clsig"):
+            return False
+    except Exception:  # noqa: BLE001 -- a broken forfeit costs the battery, never an allow
+        return False
     # The fold is loaded BEFORE the signature check since v17, because the
     # signature is now derived from this session's items rather than from the
     # shared files' bytes; passing it here keeps the store parsed once.
@@ -1407,6 +1439,14 @@ def handle_session_start(event):
     if listing:
         blocks.append(M.CTX_PLANS % (branch, listing))
         summary.append("%d open plan(s) in docs/agent/%s" % (len(live), branch))
+    # A THIRD independent block, for the reason the two above are independent:
+    # a repo with live handoff checklists and no design docs and no plans must
+    # still be told about the checklists, because the Stop hook will block on
+    # them and a session that has never heard of them cannot act.
+    cl_listing, cl_n = wl_checklist.checklists_block(root)
+    if cl_listing:
+        blocks.append(M.CTX_CHECKLISTS % cl_listing)
+        summary.append("%d live handoff checklist(s)" % cl_n)
     if not blocks:
         return
     C.emit(
@@ -1478,6 +1518,12 @@ def handle_post_compact(event):
         rel, body = plan_status_excerpt(root, live)
         if body:
             msg += "\n\n" + M.CTX_PLANS_EXCERPT % (rel, body)
+    # v20: and the handoff checklists, appended on all three branches above
+    # for the same reason. A compacted session that forgets a live checklist
+    # rediscovers it as a block it cannot explain.
+    cl_listing, _cl_n = wl_checklist.checklists_block(root)
+    if cl_listing:
+        msg += "\n\n" + M.CTX_CHECKLISTS % cl_listing
     C.emit(
         {
             "systemMessage": "PostCompact: STATE.md %s (.agent/%s/STATE.md)"
@@ -2672,6 +2718,28 @@ def run_stop(event, event_ok, worklist, hook_file):
     dstate, ddrift, ddir = docs_drift(root)
     if dstate == "drifted":
         vadd("docs-drift", False, M.V_DOCS_DRIFT % (ddrift, " ".join(PROGRAM_SURFACE), ddir))
+    # ---- v20: the /handoff checklist gate (docs/<slug>/CHECKLIST.md) --------
+    # WHY: /handoff wrote a design suite and INSTRUCTED, in prose, that the
+    # next session seed the worklist. Prose gates nothing, so a handoff whose
+    # PROMPT.md was ignored or compacted away dropped program work silently
+    # and nobody found out. CHECKLIST.md is the machine-readable half of the
+    # same handoff: deliverables are FILE-VERIFIED (the tick is bookkeeping,
+    # the file is the truth) and waves are store-linked through the
+    # `cl:<slug>/<wN>` token, so both ends of the handoff are checkable rather
+    # than promised. The two signature values are computed here because the
+    # pollbase banks them below; see wl_checklist for the adjudication.
+    cl_sig_now, cl_live_now = "", -1
+    try:
+        cl_sig_now = wl_checklist.checklists_sig(root)
+        _cl_v, _cl_a, cl_live_now = wl_checklist.checklist_findings(
+            root, fold, session_id, projects_dir
+        )
+        for _k, _always, _t in _cl_v:
+            vadd(_k, _always, _t)
+        for _k, _t, _p in _cl_a:
+            outq_add(worklist, session_id, state_doc, _k, _t, _p)
+    except Exception as exc:  # noqa: BLE001 -- fail CLOSED: a blind gate must say so
+        vadd("cl-shape", True, M.V_CL_UNREADABLE % str(exc)[:160])
     # v9: the two-cron shape (operator directive). A looped session carries
     # exactly one 5-minute inbox poll beside at most one work loop.
     # v18: a CONFIRMED waiter satisfies this in place of a poll cron. The check
@@ -2970,7 +3038,7 @@ def run_stop(event, event_ok, worklist, hook_file):
         # entirely. Its window is deliberately not marked as fired, so the
         # "last delivered" stamp the roster prints stays true and the next
         # genuinely eventful stop still owes it.
-        bank_pollbase(worklist, session_id, cur_sig)
+        bank_pollbase(worklist, session_id, cur_sig, clsig=cl_sig_now, cl_live=cl_live_now)
         counter.unlink(missing_ok=True)
         S.save_state(worklist, session_id, state_doc)
         C.emit({"systemMessage": quiet_note})
@@ -2985,7 +3053,7 @@ def run_stop(event, event_ok, worklist, hook_file):
         counter.write_text(str(int(counter.read_text()) + 1 if counter.exists() else 1))
         # Bank BEFORE emitting, because emit() exits the process and this is
         # the path a busy session actually takes. See bank_pollbase.
-        bank_pollbase(worklist, session_id, cur_sig)
+        bank_pollbase(worklist, session_id, cur_sig, clsig=cl_sig_now, cl_live=cl_live_now)
         # The reggate fail-safe promises ONE line, never silence, even on a
         # stop that blocks for other reasons. ci_report and queue_note ride
         # along rather than blocking: a downgraded CI failure or a saturated
@@ -3369,7 +3437,7 @@ def run_stop(event, event_ok, worklist, hook_file):
     # not extend its own horizon: that bound is what stops the silent path
     # becoming a way to live on polls alone, and it survives this change
     # because poll_fast_path exits before reaching here.
-    bank_pollbase(worklist, session_id, cur_sig)
+    bank_pollbase(worklist, session_id, cur_sig, clsig=cl_sig_now, cl_live=cl_live_now)
     # The guide LEADS the allow report: it is the thing the session copies
     # into its Remaining section, so it comes before everything else. Absent
     # entirely when it had no rows (v18), which is what lets a clean stop with

--- a/.claude/hooks/stop/wl_core.py
+++ b/.claude/hooks/stop/wl_core.py
@@ -321,6 +321,35 @@ def project_root(start):
     return p
 
 
+def projects_dir(root):
+    """Where this repo's session TRANSCRIPTS live, or "" when nothing says.
+
+    ONE definition, for the same reason resolve_session_id is one definition.
+    The Stop hook has always derived this from the event's transcript_path
+    (exact, and it keeps preferring that), but the CLI write path has no event
+    to derive it from and still has to answer "is this section's owner alive?".
+    Two answers to that question is how the drift starts.
+
+    The convention, verified on this machine rather than assumed: the harness
+    writes ~/.claude/projects/<abs-repo-path-with-/-as->/<session-uuid>.jsonl,
+    e.g. /home/muhammed/.claude/projects/-home-muhammed-monorepo-console/.
+
+    Returns "" rather than guessing when the directory is absent: "" means
+    CANNOT SAY, and owner_age_hours already treats that as "unknown owner",
+    which is the conservative direction (unknown never reads as dead by
+    transcript, only by its own section stamp).
+    """
+    env = os.environ.get("WORKLIST_PROJECTS_DIR")
+    if env:
+        return env
+    try:
+        slug = str(pathlib.Path(root).resolve()).replace("/", "-")
+        cand = pathlib.Path.home() / ".claude" / "projects" / slug
+    except (OSError, RuntimeError):
+        return ""
+    return str(cand) if cand.is_dir() else ""
+
+
 # <repo>/.claude/hooks/stop/wl_core.py -> parents[3] is <repo>.
 _HOOK_ROOT_DEPTH = 3
 

--- a/.claude/hooks/stop/wl_store.py
+++ b/.claude/hooks/stop/wl_store.py
@@ -34,8 +34,10 @@ survives. Compact crash = tempfile + os.replace, log intact. Sync crash
 after fold, before append = nothing written, next invocation re-syncs.
 
 The sidecars (.requests, .sessions, .loop, .reggate-*,
-.pollbase-*, .pollmark-*, .cistate-*, .cimark-*, .stuck-*, .croncount-*,
-.blocks, .waiter-*, .state-*) keep their v5-v9 formats and names: their shapes
+.pollbase-*, .pollmark-*, .cistate-*, .cimark-*, .ciqueue-*, .stuck-*,
+.croncount-*, .blocks, .waiter-*, .waiternudge-*, .state-*, .events.*,
+.lastevent-*, .emails, .emailunconf-*, .failwarned, .reaped-*, .agentstate.*)
+keep their v5-v9 formats and names: their shapes
 are pinned by the suite and by living sessions, and consolidating them buys
 nothing. New v10 state (liveness ladder, task ages, judge cache, autonomy
 windows, STATE.md world-signature) lives in ONE new per-session doc,
@@ -45,8 +47,14 @@ THIS LIST IS LOAD-BEARING, not documentation. .ci/scripts/quality/
 check-tracked-sidecars.sh parses it to decide what git must never track, so a
 sidecar missing from it is a sidecar the gate is blind to. That already
 happened: .waiter-* and .state-* were absent when the gate was written, so a
-planted tracked heartbeat passed cleanly. Add new sidecars HERE when you add
-them, and keep the parenthesised shape the parser depends on.
+planted tracked heartbeat passed cleanly. It happened AGAIN and was found
+while adding .agentstate.*: ELEVEN suffixes this module and its siblings
+actually write (.events.*, .lastevent-*, .emails, .emailunconf-*, .ciqueue-*,
+.waiternudge-*, .failwarned, .reaped-*, .agentstate.*) were absent, so the
+list was checked against the code rather than against memory --
+grepping the hook directory for with_suffix call sites enumerates the truth.
+Add new sidecars HERE when you add them, and keep the parenthesised shape the
+parser depends on (no nested parentheses: the parser stops at the first `)`).
 The compact-recovery document itself lives in the repo at
 .agent/<branch>/STATE.md (gitignored), not in TMPDIR.
 """
@@ -55,6 +63,7 @@ try:
     import fcntl
 except ImportError:  # Windows: no POSIX advisory locking
     fcntl = None
+import calendar
 import glob as _glob
 import hashlib
 import json
@@ -123,36 +132,35 @@ AGENT_STATE_MIN_CHARS = 250
 # state alone; 4000 still refuses a pasted transcript.
 AGENT_STATE_MAX_CHARS = int(os.environ.get("WORKLIST_AGENT_STATE_MAX_CHARS", "4000"))
 
-# ...but the BUDGET IS PER SESSION while the DOCUMENT IS PER BRANCH, and two
-# live sessions routinely share one branch. A flat cap then gives each session
-# `cap minus the other session's block`: measured 2026-08-05 with a 1899-char
-# neighbour, one session had ~1850 usable and was refused ELEVEN times across
-# three refresh cycles (4996/4706/4410/4243/4131/4047/4019), deleting real
-# content each round to fit.
-#
-# The dangerous part is not the friction, it is the INCENTIVE: under a flat
-# cap the cheapest way to satisfy it is to delete the other session's block,
-# which is precisely the loss this document's own header warns about and which
-# had already happened twice. A limit that rewards the failure it guards
-# against is mis-scoped, so the cap SCALES with the number of session blocks
-# present. One block behaves exactly as before.
-AGENT_STATE_SESSION_RE = re.compile(r"^##[ \t]+SESSION\b", re.MULTILINE | re.IGNORECASE)
+# The cap is FLAT again, and that is only sound because the budget and the
+# document now have the same scope. It was briefly scaled by the number of
+# `## SESSION` headings, because the budget was per SESSION while the document
+# was per BRANCH: measured 2026-08-05 with a 1899-char neighbour, one session
+# had ~1850 usable and was refused ELEVEN times across three refresh cycles,
+# deleting real content each round to fit -- and the cheapest way to satisfy a
+# flat cap was to delete the OTHER session's block. Scaling the cap treated the
+# symptom. The real defect was that `--state` rewrote the whole file, so on
+# 2026-08-09 a session obeyed a staleness nag and destroyed a peer's entire
+# document describing a live campaign. Since that fix the document is a set of
+# OWNED SECTIONS merged one at a time (agent_state_parse / _render), the cap
+# applies to ONE section, and no budget pressure can reach a neighbour.
 
-
-def agent_state_blocks(text):
-    """How many `## SESSION ...` blocks a STATE.md body carries (minimum 1).
-
-    Deliberately counts the HEADING rather than parsing owners: the merge
-    convention is a heading per session, and a body with no such heading is
-    the single-session shape this file has always had.
-    """
-    return max(1, len(AGENT_STATE_SESSION_RE.findall(text or "")))
-
-
-def agent_state_max_chars(text):
-    """The effective cap for THIS body: the per-session budget times the
-    number of session blocks in it."""
-    return AGENT_STATE_MAX_CHARS * agent_state_blocks(text)
+# The heading that owns a section. The owner group is deliberately wider than
+# hex so the `legacy` pseudo-owner parses through the same path, and the tail
+# is captured whole so a heading a human annotated survives a round trip.
+AGENT_STATE_HEAD_RE = re.compile(
+    r"^##[ \t]+SESSION[ \t]+([A-Za-z0-9_-]{4,32})\b[ \t]*(.*)$", re.MULTILINE
+)
+# The section's own age lives in its heading, not in a sidecar: a sidecar is
+# invisible to the human reading the file, and the file being readable is what
+# made the 2026-08-09 loss recoverable at all. Seconds optional, because the
+# headings live sessions were already writing by hand carry minute stamps.
+AGENT_STATE_TS_RE = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2})?Z")
+AGENT_STATE_TS_FMTS = ("%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%MZ")
+# Content that predates the section format, or any text before the first
+# heading, is owned by nobody. It is adopted under this pseudo-owner rather
+# than deleted, and ages out through the ordinary reap path.
+AGENT_STATE_LEGACY_OWNER = "legacy"
 
 
 # A second session arriving on a branch has no recorded signature for a
@@ -260,6 +268,23 @@ def agent_state_backup_path(worklist, branch=""):
         safe = re.sub(r"[^A-Za-z0-9._-]", "_", str(branch))
         return worklist.with_suffix(".agentstate.prev.%s.md" % safe)
     return worklist.with_suffix(".agentstate.prev.md")
+
+
+def agent_state_reaped_path(worklist, branch=""):
+    """APPEND-ONLY archive of sections reaped as dead. Same branch-sanitising
+    rule as the backup slot beside it.
+
+    Separate from `.prev` and strictly stronger, because the hazard is
+    different. `.prev` covers one generation of a document a session CHOSE to
+    replace; reaping deletes a section NOBODY chose to delete, so it appends
+    instead of overwriting. One append per dead session per branch, which is
+    small enough that unbounded growth is the right trade against ever losing
+    the last words of a session that died mid-campaign.
+    """
+    if branch:
+        safe = re.sub(r"[^A-Za-z0-9._-]", "_", str(branch))
+        return worklist.with_suffix(".agentstate.reaped.%s.md" % safe)
+    return worklist.with_suffix(".agentstate.reaped.md")
 
 
 def trap_headings(root):
@@ -1181,27 +1206,160 @@ def agent_state_shape(body):
     forbid headings outright. Presence of a `## Next action` section is a
     strictly better gate: it targets the one question STATE.md exists to
     answer, and padding cannot satisfy it.
+
+    The subject is ONE SECTION, not the whole document, so the cap is flat
+    again (see AGENT_STATE_MAX_CHARS).
     """
     text = (body or "").strip()
     if len(text) < AGENT_STATE_MIN_CHARS:
         return "thin", "%d chars, minimum %d" % (len(text), AGENT_STATE_MIN_CHARS)
-    cap = agent_state_max_chars(text)
-    if len(text) > cap:
-        blocks = agent_state_blocks(text)
-        # Name the arithmetic when the cap is not the bare constant, so a
-        # refusal on a shared document does not read as "you wrote too much".
-        detail = "%d chars, maximum %d" % (len(text), cap)
-        if blocks > 1:
-            detail += " (%d session blocks x %d)" % (blocks, AGENT_STATE_MAX_CHARS)
-        return "bloated", detail
+    if len(text) > AGENT_STATE_MAX_CHARS:
+        return "bloated", "%d chars, maximum %d" % (len(text), AGENT_STATE_MAX_CHARS)
     if not AGENT_NEXT_RE.search(text):
         return "aimless", "no '## Next action' section; the next action IS the value"
     return "ok", "%d chars" % len(text)
 
 
-def agent_state_state(root, branch, cur_sig=None, saved_sig=None):
+def agent_state_stamp(epoch):
+    """An ISO8601Z heading stamp for `epoch` seconds. Seconds included: the
+    staleness threshold is 15 MINUTES and a minute-truncated stamp reads up to
+    59 seconds older than the truth, which is exactly the sort of quiet
+    off-by-one that makes a boundary case pass for the wrong reason."""
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(epoch))
+
+
+# A stamp this far in the FUTURE is not a stamp, it is a wrong clock. Found on
+# the live .agent/main/STATE.md while driving this code for the first time: a
+# session's hand-written heading read 101 minutes ahead, almost certainly local
+# time written with a Z. Trusting it would make that section PERMANENTLY fresh,
+# which is a strictly worse failure than the unstamped fallback -- the whole
+# point of per-section staleness is that a section cannot dodge its own clock.
+# So a future stamp is treated exactly like an unparseable one: fall back to the
+# file's mtime and record stamped=False, which is the honest answer and which
+# the 24-hour reap path still bounds.
+AGENT_STATE_FUTURE_SKEW_SEC = 300
+
+
+def _agent_state_ts(tail, fallback):
+    """(epoch, stamped) for a heading tail: the first ISO8601Z stamp anywhere
+    in it, else `fallback` with stamped=False. A stamp in the future beyond
+    AGENT_STATE_FUTURE_SKEW_SEC is not trusted (see above)."""
+    m = AGENT_STATE_TS_RE.search(tail or "")
+    if m:
+        for fmt in AGENT_STATE_TS_FMTS:
+            try:
+                ts = calendar.timegm(time.strptime(m.group(0), fmt))
+            except ValueError:
+                continue
+            if ts > time.time() + AGENT_STATE_FUTURE_SKEW_SEC:
+                return fallback, False
+            return ts, True
+    return fallback, False
+
+
+def agent_state_parse(text, mtime):
+    """A STATE.md body -> the ordered list of sections it holds.
+
+    Each section is {"owner", "tail", "ts", "stamped", "body"}: `tail` is the
+    heading text after the owner (kept verbatim so a human's annotation
+    survives a round trip), `ts` is epoch seconds from the stamp in that tail,
+    and `stamped` says whether the stamp was really there.
+
+    NEVER RAISES, and never discards. A document with no headings -- every
+    STATE.md written before 2026-08-09, plus anything a raw `cat >` produced --
+    becomes ONE section owned by the `legacy` pseudo-owner carrying the whole
+    text. Text before the first heading is the same case. Silently dropping
+    either would be the loss this whole redesign exists to prevent, arriving
+    through the parser instead of through the writer.
+    """
+    text = text or ""
+    heads = list(AGENT_STATE_HEAD_RE.finditer(text))
+    sections = []
+    preamble = (text[: heads[0].start()] if heads else text).strip()
+    if preamble:
+        ts, stamped = mtime, False
+        sections.append(
+            {
+                "owner": AGENT_STATE_LEGACY_OWNER,
+                "tail": "%s (adopted from a pre-section document)" % agent_state_stamp(mtime),
+                "ts": ts,
+                "stamped": stamped,
+                "body": preamble,
+            }
+        )
+    for i, m in enumerate(heads):
+        end = heads[i + 1].start() if i + 1 < len(heads) else len(text)
+        tail = m.group(2).strip()
+        ts, stamped = _agent_state_ts(tail, mtime)
+        sections.append(
+            {
+                "owner": m.group(1),
+                "tail": tail,
+                "ts": ts,
+                "stamped": stamped,
+                "body": text[m.end() : end].strip(),
+            }
+        )
+    return sections
+
+
+def agent_state_render(sections):
+    """The inverse of agent_state_parse, and idempotent on anything this
+    program wrote: render(parse(x)) == x for such an x. Order is preserved,
+    because a diff between two writes must show exactly one section changed."""
+    out = []
+    for s in sections:
+        head = "## SESSION %s" % s["owner"]
+        if s.get("tail"):
+            head += " " + s["tail"]
+        out.append(head + "\n\n" + (s["body"] or "").strip() + "\n")
+    return "\n".join(out)
+
+
+def agent_state_mine(sections, session_id):
+    """This caller's own section, or None.
+
+    C.same_session rather than C.owned_by_me: the CLI passes a short prefix and
+    the Stop event carries the full uuid, and either side of this comparison
+    can be either. owned_by_me is one-directional, so a session that once wrote
+    a longer tag than the prefix it later passes would grow a SECOND section
+    for itself -- harmless to peers but a document that nags forever.
+    """
+    for s in sections:
+        if s["owner"] != AGENT_STATE_LEGACY_OWNER and C.same_session(s["owner"], session_id):
+            return s
+    return None
+
+
+def agent_state_dead(sections, session_id, projects_dir, now=None):
+    """(kept, reaped) under the repo's ONE liveness notion.
+
+    A section is dead when its owner is not the caller AND either the owner's
+    newest transcript is at least WORKLIST_DEAD_HOURS old, or the owner has no
+    transcript at all (a `legacy` pseudo-owner, or a session whose transcripts
+    live on another machine) and the section's OWN stamp is that old. Falling
+    back to the section stamp keeps one horizon instead of inventing a second.
+
+    The caller's own section is NEVER reaped, at any age: a session's own stale
+    section is a nag, not garbage.
+    """
+    now = time.time() if now is None else now
+    dead_h = float(os.environ.get("WORKLIST_DEAD_HOURS", "24"))
+    kept, reaped = [], []
+    for s in sections:
+        if C.same_session(s["owner"], session_id):
+            kept.append(s)
+            continue
+        age_h = owner_age_hours(s["owner"], projects_dir)
+        if age_h is None:
+            age_h = (now - s["ts"]) / 3600.0
+        (reaped if age_h >= dead_h else kept).append(s)
+    return kept, reaped
+
+
+def agent_state_state(root, branch, session_id="", cur_sig=None, saved_sig=None):
     """('no-branch'|'no-dir'|'missing'|'thin'|'bloated'|'aimless'|'stale'|'ok',
-    age_min, text).
+    age_min, my_body).
 
     WHY THIS EXISTS. Compaction silently drops context, and a session lost a
     real operator decision that way: the rediacc-autopilot App had already been
@@ -1212,14 +1370,28 @@ def agent_state_state(root, branch, cur_sig=None, saved_sig=None):
     Staleness is WORLD-KEYED, unchanged from v10: age alone never stales the
     document; the world signature must also have moved since it was recorded.
 
-    ADOPT-ON-FIRST-SIGHT is the one semantic change, forced by the document
-    becoming per-BRANCH. `saved_sig is None` used to fall back to pure age and
-    demand a rewrite; with a shared document that would order a second session
-    to rewrite what the first wrote thirty seconds ago, reproducing the exact
-    churn the redesign fixes. An unsigned document young enough
-    (<= AGENT_STATE_ADOPT_MAX_MIN) is "ok" and the CALLER banks the signature;
-    an abandoned one is not adopted. Named residual: a session's first stop on
-    a branch grants at most one stop of grace on a document up to that old.
+    ADOPT-ON-FIRST-SIGHT was forced by the document becoming per-BRANCH.
+    `saved_sig is None` used to fall back to pure age and demand a rewrite;
+    with a shared document that would order a second session to rewrite what
+    the first wrote thirty seconds ago. An unsigned document young enough
+    (<= AGENT_STATE_ADOPT_MAX_MIN) is "ok" and the CALLER banks the signature.
+
+    PER-SESSION since 2026-08-09, and this is the half that matters. The
+    verdict is about the CALLER'S OWN SECTION and nothing else. Age comes from
+    that section's heading stamp, not from the file's mtime, because mtime is
+    per FILE while the obligation is per SESSION: a peer's write used to reset
+    everyone's clock, so B's stale document read "ok" the moment A wrote, and
+    wl_checks then banked A's world signature as B's own. A peer's MALFORMED
+    section never blocks me either -- blocking me on a section I must not edit
+    leaves deletion as the only way to clear the gate, which is precisely the
+    incentive that destroyed a live campaign's document.
+
+    NAMED RESIDUAL, fail-open by at most one peer-write interval: a section
+    whose heading carries no parseable stamp (only reachable by a raw
+    `cat > STATE.md`, since Write and Edit are both denied) falls back to the
+    file's mtime, which is the NEWEST write to the file, so it can read fresher
+    than it is. Treating it as permanently stale would nag forever on a
+    document the tool did not write; the reap path still bounds it at 24 hours.
 
     OSError degrades to "missing", which BLOCKS: a permissions problem on
     .agent/ must not read as a clean bill.
@@ -1233,21 +1405,69 @@ def agent_state_state(root, branch, cur_sig=None, saved_sig=None):
         return "missing", None, ""
     try:
         text = p.read_text(encoding="utf-8", errors="replace")
-        age = (time.time() - p.stat().st_mtime) / 60.0
+        mtime = p.stat().st_mtime
     except OSError:
         return "missing", None, ""
-    verdict, _detail = agent_state_shape(text)
+    sections = agent_state_parse(text, mtime)
+    mine = agent_state_mine(sections, session_id)
+    if mine is None:
+        # No section of my own. An UNOWNED preamble is judged as if it were
+        # mine, which reproduces the single-session behaviour this file had
+        # before sections existed -- including the adopt grace below, and
+        # including the stale verdict once that grace runs out. Peers' sections
+        # are not adoptable: writing my own costs one command and destroys
+        # nothing, so there is no churn to avoid any more.
+        mine = next((s for s in sections if s["owner"] == AGENT_STATE_LEGACY_OWNER), None)
+        if mine is None:
+            return "missing", None, ""
+    body = mine["body"]
+    age = max(0.0, (time.time() - mine["ts"]) / 60.0)
+    verdict, _detail = agent_state_shape(body)
     if verdict != "ok":
-        return verdict, int(age), text
+        return verdict, int(age), body
     if age <= AGENT_STATE_STALE_MIN:
-        return "ok", int(age), text
+        return "ok", int(age), body
     if saved_sig is None:
         if age <= AGENT_STATE_ADOPT_MAX_MIN:
-            return "ok", int(age), text
-        return "stale", int(age), text
+            return "ok", int(age), body
+        return "stale", int(age), body
     if cur_sig is not None and cur_sig != saved_sig:
-        return "stale", int(age), text
-    return "ok", int(age), text
+        return "stale", int(age), body
+    return "ok", int(age), body
+
+
+def agent_state_briefing(root, branch, session_id, projects_dir=""):
+    """(own_body_or_None, peers_rendered, n_live_peers) for PostCompact and for
+    the Stop check's peer note.
+
+    Dead sections are SKIPPED here, never removed: a read-only path that
+    mutates the shared document is the fastest route to the next clobber. Only
+    the write path reaps.
+    """
+    if not branch:
+        return None, "", 0
+    p = agent_state_path(root, branch)
+    try:
+        text = p.read_text(encoding="utf-8", errors="replace")
+        mtime = p.stat().st_mtime
+    except OSError:
+        return None, "", 0
+    sections = agent_state_parse(text, mtime)
+    mine = agent_state_mine(sections, session_id)
+    if mine is None:
+        mine = next((s for s in sections if s["owner"] == AGENT_STATE_LEGACY_OWNER), None)
+    live, _dead = agent_state_dead(sections, session_id, projects_dir)
+    now = time.time()
+    rows = []
+    for s in live:
+        if s is mine:
+            continue
+        rows.append(
+            "--- SESSION %s, written %d minutes ago. NOT YOURS: read it, never "
+            "rewrite or delete it.\n%s"
+            % (s["owner"], int(max(0.0, (now - s["ts"]) / 60.0)), s["body"])
+        )
+    return (mine["body"] if mine else None), "\n\n".join(rows), len(rows)
 
 
 # ---- world signature --------------------------------------------------------

--- a/.claude/hooks/stop/worklist.py
+++ b/.claude/hooks/stop/worklist.py
@@ -923,6 +923,14 @@ def main():
                     max(0.0, (time.time() - mine["ts"]) / 60.0)
                 )
                 mine["tail"] = stamp
+                # AFTER `replaced` above, which deliberately reports the age of
+                # the section being replaced. Without this line the kept_rows
+                # confirmation below re-uses the OLD ts and tells the writer its
+                # freshly-written section is minutes old, which is exactly the
+                # kind of thing this whole change exists to stop a session
+                # believing. The on-disk document was always right; only the
+                # confirmation lied. Caught in review of PR #565.
+                mine["ts"] = time.time()
                 mine["body"] = body.strip()
             else:
                 kept.append(

--- a/.claude/hooks/stop/worklist.py
+++ b/.claude/hooks/stop/worklist.py
@@ -786,14 +786,23 @@ def main():
         sys.stderr.write(M.CLI_STATE_USAGE)
         sys.exit(2)
     if len(sys.argv) > 2 and sys.argv[1] == "--state":
-        # `... --state <prefix>` with the STATE.md body on stdin. The document
-        # is PER BRANCH now, not per session, so the old "no other writer to
-        # race" assumption is dead: two live sessions share one branch today.
-        # flock + tempfile + os.replace makes the write atomic (a reader never
-        # sees half a file); last-write-wins is deliberate, because a document
-        # whose contract is "rewrite every time" has no merge semantics. The
-        # success line names what was replaced, which is the only cheap
-        # defence against session B silently deleting session A's next action.
+        # `... --state <prefix>` with THIS SESSION'S SECTION BODY on stdin.
+        #
+        # It used to be the whole document, and last-write-wins was called
+        # deliberate: "a document whose contract is rewrite-every-time has no
+        # merge semantics". On 2026-08-09 that contract met three live sessions
+        # in one checkout. The staleness gate nagged 99ccf057 about a document
+        # 2fd369e0 owned, 99ccf057 obeyed, and a peer's entire state document
+        # (a live canary campaign, attempt 6 in flight) was destroyed. It came
+        # back only because the single-slot .prev backup was read before the
+        # next write overwrote it.
+        #
+        # So the document has merge semantics now: one OWNED SECTION per
+        # session, replaced or appended in place under the existing flock,
+        # every other section byte-identical afterwards. flock + tempfile +
+        # os.replace still makes the write atomic. The success line names what
+        # was kept and what was reaped, because a session that cannot see the
+        # peers cannot be expected to respect them.
         wl = _local_worklist_path(_local_project_start())
         prefix = sys.argv[2]
         _identity_or_die(prefix, _die2)
@@ -826,7 +835,14 @@ def main():
                 )
             sys.stderr.write(M.CLI_STATE_NO_BODY % (extra, prefix))
             sys.exit(2)
-        # Refuse a document the Stop check would reject, with the SAME rule.
+        # A body carrying a '## SESSION' heading is a session pasting the WHOLE
+        # document, which is the pre-2026-08-09 habit. Refusing it is how the
+        # contract gets taught, and the refusal costs nothing: the previous
+        # document is untouched, so the worst case is one wasted command.
+        if S.AGENT_STATE_HEAD_RE.search(body):
+            sys.stderr.write(M.CLI_STATE_WHOLE_DOC % prefix)
+            sys.exit(2)
+        # Refuse a section the Stop check would reject, with the SAME rule.
         # Accept-then-reject leaves the one artifact designed to survive
         # compaction broken while the session believes it is fine; refusing
         # leaves the previous good document untouched.
@@ -834,7 +850,7 @@ def main():
         if verdict != "ok":
             sys.stderr.write(
                 M.CLI_STATE_REFUSED
-                % (verdict, detail, S.AGENT_STATE_MIN_CHARS, S.agent_state_max_chars(body))
+                % (verdict, detail, S.AGENT_STATE_MIN_CHARS, S.AGENT_STATE_MAX_CHARS)
             )
             sys.exit(2)
         target = S.agent_state_path(root, branch)
@@ -842,41 +858,106 @@ def main():
         # 3688784930/3688787780): a shared slot let a write on ANOTHER branch
         # destroy this branch's only backup.
         backup = S.agent_state_backup_path(wl, branch)
+        reaped_path = S.agent_state_reaped_path(wl, branch)
+        pdir = C.projects_dir(root)
+        backed_up = had_prev = False
         replaced = ""
-        try:
-            prev_age = int((time.time() - target.stat().st_mtime) / 60.0)
-            prev_first = (
-                target.read_text(encoding="utf-8", errors="replace").strip().splitlines()[0][:100]
-            )
-            replaced = ", replacing a %d-minute-old document (first line: %r)" % (
-                prev_age,
-                prev_first,
-            )
-        except (OSError, IndexError):
-            pass
-        backed_up = False
+        kept_rows, reaped_rows = [], []
         lock = S.agent_state_lock_path(wl)
         with open(lock, "w", encoding="utf-8") as lf:
             fcntl.flock(lf, fcntl.LOCK_EX)
-            # Keep the outgoing document before overwriting it. Inside the lock
-            # and before os.replace, so the copy is of the body we are actually
-            # about to destroy and not of one a racing writer slipped in.
+            # EVERYTHING between here and os.replace reads and writes under the
+            # lock. The old code read the outgoing document before taking it,
+            # which was harmless when the write was a whole-file replace and is
+            # not harmless now: a merge that parsed a pre-lock snapshot would
+            # drop a section a racing writer added in between.
             try:
-                backup.write_text(target.read_text(encoding="utf-8"), encoding="utf-8")
-                backed_up = True
+                current = target.read_text(encoding="utf-8", errors="replace")
+                mtime = target.stat().st_mtime
             except OSError:
-                pass  # first write on this branch, or an unreadable target
+                current, mtime = "", time.time()
+            had_prev = bool(current.strip())
+            if had_prev:
+                try:
+                    backup.write_text(current, encoding="utf-8")
+                    backed_up = True
+                except OSError:
+                    pass  # unwritable backup slot; confessed in the line below
+            sections = S.agent_state_parse(current, mtime)
+            kept, reaped = S.agent_state_dead(sections, prefix, pdir)
+            if reaped:
+                # ARCHIVE BEFORE DROP, append-only. Reaping is the one path that
+                # deletes content nobody chose to delete, so it is the one path
+                # that gets a guarantee stronger than the single .prev slot. A
+                # failed archive ABORTS the reap: keeping a dead section forever
+                # is a tidiness problem, losing it is the failure this file
+                # exists to prevent.
+                try:
+                    with open(reaped_path, "a", encoding="utf-8") as af:
+                        af.write(
+                            "\n".join(
+                                "# reaped %s by %s from branch %s\n%s\n"
+                                % (
+                                    S.agent_state_stamp(time.time()),
+                                    prefix,
+                                    branch,
+                                    S.agent_state_render([s]),
+                                )
+                                for s in reaped
+                            )
+                        )
+                    reaped_rows = [
+                        "%s (%d min old)" % (s["owner"], int((time.time() - s["ts"]) / 60.0))
+                        for s in reaped
+                    ]
+                except OSError as exc:
+                    sys.stderr.write(
+                        "WARNING: could not archive %d dead section(s) to %s (%s), so they "
+                        "were KEPT rather than dropped.\n" % (len(reaped), reaped_path, exc)
+                    )
+                    kept, reaped = sections, []
+            mine = S.agent_state_mine(kept, prefix)
+            stamp = S.agent_state_stamp(time.time())
+            if mine is not None:
+                replaced = ", replacing your %d-minute-old section" % int(
+                    max(0.0, (time.time() - mine["ts"]) / 60.0)
+                )
+                mine["tail"] = stamp
+                mine["body"] = body.strip()
+            else:
+                kept.append(
+                    {
+                        "owner": prefix,
+                        "tail": stamp,
+                        "ts": time.time(),
+                        "stamped": True,
+                        "body": body.strip(),
+                    }
+                )
+            merged = S.agent_state_render(kept)
+            kept_rows = [
+                "%s%s (%d min old)"
+                % (
+                    s["owner"],
+                    " <- you" if s["owner"] == prefix else "",
+                    int(max(0.0, (time.time() - s["ts"]) / 60.0)),
+                )
+                for s in kept
+            ]
             fd, tmp = tempfile.mkstemp(dir=str(target.parent), suffix=".tmp")
             with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(body)
+                f.write(merged)
             os.replace(tmp, target)
-        if replaced:
-            # Name the backup ONLY when something was replaced AND the copy
-            # actually landed (findings 3688770247/3688779150/3688787850: the
-            # old line advertised a recovery path that a failed write had
-            # never created, which is worse than no promise at all).
+        # Name the backup ONLY when a previous document existed AND the copy
+        # actually landed (findings 3688770247/3688779150/3688787850: the old
+        # line advertised a recovery path that a failed write had never
+        # created, which is worse than no promise at all). The condition is
+        # "there was a document", not "I replaced my own section": since the
+        # merge, a write that only APPENDS a section still rewrites the file,
+        # so the backup is real and worth naming either way.
+        if had_prev:
             if backed_up:
-                replaced += "; previous body saved to %s" % backup
+                replaced += "; previous document saved to %s" % backup
             else:
                 replaced += "; WARNING: the backup copy FAILED, the replaced body is gone"
         try:
@@ -886,7 +967,15 @@ def main():
             S.save_state(wl, prefix, doc)
         except Exception:  # noqa: BLE001 -- the sig is an optimisation, never a gate on writing
             pass
-        print("STATE.md written for branch %s (%d chars)%s" % (branch, len(body), replaced))
+        print(
+            "STATE.md section written for %s on branch %s (%d chars)%s\n"
+            "  sections kept: %s" % (prefix, branch, len(body), replaced, ", ".join(kept_rows))
+        )
+        if reaped_rows:
+            print(
+                "  sections REAPED as dead: %s; archived to %s"
+                % (", ".join(reaped_rows), reaped_path)
+            )
         return
     if sys.argv[1:2] == ["--session-start"]:
         ev, _ok = _read_event()

--- a/.claude/hooks/stop/worklist.py
+++ b/.claude/hooks/stop/worklist.py
@@ -72,6 +72,7 @@ MODULE MAP:
     wl_reggate    v7/v8 regression-gate machinery
     wl_email      the operator email channel (SES digests of open questions)
     wl_judge      the stop-legitimacy judge and its verdict cache
+    wl_checklist  the /handoff checklist gate over docs/<slug>/CHECKLIST.md
     wl_checks     the static battery and the Stop orchestration (run_stop)
     worklist_messages  every user-facing string (arity-pinned by the suite)
 

--- a/.claude/hooks/stop/worklist_messages.py
+++ b/.claude/hooks/stop/worklist_messages.py
@@ -447,6 +447,24 @@ N_CL_FOREIGN = (
     "never blocked on.%s"
 )
 
+# THE OWNER'S ORDER, SAID TO SOMEBODY ELSE, was the bug (found by the automated
+# review on PR #563). Drift used to build ONE body -- V_CL_FLIP, which ends
+# "...in this turn" -- and route it either to a blocking violation or to this
+# advisory, so a session that does not own the handoff read a direct
+# instruction to repair another session's artifacts and header. That is not
+# theoretical: a peer's shared STATE.md was destroyed here by a session obeying
+# an instruction addressed to whoever happened to read it. This constant states
+# the same FACTS and names no action for the reader. V_CL_FLIP keeps its
+# imperative, because on that path the reader IS the owner.
+N_CL_FOREIGN_DRIFT = (
+    "Handoff checklist %s says 'Status: %s' but its artifacts disagree, and it "
+    "is owned by session %s:\n%s\n"
+    "Restoring those artifacts, or writing the honest status, is that session's "
+    "repair to make. Editing another session's checklist header or its files "
+    "from here would overwrite work that is still live. Reported, never blocked "
+    "on."
+)
+
 CLI_STATE_REFUSED = (
     "STATE REFUSED (%s: %s). Limits: %d-%d chars and a '## Next action' "
     "section. Nothing was written; the previous STATE.md is untouched.\n"

--- a/.claude/hooks/stop/worklist_messages.py
+++ b/.claude/hooks/stop/worklist_messages.py
@@ -256,7 +256,8 @@ V_MANY_POLL_CRONS = (
 )
 
 V_AGENT_STATE = (
-    "the compact-recovery document .agent/%s/STATE.md is %s%s. Compaction has "
+    "YOUR SECTION of the compact-recovery document .agent/%s/STATE.md is %s%s. "
+    "Compaction has "
     "already cost this project one operator decision (the autopilot App was "
     "reported blocked AFTER the operator had created it), and the transcript "
     "cannot be the recovery mechanism because the transcript is what gets "
@@ -264,7 +265,10 @@ V_AGENT_STATE = (
     "a session that knows NOTHING: what is true right now and what happens "
     "next. RULES.md and TRAPS.md are not freshness-gated, so do NOT restate "
     "them here; STATE.md carries only what is volatile. Stale means the WORLD "
-    "has moved since it was written; an unchanged world never stales it:\n"
+    "has moved since it was written; an unchanged world never stales it. The "
+    "document holds ONE OWNED SECTION PER SESSION and this verdict is about "
+    "yours alone: send YOUR SECTION'S BODY ONLY, never the whole file, and the "
+    "tool merges it in place while every peer's section stays byte-identical:\n"
     "    .claude/hooks/stop/worklist.py --state %s <<'EOF'\n    ...\n    EOF"
 )
 
@@ -275,12 +279,20 @@ V_AGENT_BOOTSTRAP = (
     "you):\n"
     "    mkdir -p .agent/%s\n"
     "    cp .agent/<previous-branch>/RULES.md .agent/%s/RULES.md   # then sharpen\n"
-    "then write a fresh STATE.md via worklist.py --state. See .agent/README.md."
+    "then write a fresh STATE.md via worklist.py --state. (.agent/ is gitignored, so its README may be absent on a fresh clone.)"
 )
 
 V_AGENT_STILL_ABSENT = (
     ".agent/%s/ is still absent; the bootstrap commands were shown on an "
     "earlier stop. Create it, then write STATE.md via worklist.py --state."
+)
+
+N_AGENT_PEERS = (
+    "NOTE: .agent/%s/STATE.md carries other sessions' sections beside yours. "
+    "They are theirs; read them for cross-session context and NEVER rewrite or "
+    "delete one. `--state` merges only your own section, so you cannot lose "
+    "them by accident -- a raw `cat > STATE.md` in Bash still can. A section "
+    "marked reap-eligible is dropped by the next write and archived first:\n%s"
 )
 
 N_AGENT_BLIND = (
@@ -466,8 +478,26 @@ N_CL_FOREIGN_DRIFT = (
 )
 
 CLI_STATE_REFUSED = (
-    "STATE REFUSED (%s: %s). Limits: %d-%d chars and a '## Next action' "
-    "section. Nothing was written; the previous STATE.md is untouched.\n"
+    "STATE REFUSED (%s: %s). Limits for YOUR SECTION: %d-%d chars and a "
+    "'## Next action' section. Nothing was written; the previous STATE.md is "
+    "untouched, including every other session's section.\n"
+)
+
+# The refusal an in-flight session running the pre-section instructions will
+# meet mid-task, so it states the whole contract rather than merely saying no.
+# Piping the whole document in was the old habit, and it is the exact habit
+# that destroyed a peer's live campaign document on 2026-08-09.
+CLI_STATE_WHOLE_DOC = (
+    "STATE REFUSED: the body you piped in carries a '## SESSION' heading, so it "
+    "looks like the WHOLE document rather than your own section.\n"
+    "The contract changed: .agent/<branch>/STATE.md is one OWNED SECTION per "
+    "session, and `--state` merges YOUR body into it under a lock, leaving "
+    "every other section byte-identical. It writes your heading for you.\n"
+    "Send your section's body ALONE -- no '## SESSION' line, no peer's text:\n"
+    "    .claude/hooks/stop/worklist.py --state %s <<'EOF'\n"
+    "    ...what is true right now, and a '## Next action' section...\n"
+    "    EOF\n"
+    "Nothing was written; the previous document is untouched.\n"
 )
 
 # WHY THESE TWO EXIST (cross-session report #7c1c2629, 2026-08-05, reproduced
@@ -1239,6 +1269,19 @@ CTX_POSTCOMPACT_NO_BRANCH = (
     "so the per-branch STATE.md cannot be located. Check out a branch or set "
     "WORKLIST_AGENT_BRANCH, then read .agent/<branch>/STATE.md and RULES.md. "
     "Branch-independent hard-won facts, titles from .agent/TRAPS.md:\n%s"
+)
+
+# Appended as its OWN block rather than widened into CTX_POSTCOMPACT_BRIEFING,
+# for two reasons: it keeps that message's arity frozen, and it has to ride the
+# MISSING branch too. Before sections existed, a compacted session on a branch
+# where only a peer had written got no state content whatsoever, which is a
+# strictly worse briefing than the file in front of it contains.
+CTX_POSTCOMPACT_PEERS = (
+    "=== OTHER SESSIONS' SECTIONS of .agent/<branch>/STATE.md ===\n"
+    "These belong to sessions sharing this checkout. They are context, not your "
+    "work: read them so you do not sweep their uncommitted files or re-decide "
+    "what they decided, and never rewrite or delete one. `--state` merges only "
+    "your own section.\n\n%s"
 )
 
 CTX_POSTCOMPACT_BRIEFING = (

--- a/.claude/hooks/stop/worklist_messages.py
+++ b/.claude/hooks/stop/worklist_messages.py
@@ -441,6 +441,12 @@ N_PHANTOM_BLIND = (
     "found six that were the former while looking like the latter."
 )
 
+N_CL_FOREIGN = (
+    "Handoff checklist docs/%s/CHECKLIST.md is 'Status: producing', owned by "
+    "session %s -- its deliverables are that session's to finish. Reported, "
+    "never blocked on.%s"
+)
+
 CLI_STATE_REFUSED = (
     "STATE REFUSED (%s: %s). Limits: %d-%d chars and a '## Next action' "
     "section. Nothing was written; the previous STATE.md is untouched.\n"
@@ -506,6 +512,58 @@ V_DOCS_DRIFT = (
     "updated. Those documents are how a new or compacted session understands this "
     "work, so code moving without them deletes the next session's starting "
     "context. Update the ones your changes invalidated, in this turn."
+)
+
+# ---- the /handoff checklist gate (docs/<slug>/CHECKLIST.md, wl_checklist) ---
+
+V_CL_SHAPE = (
+    "handoff checklist %s is MALFORMED, and a checklist the hook cannot parse "
+    "gates nothing at all, so it blocks rather than passing quietly:\n%s\n"
+    "    THE GRAMMAR: a 'Status:' line in the first 10 lines carrying one of "
+    "producing, executing, done, superseded; an 'Owner: <your session prefix>' "
+    "line while it is producing; '- [ ] d1 file:<path>' rows under "
+    "'## Deliverables', each with at least one file: token; '- [ ] w1 <title>' "
+    "rows under '## Waves'; ids unique across the file; only '[ ]' and '[x]', "
+    "because leases and deferrals live in the worklist store, not here."
+)
+
+V_CL_UNREADABLE = (
+    "THIS IS A HOOK BUG: the handoff-checklist check failed (%s), so that check "
+    "is blind. It blocks rather than passing quietly, per no-escape-hatch. Fix "
+    "wl_checklist.py, or repair the checklist file it choked on -- there is "
+    "deliberately no flag that turns this check off."
+)
+
+V_CL_PRODUCING = (
+    "you ran /handoff for '%s' and its deliverables DO NOT VERIFY (%d of %d are "
+    "present and non-empty):\n%s\n"
+    "A tick is bookkeeping; the FILE is the truth, which is why the box being "
+    "checked would not have saved this. Write the missing artifacts now, then "
+    "flip 'Status: producing' to 'Status: executing' in %s. This session owns "
+    "that handoff and cannot stop until both are done."
+)
+
+V_CL_PRODUCING_DONE = (
+    "every deliverable of handoff '%s' verifies, so ONE step remains and it is "
+    "the flip: edit %s and change 'Status: producing' to 'Status: executing'. "
+    "Until then every stop of this session blocks here, because a handoff left "
+    "at producing is a handoff nobody has been handed."
+)
+
+V_CL_FLIP = (
+    "handoff checklist %s says 'Status: %s' but reality disagrees:\n%s\n"
+    "A status ahead of its artifacts is exactly how program work drops "
+    "silently: the next session reads the header, believes it, and never looks. "
+    "Restore the artifact(s), or write the honest status in %s, in this turn."
+)
+
+V_CL_WAVES = (
+    "handoff '%s' (%s) carries program state the worklist DOES NOT COVER:\n%s\n"
+    "An UNCOVERED wave is unclaimed work, so it blocks every stopping session "
+    "until someone claims it -- the same semantics an untagged worklist item "
+    "has today, and it stops blocking the others the moment one session adds "
+    "the item. Each row above carries its own one-command exit; run the one "
+    "that matches what you are actually doing."
 )
 
 V_UNCONFIRMED = (
@@ -1135,6 +1193,18 @@ CTX_PLANS_EXCERPT = (
     "=== %s, its '## Status' section (the progress cursor of work already "
     "under way; treat it as the truth and your own recollection as "
     "unreliable) ===\n%s"
+)
+
+CTX_CHECKLISTS = (
+    "LIVE HANDOFF CHECKLISTS (docs/<slug>/CHECKLIST.md, the machine-readable "
+    "half of a /handoff):\n%s\n\n"
+    "The Stop hook ENFORCES these, so they are not documentation: one at "
+    "'Status: producing' blocks its owner until every 'file:' token exists and "
+    "is non-empty, and one at 'Status: executing' blocks ANY stopping session "
+    "while a wave is neither covered by a worklist item nor ticked. Claim a "
+    "wave before you work it with `.claude/hooks/stop/worklist.py --add "
+    "<your-prefix> 'cl:<slug>/<id> <title>'`, tick its box once the wave is "
+    "done, and set 'Status: done' when every box is ticked."
 )
 
 CTX_POSTCOMPACT_MISSING = (

--- a/.claude/hooks/test-hooks.sh
+++ b/.claude/hooks/test-hooks.sh
@@ -22,6 +22,25 @@ check() {
     fi
 }
 
+# check_out <expected-exit> <script> <json-stdin> <label> <must-contain>
+# Like check(), plus an assertion on what the guard SAID. Used where the
+# message is the product: the STATE.md guard's whole job since 2026-08-09 is to
+# redirect a session to the one writer that can merge, and an exit code alone
+# cannot tell "blocked, here is the correct command" from "blocked, good luck".
+check_out() {
+    local expected="$1" script="$2" json="$3" label="$4" needle="$5" rc out
+    out="$(echo "$json" | bash "$DIR/$script" 2>&1 >/dev/null)"
+    rc=$?
+    if [[ "$rc" == "$expected" ]] && grep -qF "$needle" <<<"$out"; then
+        PASS=$((PASS + 1))
+        printf 'ok   [%s] %s (exit %s)\n' "$expected" "$label" "$rc"
+    else
+        FAIL=$((FAIL + 1))
+        printf 'FAIL [%s] %s (got exit %s, needle %s)\n' "$expected" "$label" "$rc" \
+            "$(grep -qF "$needle" <<<"$out" && echo present || echo MISSING)"
+    fi
+}
+
 bash_json() { printf '{"tool_input":{"command":%s}}' "$(jq -Rn --arg c "$1" '$c')"; }
 edit_json() { printf '{"tool_input":{"new_string":%s}}' "$(jq -Rn --arg c "$1" '$c')"; }
 multiedit_json() { printf '{"tool_input":{"edits":[{"new_string":%s}]}}' "$(jq -Rn --arg c "$1" '$c')"; }
@@ -168,11 +187,20 @@ check 2 pre-bash/block-nondraft-pr-create.sh "$(bash_json 'gh pr create --draft 
 check 2 pre-edit/block-suppressions.sh "$(edit_json "a // @ts-""ignore")" "suppressions(new_string)"
 check 2 pre-edit/block-suppressions.sh "$(multiedit_json "b // eslint-""disable")" "suppressions(MultiEdit)"
 check 2 pre-edit/block-inline-workflow-run.sh "$(wf_edit_json '.github/workflows/x.yml' "$WF_FAT")" "inline-workflow-run: 9-line block blocked"
-# STATE.md shape guard: the CLI refusal alone is bypassed by a raw Write (the
+# STATE.md write guard: the CLI refusal alone is bypassed by a raw Write (the
 # document lives at a plain repo path), so the guard is the closing half.
-check 2 pre-edit/block-agent-state-shape.sh "$(tool_json Write /r/.agent/b/STATE.md content tiny)" "agent-state: thin Write blocked"
-check 2 pre-edit/block-agent-state-shape.sh "$(tool_json Write /r/.agent/b/STATE.md content "$STATE_AIMLESS")" "agent-state: aimless Write (no Next action) blocked"
-check 2 pre-edit/block-agent-state-shape.sh "$(tool_json Edit /r/.agent/b/STATE.md new_string patch)" "agent-state: Edit blocked (rewrite, never append)"
+#
+# IT DENIES EVERY DIRECT WRITE NOW, shape-valid ones included, and the
+# WELL-SHAPED case below is the one that changed. STATE.md holds one owned
+# section per session and only the CLI can merge; a perfectly shaped whole-file
+# Write deletes every peer's section exactly as thoroughly as a malformed one,
+# so a guard that measured LENGTH was waving through the only defect that
+# matters. Each case asserts the message too, because redirecting to `--state`
+# IS the guard's product.
+check_out 2 pre-edit/block-agent-state-shape.sh "$(tool_json Write /r/.agent/b/STATE.md content tiny)" "agent-state: thin Write blocked" "worklist.py --state"
+check_out 2 pre-edit/block-agent-state-shape.sh "$(tool_json Write /r/.agent/b/STATE.md content "$STATE_AIMLESS")" "agent-state: aimless Write (no Next action) blocked" "worklist.py --state"
+check_out 2 pre-edit/block-agent-state-shape.sh "$(tool_json Edit /r/.agent/b/STATE.md new_string patch)" "agent-state: Edit blocked (rewrite, never append)" "ONE OWNED SECTION PER SESSION"
+check_out 2 pre-edit/block-agent-state-shape.sh "$(tool_json MultiEdit /r/.agent/b/STATE.md new_string patch)" "agent-state: MultiEdit blocked" "worklist.py --state"
 
 # --- should PASS (exit 0) ---
 # NOTE: block-premature-ready.sh and block-admin-merge.sh verify live CI/thread
@@ -230,9 +258,16 @@ check 0 pre-bash/block-worktree-add.sh "$(bash_json 'git worktree remove ../foo'
 check 0 pre-bash/block-worktree-add.sh "$(bash_json 'git status')" "worktree-add: unrelated git command ok"
 check 0 pre-bash/block-worktree-add.sh "$(bash_json 'echo "lets talk about git worktree add sometime"')" "worktree-add: quoted prose mention ignored"
 check 0 pre-edit/block-suppressions.sh "$(edit_json 'const x = 1;')" "suppressions: clean"
-check 0 pre-edit/block-agent-state-shape.sh "$(tool_json Write /r/.agent/b/STATE.md content "$STATE_GOOD")" "agent-state: well-shaped Write passes"
+# INVERTED 2026-08-09: a well-shaped whole-file Write used to PASS here, and
+# that is the hole the incident went through. It is now denied like every other
+# direct write, and it lives up in the deny block above only in spirit -- it is
+# asserted here, beside its controls, so the pair reads as one decision.
+check_out 2 pre-edit/block-agent-state-shape.sh "$(tool_json Write /r/.agent/b/STATE.md content "$STATE_GOOD")" "agent-state: well-shaped Write is ALSO blocked (shape was never the defect)" "worklist.py --state"
+# The two controls that keep the guard from being a blanket denial: it must not
+# reach RULES.md (sharpened by ordinary edits) or anything outside .agent/.
 check 0 pre-edit/block-agent-state-shape.sh "$(tool_json Edit /r/.agent/b/RULES.md new_string sharpen)" "agent-state: RULES.md edits untouched"
 check 0 pre-edit/block-agent-state-shape.sh "$(tool_json Write /r/packages/cli/src/foo.ts content tiny)" "agent-state: non-agent files untouched"
+check 0 pre-edit/block-agent-state-shape.sh "$(tool_json Write /r/.agent/TRAPS.md content "$STATE_GOOD")" "agent-state: TRAPS.md untouched"
 check 0 pre-edit/block-inline-workflow-run.sh "$(wf_edit_json '.github/workflows/x.yml' "$WF_THIN")" "inline-workflow-run: thin block ok"
 check 0 pre-edit/block-inline-workflow-run.sh "$(wf_edit_json 'packages/cli/src/foo.ts' "$WF_FAT")" "inline-workflow-run: non-workflow file ok"
 

--- a/docs/ci-overhaul/06-progress.md
+++ b/docs/ci-overhaul/06-progress.md
@@ -3205,3 +3205,107 @@ label applied mid-PR needs a real push to take effect: `external_quality`
 is computed from the EVENT payload's label snapshot (ci.yml:129) and
 `pull_request` triggers only on [opened, synchronize], so a bare rerun
 re-reads the unlabeled payload.
+
+## Handoff checklist gate: /handoff <-> Stop hook (2026-08-09)
+
+`/handoff` produced prose and nothing else. Its scope waves lived in a README
+paragraph, its deliverables lived in the command's own step list, and the only
+thing that ever asked the consuming session to seed the worklist was an
+instruction sentence inside PROMPT.md. The Stop hook, 13k lines across 13
+modules, had zero grep hits for "handoff": nothing verified that a producing
+session actually wrote every deliverable, and nothing verified that the
+consuming session claimed or finished a single wave. An ignored PROMPT.md, or
+one compacted out of context, silently dropped program work with no red
+anywhere. `docs/<slug>/CHECKLIST.md` is now the artifact both sides are held
+to, and the hook reads it.
+
+The grammar, deliberately small enough to write from memory:
+
+```
+# Handoff checklist: <slug>
+Status: producing            <- first 10 lines; producing|executing|done|superseded
+Owner: 99ccf057              <- 8-char session prefix, required while producing
+
+## Deliverables
+- [ ] d1 file:docs/<slug>/README.md
+- [ ] d2 file:docs/<slug>/PROMPT.md
+- [ ] d3 file:~/.claude/projects/-home-muhammed-monorepo-console/programs/<slug>/MANIFEST.md
+
+## Waves
+- [ ] w1 Wave A: <one-line title>
+```
+
+Ids are section-scoped (`d` under Deliverables, `w` under Waves), only ` ` and
+`x` are legal box states, and every deliverable carries a `file:` token.
+Deliverables are file-verified, period: the path must exist and be non-empty,
+`~` expands, relative paths resolve against the repo root, and the tick is
+bookkeeping while the file is the truth. A ticked-but-missing deliverable is
+called out loudly rather than believed. Waves are tick-on-trust with store
+linkage: a wave is settled by `[x]` or covered by any worklist store item whose
+text contains the literal token `cl:<slug>/<wN>`, seeded with
+`worklist.py --add <me> 'cl:<slug>/<wN> <title>'`. Evidence discipline rides
+the existing `--tick` gate, so no new evidence machinery was invented.
+
+Four check keys. `cl-shape` is ALWAYS-tier when the parser itself crashed (the
+V_CI_UNREADABLE precedent, fail closed rather than unknown-and-pass) and
+rotated for ordinary grammar violations: bad Status, missing Owner while
+producing, malformed item line, duplicate id, deliverable without a `file:`.
+`cl-producing` is rotated and blocks the OWNER only, on unmet deliverables or,
+once they all verify, on the missing flip. `cl-flip` is rotated and fires when
+Status is executing or done but a deliverable file is missing or empty, or done
+carries unticked waves. `cl-waves` is rotated, one body per slug, and blocks
+ANY stopping session on an uncovered `[ ]` wave, on a done-but-unticked box,
+and on an all-settled checklist that has not been set to `Status: done`.
+
+Blocking everyone on `cl-waves` is the deliberate part. An uncovered wave is
+unclaimed work, exactly the semantics an untagged worklist item already has:
+the moment any session adds the `cl:` item the wave has an owner and stops
+blocking everybody else. Worst case is one redundant simultaneous block, and it
+self-resolves on the next stop because every violation has a single-turn solo
+exit (add the item, tick the box, or flip the status). A foreign producing
+checklist never blocks: it emits the advisory `cl-foreign`, change-latched, and
+after the owner's transcript has been idle 24h the advisory gains an adoption
+hint (edit `Owner:`, or supersede the program).
+
+Cost is bounded on both paths. The full Stop battery reads checklists because
+that is the enforcement point: zero checklists costs one glob, live ones get a
+header read, and only producing/executing files are parsed in full (typically
+0-2 small files). The poll fast path stays read-free by contract: `clsig` is a
+sha1 over sorted `(relpath, mtime_ns, size)`, stat-only so a chmod-000
+checklist cannot make it raise, and both `clsig` and `cl_live` are banked in
+the pollbase. A poll forfeits the fast path when the signature moved, when
+banked `cl_live > 0`, or when the keys are absent from an older baseline. In
+plain terms: a live checklist means polls pay the battery, and done or
+superseded checklists cost polls nothing. SessionStart and PostCompact inject a
+LIVE HANDOFF CHECKLISTS listing, one line per live checklist with status,
+owner, and the verified/settled counts.
+
+Lifecycle is `producing` -> `executing` -> `done` or `superseded`. The owner
+cannot stop while producing until every file verifies and the status is
+flipped; `done` is gated on all-verified plus all-ticked, so it cannot be used
+as an escape; `superseded` is the terminal exit for an abandoned program. An
+update-mode `/handoff` re-verifies every `file:`, appends new waves with fresh
+monotonic ids, never renumbers or un-ticks, and flips `done` back to
+`executing` when it adds waves. The hook never writes the checklist, and the md
+file is the single source of truth, with no checklist events in the JSONL store
+to reconcile against.
+
+Two accepted residuals, stated rather than solved. A session that skips writing
+a checklist at all is invisible to the hook; the mitigation is social, making
+the checklist the FIRST file write plus a named line in the command's Report
+and Constraints sections. And the 45/90/120 liveness ladder does not apply to
+checklist items: once a wave is claimed it rides the worklist store item, whose
+existing ladder and lease machinery already cover it, so nothing new ages
+checklist rows.
+
+Enforced in `.claude/hooks/stop/wl_checklist.py` (parse, verify, sig, findings)
+wired into `run_stop`, `poll_fast_path`, `bank_pollbase`, `handle_session_start`
+and `handle_post_compact` in `wl_checks.py`, with the eight message constants in
+`worklist_messages.py` (V_CL_SHAPE, V_CL_UNREADABLE, V_CL_PRODUCING,
+V_CL_PRODUCING_DONE, V_CL_FLIP, V_CL_WAVES, N_CL_FOREIGN, CTX_CHECKLISTS; the
+wave-token format constant is spelled CL_LINK_FMT because ruff S105 fires on
+names containing TOKEN). Suite coverage lands in
+`.claude/hooks/stop/test-worklist-v5.sh` cases 193 onward, house style
+throughout: every blocking case paired with a clean-fixture control, including
+a zero-checklist control that must produce no checklist output at all and a
+stat-only unit call against an unreadable file.

--- a/docs/ci-overhaul/06-progress.md
+++ b/docs/ci-overhaul/06-progress.md
@@ -3298,14 +3298,59 @@ checklist items: once a wave is claimed it rides the worklist store item, whose
 existing ladder and lease machinery already cover it, so nothing new ages
 checklist rows.
 
+Findings are keyed PER CHECKLIST, `<check-class>:<slug>`, built by
+`wl_checklist._ckey`. This is the design rather than a detail because two
+things downstream read the key as an identity and neither degrades gracefully
+when it is shared: the focused block's rotation ties-breaks on
+`order = {v[0]: i for ...}`, a dict comp in which duplicate keys collapse, so
+two violations under one key get identical sort tuples and `min` returns the
+first one on every stop; and `outq_add` finds a non-sticky entry by key alone,
+so a second advisory's body overwrites the first's rather than queueing beside
+it. A shared key therefore starved the second concurrent handoff permanently,
+not for a stop or two, leaving it visible only inside the "N more outstanding"
+count. Scoping costs nothing: the rotation already prunes keys that stop being
+outstanding, so a settled checklist's key leaves `served` on the next stop. The
+prefixes are preserved verbatim (`cl-shape`, `cl-flip`, `cl-producing`,
+`cl-waves`, `cl-foreign`) so a grep on the check class still matches. One key
+stays unscoped, the glob-level fail-closed backstop in `checklist_findings`:
+the glob itself failed, so no slug exists, and that path returns immediately,
+which means at most one such finding can exist per stop. The per-FILE
+fail-closed wrapper beside it is scoped, reading its slug off the path rather
+than out of the parse that just threw.
+
+Drift under a foreign owner gets its OWN message, `N_CL_FOREIGN_DRIFT`, and
+does not reuse `V_CL_FLIP`. Both statuses that can drift (`done` and
+`executing`) used to build one body and route it either to a blocking violation
+or to the `cl-foreign` advisory, which meant a session that does not own the
+handoff was handed the owner's imperative, ending "in this turn". Acting on it
+means editing another session's `Owner:`/`Status:` header or its files; a
+peer's shared `STATE.md` was destroyed here by a session obeying an instruction
+addressed to whoever happened to read it. The advisory now states the same
+facts (checklist, status, owner, the same drift rows), says the repair belongs
+to the owning session, warns that editing it from here would overwrite live
+work, and closes with `Reported, never blocked on.` matching `N_CL_FOREIGN`.
+`V_CL_FLIP` keeps its imperative unchanged, because on that path the reader is
+the owner.
+
+Both were found by the automated review on PR #563, and neither is an accepted
+residual: they are fixed, with the per-slug keying making the "one body per
+slug" claim above true rather than aspirational.
+
 Enforced in `.claude/hooks/stop/wl_checklist.py` (parse, verify, sig, findings)
 wired into `run_stop`, `poll_fast_path`, `bank_pollbase`, `handle_session_start`
-and `handle_post_compact` in `wl_checks.py`, with the eight message constants in
+and `handle_post_compact` in `wl_checks.py`, with the nine message constants in
 `worklist_messages.py` (V_CL_SHAPE, V_CL_UNREADABLE, V_CL_PRODUCING,
-V_CL_PRODUCING_DONE, V_CL_FLIP, V_CL_WAVES, N_CL_FOREIGN, CTX_CHECKLISTS; the
-wave-token format constant is spelled CL_LINK_FMT because ruff S105 fires on
-names containing TOKEN). Suite coverage lands in
+V_CL_PRODUCING_DONE, V_CL_FLIP, V_CL_WAVES, N_CL_FOREIGN, N_CL_FOREIGN_DRIFT,
+CTX_CHECKLISTS; the wave-token format constant is spelled CL_LINK_FMT because
+ruff S105 fires on names containing TOKEN). Suite coverage lands in
 `.claude/hooks/stop/test-worklist-v5.sh` cases 193 onward, house style
 throughout: every blocking case paired with a clean-fixture control, including
 a zero-checklist control that must produce no checklist output at all and a
-stat-only unit call against an unreadable file.
+stat-only unit call against an unreadable file. Cases 204-206 cover the two
+review findings, each verified to FAIL against the unfixed code first: two
+uncovered waves served across two stops, two foreign advisories surviving one
+drain, and the foreign drift wording paired with the same fixture under its
+owner. Case 205 keeps a separate fixture per leg deliberately, because draining
+an advisory latches it in the queue's `shown` ledger and a second checklist
+planted beside an already-shown one is suppressed by the refresh window, which
+looks exactly like the overwrite bug.


### PR DESCRIPTION
**Stacked on #563** (base `0809-2`). Merge that one first; this PR's diff against `main` will include #563's commits until it does.

## The incident this fixes

`.agent/<branch>/STATE.md` is the compact-recovery document. It is keyed per **branch**, but sessions are per **session**, and this repo routinely runs several sessions in one shared checkout.

On 2026-08-09 the Stop hook told session `99ccf057` its STATE.md was stale and demanded a rewrite. It obeyed, and **destroyed peer session `2fd369e0`'s entire state document** — a live canary campaign's notes: attempt in flight, watch id, five flag flips, a released version, an operator-owned design question. It was recovered only because the single-slot `.prev` backup was read *before* the next write clobbered that too. It then had to be hand-merged three more times in the same afternoon.

The staleness gate actively **drove** the collision: it nags every session on the branch, on a 15-minute limit, to rewrite the one shared file. More sessions, more overwrites.

The format was already half-present — `AGENT_STATE_SESSION_RE` and `agent_state_blocks()` existed and only scaled the character cap by heading count. The headings existed; the ownership, ageing and merge semantics did not. That gap is exactly why the tooling could not see the collision, and why a peer had already invented the `## SESSION` convention by hand.

## What changes

- **One owned section per session.** `--state` takes YOUR body alone and merges it under a lock, leaving every other section byte-identical. It writes your heading for you.
- **Staleness is per section.** One session's write can no longer silence another's obligation, nor can a stale section hide behind a fresh peer. Previously `wl_checks` also banked the *peer's* world signature as this session's own, so B adopted a document describing A's world as its own recovery artifact.
- **A dead session's section is archived before it is dropped**, reusing the existing `owner_age_hours` liveness notion rather than inventing a second one.
- **A legacy single-section document is adopted**, never destroyed.
- **A malformed document is never silently replaced.**
- `wl_core` gains one `projects_dir()` definition so the CLI write path can answer "is this owner alive?" without a second, drifting answer.

## Prose would not have prevented a repeat, so the doors are shut mechanically

This is the point. A document explaining the contract only protects a session that reads it.

- The **pre-edit guard now DENIES a whole-file `Write`** to STATE.md outright. A shape-only shell guard cannot enforce merge semantics, and a raw Write clobbers peers exactly as thoroughly as the old CLI did.
- **`--state` refuses a body carrying a `## SESSION` heading**, which is what a session sends when it has pasted the whole file.

Both messages name the incident and print the correct command, so a session that never read a doc still cannot destroy a peer's state.

## Verification

Every number below was produced by running the thing, with exit codes captured directly rather than read after a pipe.

| gate | result |
|---|---|
| `bash .claude/hooks/stop/test-worklist-v5.sh` | exit 0, `passed=657 failed=0` (up from 634) |
| `bash .ci/scripts/test/gates/test-worklist-hooks.sh` | exit 0, stop-hook `657/0`, report-inbox `118/0` |
| `bash .claude/hooks/test-hooks.sh` | exit 0, `PASS=740 FAIL=0` |
| `bash .ci/scripts/quality/check-python-lint.sh` | exit 0, 28 files lint + format clean |

**Proven by mutation, not by assertion.** Against an isolated copy of the hook tree, `agent_state_render` was mutated to render only the last section — the classic clobber. The suite went to **exit 1 with 10 failures**, naming exactly the right defects:

```
FAIL: 29f: B's write MUTATED A's section
FAIL: 29f: a section is missing from the merged document
FAIL: 29i: the legacy document was lost
FAIL: 29h CONTROL 2: the writer reaped or duplicated its own section
FAIL: 44b: session A, fresh, is NOT nagged by B's staleness
FAIL: 21b: ordering/labelling wrong
```

New cases extend the existing STATE.md families rather than appending at the end: `20b`, `21b` (PostCompact puts my section first and labels the peer's), `29f` (two sessions, both survive), `29g` (`--state` refuses a whole-file body), `29h` (dead section reaped, archived first), `29i` (legacy adopted), `29j` (malformed never silently replaced), `44b` (staleness is per session).

## Live proof, unplanned

The merge semantics went live while this session was still working, and were verified on the **real shared document** rather than a fixture: a peer's section survived a merge byte-identical at 2130 bytes, twice, including once when that peer's own section was zero minutes old. A legacy pre-section document was adopted rather than dropped. That is the exact three-session collision that motivated the work, resolved in place.

## Not included, deliberately

- `.agent/README.md` gained 120 lines of contract prose, but `.agent/` is gitignored, so it cannot ship. The contract that matters travels in the committed guard messages instead. One knock-on defect was found and fixed here: those committed messages pointed readers at `.agent/README.md`, a dead pointer on a fresh clone.
- `.ci/scripts/quality/check-submodule-branches.sh` carries a peer session's review-pipeline work and is not staged.

## Submodule PRs

**None.** All four pointers are unchanged and equal to `origin/main`.

---

## Round 2 (6ad4605cf): shfmt

`Quality / Static` failed on `shfmt` for `test-worklist-v5.sh`, with five siblings force-cancelled — the correct watchdog signature for one genuine failure, as distinct from the zero-failure cancellation that means a run was superseded.

The cause was the delegation brief, not the work: it named the stop-hook suite, the gate wrapper, the hook umbrella, the python lint and an em-dash scan, and omitted `shfmt` for a task whose largest artifact is 605 lines of shell. Four lines, reformatted with the gate's own `-i 4 -ci` flags. Only that one file was affected; the other three shell files in this PR already passed.

The full suite was re-run after formatting rather than assuming a formatter is behaviour-preserving across that much test code: still `passed=657 failed=0`, exit 0.

---

## Round 3 (279dc801f): the review's one finding

Review verdict was **approve with one low-severity finding**, and it was a fair catch. When `--state` replaced the caller's own section it set `tail` and `body` but never `ts`, while `kept_rows` computes every age from `ts` — so a session that had just written its section was told the section was minutes old.

The persisted document was always correct and the staleness gate always re-derived the age from the rendered heading. Only the tool's report *about itself* was wrong, which is the smallest possible version of the exact failure this PR exists to prevent. I had that line in my own terminal twice (`<- you (26 min old)` immediately after a write) and read past it; the review caught it from the code path.

The new stamp lands *after* the `replacing your N-minute-old section` message, which deliberately reports the age of the section being replaced. Proven both directions on a fixture with the heading rewound 132 minutes: the message still says `132`, the confirmation row now says `0`.

Re-verified after the change: stop-hook `passed=657 failed=0`, umbrella `PASS=750 FAIL=0`, `shfmt` clean.
